### PR TITLE
cmake: add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ add_executable(strobealign ${SOURCES})
 
 target_link_libraries(strobealign PUBLIC ZLIB::ZLIB OpenMP::OpenMP_CXX)
 
+install(TARGETS strobealign DESTINATION bin)
+
 IF(ENABLE_AVX)
   target_compile_options(strobealign PUBLIC "-mavx2")
 ENDIF()


### PR DESCRIPTION
Hi @ksahlin,

I've now also added an install target to cmake; by default, `make install` would attempt
installation to /usr/local, but this can be adapted with `-DCMAKE_INSTALL_PREFIX:PATH=${PREFIX}`
when invoking cmake.