### PR TITLE
cmake build: add pthreads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(strobealign VERSION 0.7)
 option(ENABLE_AVX "Enable AVX2 support" ON)
 
 find_package(ZLIB)
-
+find_package(Threads)
 find_package(OpenMP)
 
 set(CMAKE_CXX_STANDARD 14)
@@ -28,7 +28,7 @@ source/aln.cpp
 
 add_executable(strobealign ${SOURCES})
 
-target_link_libraries(strobealign PUBLIC ZLIB::ZLIB)
+target_link_libraries(strobealign PUBLIC ZLIB::ZLIB Threads::Threads)
 
 install(TARGETS strobealign DESTINATION bin)
 


### PR DESCRIPTION
Not sure why this didnt happen before, but 0.7 failed to build for me when trying
to link the final executable:

```
[100%] Linking CXX executable strobealign
/usr/bin/ld: CMakeFiles/strobealign.dir/main.cpp.o: in function `main':
main.cpp:(.text.startup+0x1f95): undefined reference to `pthread_create'
/usr/bin/ld: main.cpp:(.text.startup+0x2618): undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/strobealign.dir/build.make:190: strobealign] Error 1
make[1]: *** [CMakeFiles/Makefile2:76: CMakeFiles/strobealign.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```

This PR adds pthread detection and corresponding link flags to the cmake build.