### PR TITLE
Fix cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,35 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(StrobeAlign VERSION 0.5)
+project(strobealign VERSION 0.5)
+
+option(ENABLE_AVX "Enable AVX2 support" ON)
 
 find_package(ZLIB)
 
 find_package(OpenMP)
 
-add_executable(StrobeAlign
-   main.cpp
-   source/index.cpp
-   source/ksw2_extz2_sse.c
-   source/xxhash.c
-   source/ssw_cpp.cpp
-   source/ssw.c
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_C_FLAGS "-O3 ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "-O3 ${CMAKE_CXX_FLAGS}")
+
+set(SOURCES
+main.cpp
+source/index.cpp
+source/ksw2_extz2_sse.c
+source/xxhash.c
+source/ssw_cpp.cpp
+source/ssw.c
 )
 
-target_link_libraries(StrobeAlign PUBLIC ZLIB::ZLIB OpenMP::OpenMP_CXX)
+add_executable(strobealign ${SOURCES})
 
-target_compile_features(StrobeAlign PUBLIC cxx_std_14)
+target_link_libraries(strobealign PUBLIC ZLIB::ZLIB OpenMP::OpenMP_CXX)
+
+IF(ENABLE_AVX)
+  target_compile_options(strobealign PUBLIC "-mavx2")
+ENDIF()
+
+


### PR DESCRIPTION
cmake didn't work out of the box with v0.5, so I played around with it a little bit (and
learned more about cmake than I ever wanted :-)

This PR fixes building with cmake; I made -O3 the default optimization; also, AVX2
is enabled by default, but can be disabled with `cmake -DENABLE_AVX=0`.