### PR TITLE
Disable AVX2 support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(strobealign VERSION 0.7.1)
 
-option(ENABLE_AVX "Enable AVX2 support" ON)
+option(ENABLE_AVX "Enable AVX2 support" OFF)
 
 find_package(ZLIB)
 find_package(Threads)


### PR DESCRIPTION
We cannot rely on AVX2 instructions being supported by the target CPU, so
it’s better to disable it by default and let the user enable it explicitly.

Automatic CPU detection would be even nicer.

Closes #34