### PR TITLE
Maintain version number in only one place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.16)
 
 project(strobealign VERSION 0.7.1)
 
+configure_file(
+    "${PROJECT_SOURCE_DIR}/src/version.hpp.in"
+    "${PROJECT_BINARY_DIR}/version.hpp"
+)
 option(ENABLE_AVX "Enable AVX2 support" OFF)
 
 find_package(ZLIB)
@@ -28,7 +32,7 @@ ext/ssw.c
 add_executable(strobealign ${SOURCES})
 
 target_link_libraries(strobealign PUBLIC ZLIB::ZLIB Threads::Threads)
-target_include_directories(strobealign PUBLIC src/ ext/)
+target_include_directories(strobealign PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
 install(TARGETS strobealign DESTINATION bin)
 
 IF(ENABLE_AVX)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@ using namespace klibpp;
 #include "ssw_cpp.h"
 #include "pc.hpp"
 #include "aln.hpp"
+#include "version.hpp"
 
 //develop
 #include <chrono>
@@ -251,7 +252,7 @@ struct CommandLineOptions {
 
 std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int argc, char **argv) {
 
-    args::ArgumentParser parser("StrobeAlign 0.7.1");
+    args::ArgumentParser parser("StrobeAlign " VERSION_STRING);
     parser.helpParams.showTerminator = false;
     parser.helpParams.helpindent = 20;
     parser.helpParams.width = 90;
@@ -614,7 +615,7 @@ int main (int argc, char **argv)
 //            out << "@SQ\tSN:" << it.second << "\tLN:" << ref_lengths[it.first] << "\n";
             out << "@SQ\tSN:" << acc_map[i] << "\tLN:" << ref_lengths[i] << "\n";
         }
-        out << "@PG\tID:strobealign\tPN:strobealign\tVN:0.7.1\tCL:strobealign\n";
+        out << "@PG\tID:strobealign\tPN:strobealign\tVN:" VERSION_STRING "\tCL:strobealign\n";
     }
 
     std::unordered_map<std::thread::id, logging_variables> log_stats_vec(opt.n_threads);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,33 +3,28 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
-#include <assert.h>
-#include <math.h>
-#include <chrono>  // for high_resolution_clock
-//#include <omp.h>
-#include <zlib.h>
+#include <chrono>
 #include <sstream>
 #include <algorithm>
 #include <numeric>
+#include <thread>
+#include <assert.h>
+#include <math.h>
 #include <inttypes.h>
 
-#include <args.hxx>
-
+#include <zlib.h>
+#include "args.hxx"
 #include "kseq++.hpp"
-using namespace klibpp;
 #include "robin_hood.h"
-#include "index.hpp"
-//#include "ksw2.h"
 #include "ssw_cpp.h"
+
+#include "index.hpp"
 #include "pc.hpp"
 #include "aln.hpp"
 #include "version.hpp"
 
-//develop
-#include <chrono>
-#include <thread>
-#include <sstream>
 
+using namespace klibpp;
 using std::chrono::high_resolution_clock;
 
 

--- a/src/version.hpp.in
+++ b/src/version.hpp.in
@@ -1,0 +1,6 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define VERSION_STRING "@PROJECT_VERSION@"
+
+#endif


### PR DESCRIPTION
With this, CMake generates a version.hpp containing the version number set in `CMakeLists.txt`. The `version.hpp` file is included from `main.cpp`.

To update the version number in the future, only `CMakeLists.txt` needs to be changed.