### PR TITLE
Add const to some function calls (and refactor process_flat_vector)

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -11,7 +11,7 @@
 #include <bitset>
 #include <climits>
 #include <inttypes.h>
-
+#include <cassert>
 
 /**********************************************************
  *
@@ -93,26 +93,19 @@ static unsigned char seq_nt4_table[256] = {
 //}
 
 
-void process_flat_vector(mers_vector &flat_vector, uint64_t &unique_elements){
-
-    //    flat_array sort
-    std::sort(flat_vector.begin(), flat_vector.end());
-
-    uint64_t prev_k;
-    std::tuple<uint64_t, unsigned int, int> t = flat_vector[0];
-    prev_k = std::get<0>(t);
+uint64_t count_unique_elements(const mers_vector &flat_vector){
+    assert(flat_vector.size() > 0);
+    uint64_t prev_k = std::get<0>(flat_vector[0]);
     uint64_t curr_k;
-    unique_elements = 1;
-    for ( auto &t : flat_vector ) {
-//        std::cerr << t << std::endl;
+    uint64_t unique_elements = 1;
+    for (auto &t : flat_vector) {
         curr_k = std::get<0>(t);
-        if (curr_k != prev_k){
+        if (curr_k != prev_k) {
             unique_elements ++;
         }
         prev_k = curr_k;
     }
-
-//    return flat_vector;
+    return unique_elements;
 }
 
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -108,8 +108,7 @@ uint64_t count_unique_elements(const mers_vector &flat_vector){
     return unique_elements;
 }
 
-
-unsigned int index_vector(mers_vector &flat_vector, kmer_lookup &mers_index, float f){
+unsigned int index_vector(const mers_vector &flat_vector, kmer_lookup &mers_index, float f){
 
     std::cerr << "Flat vector size: " << flat_vector.size() << std::endl;
 //    kmer_lookup mers_index;
@@ -417,7 +416,7 @@ static inline void make_string_to_hashvalues_closed_syncmers_canonical(std::stri
 }
 
 
-static inline void make_string_to_hashvalues_open_syncmers_canonical(std::string &seq, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, uint64_t kmask, int k, uint64_t smask, int s, int t) {
+static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::string &seq, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, uint64_t kmask, int k, uint64_t smask, int s, int t) {
     // initialize the deque
     std::deque <uint64_t> qs;
     std::deque <unsigned int> qs_pos;
@@ -609,7 +608,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(std::string
 
 
 
-static inline void get_next_strobe(std::vector<uint64_t> &string_hashes, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next,  unsigned int w_start, unsigned int w_end, uint64_t q){
+static inline void get_next_strobe(const std::vector<uint64_t> &string_hashes, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next, unsigned int w_start, unsigned int w_end, uint64_t q){
     uint64_t min_val = UINT64_MAX;
 //    int max_val = INT_MIN;
 //    int min_val = INT_MAX;
@@ -665,7 +664,8 @@ static inline void get_next_strobe(std::vector<uint64_t> &string_hashes, uint64_
 }
 
 
-static inline void get_next_strobe_dist_constraint(std::vector<uint64_t> &string_hashes,  std::vector<unsigned int> &pos_to_seq_choord, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next,  unsigned int w_start, unsigned int w_end, uint64_t q, unsigned int seq_start, unsigned int seq_end_constraint, unsigned int strobe1_start){
+static inline void get_next_strobe_dist_constraint(const std::vector<uint64_t> &string_hashes, const std::vector<unsigned int> &pos_to_seq_choord, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next,  unsigned int w_start, unsigned int w_end, uint64_t q, unsigned int seq_start, unsigned int seq_end_constraint, unsigned int strobe1_start)
+{
     uint64_t min_val = UINT64_MAX;
     strobe_pos_next = strobe1_start; // Defaults if no nearby syncmer
     strobe_hashval_next = string_hashes[strobe1_start];
@@ -733,8 +733,6 @@ mers_vector seq_to_randstrobes2(int n, int k, int w_min, int w_max, std::string 
 
     std::transform(seq.begin(), seq.end(), seq.begin(), ::toupper);
     uint64_t kmask=(1ULL<<2*k) - 1;
-//    std::bitset<64> x(q);
-//    std::cerr << x << '\n';
     // make string of strobes into hashvalues all at once to avoid repetitive k-mer to hash value computations
     std::vector<uint64_t> string_hashes;
     std::vector<unsigned int> pos_to_seq_choord;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -50,6 +50,10 @@ static inline uint64_t hash64(uint64_t key, uint64_t mask)
 }//hash64
 
 
+// a, A -> 0
+// c, C -> 1
+// g, G -> 2
+// t, T, u, U -> 3
 static unsigned char seq_nt4_table[256] = {
         0, 1, 2, 3,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
         4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
@@ -67,7 +71,7 @@ static unsigned char seq_nt4_table[256] = {
         4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
         4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
         4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4
-}; //seq_nt4_table
+};
 
 
 
@@ -416,10 +420,10 @@ static inline void make_string_to_hashvalues_closed_syncmers_canonical(std::stri
 }
 
 
-static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::string &seq, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, uint64_t kmask, int k, uint64_t smask, int s, int t) {
-    // initialize the deque
-    std::deque <uint64_t> qs;
-    std::deque <unsigned int> qs_pos;
+static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::string &seq, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, uint64_t kmask, int k, uint64_t smask, int s, int t)
+{
+    std::deque<uint64_t> qs;
+    std::deque<unsigned int> qs_pos;
     int seq_length = seq.length();
     int qs_size = 0;
     uint64_t qs_min_val = UINT64_MAX;
@@ -449,12 +453,12 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::
             xs[0] = (xs[0] << 2 | c) & smask;                  // forward strand
             xs[1] = xs[1] >> 2 | (uint64_t)(3 - c) << sshift;  // reverse strand
             if (++l >= s) { // we find an s-mer
-                uint64_t ys = xs[0] < xs[1]? xs[0] : xs[1];
+                uint64_t ys = std::min(xs[0], xs[1]);
 //                uint64_t hash_s = robin_hash(ys);
                 uint64_t hash_s = ys;
 //                uint64_t hash_s = hash64(ys, mask);
 //                uint64_t hash_s = XXH64(&ys, 8,0);
-                // que not initialized yet
+                // queue not initialized yet
                 if (qs_size < k - s ) {
                     qs.push_back(hash_s);
                     qs_pos.push_back(i - s + 1);
@@ -474,7 +478,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::
                     }
                     if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer
 //                    if ( (qs_min_pos == qs_pos[t-1]) || ((gap > 10) && ((qs_min_pos == qs_pos[k - s]) || (qs_min_pos == qs_pos[0]))) ) { // occurs at first or last position in k-mer
-                        uint64_t yk = xk[0] < xk[1]? xk[0] : xk[1];
+                        uint64_t yk = std::min(xk[0], xk[1]);
 //                        uint64_t hash_k = robin_hash(yk);
 //                        uint64_t hash_k = yk;
 //                        uint64_t hash_k =  hash64(yk, mask);
@@ -498,7 +502,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::
 //                            make_string_to_hashvalues_closed_syncmers_canonical(subseq, string_hashes, pos_to_seq_choord, kmask, k, smask, s, t, i - k + 1 - gap + 1);
 //                        }
 
-                        uint64_t yk = xk[0] < xk[1]? xk[0] : xk[1];
+                        uint64_t yk = std::min(xk[0], xk[1]);
 //                        uint64_t hash_k = robin_hash(yk);
 //                        uint64_t hash_k = yk;
 //                        uint64_t hash_k = hash64(yk, mask);
@@ -522,9 +526,10 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::
 //                }
             }
         } else {
+            // if there is an "N", restart
             qs_min_val = UINT64_MAX;
             qs_min_pos = -1;
-            l = 0, xs[0] = xs[1] = 0,  xk[0] = xk[1] = 0; // if there is an "N", restart
+            l = xs[0] = xs[1] = xk[0] = xk[1] = 0;
             qs_size = 0;
             qs.clear();
             qs_pos.clear();

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -37,7 +37,7 @@ mers_vector seq_to_randstrobes2(int n, int k, int w_min, int w_max, std::string 
 mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int s, int t, uint64_t q, int max_dist);
 //mers_vector seq_to_randstrobes3(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int w);
 
-void process_flat_vector(mers_vector &flat_vector, uint64_t &unique_elements);
+uint64_t count_unique_elements(const mers_vector &flat_vector);
 unsigned int index_vector(mers_vector  &mers_vector, kmer_lookup &mers_index, float f);
 
 struct hit {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -28,7 +28,7 @@ typedef robin_hood::unordered_map< uint64_t, std::tuple<unsigned int, unsigned i
 typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool>> mers_vector_read;
 
 //static inline void make_string_to_hashvalues(std::string &seq, std::vector<uint64_t> &string_hashes, int k, uint64_t kmask);
-static inline void get_next_strobe(std::vector<uint64_t> &string_hashes, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next,  unsigned int w_start, unsigned int w_end, uint64_t q);
+static inline void get_next_strobe(const std::vector<uint64_t> &string_hashes, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next,  unsigned int w_start, unsigned int w_end, uint64_t q);
 
 
 //mers_vector seq_to_kmers(int k, std::string &seq, unsigned int ref_index);
@@ -37,7 +37,7 @@ mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, st
 //mers_vector seq_to_randstrobes3(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int w);
 
 uint64_t count_unique_elements(const mers_vector &flat_vector);
-unsigned int index_vector(mers_vector &flat_vector, kmer_lookup &mers_index, float f);
+unsigned int index_vector(const mers_vector &flat_vector, kmer_lookup &mers_index, float f);
 
 struct hit {
     int query_s;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -37,7 +37,7 @@ mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, st
 //mers_vector seq_to_randstrobes3(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int w);
 
 uint64_t count_unique_elements(const mers_vector &flat_vector);
-unsigned int index_vector(mers_vector  &mers_vector, kmer_lookup &mers_index, float f);
+unsigned int index_vector(mers_vector &flat_vector, kmer_lookup &mers_index, float f);
 
 struct hit {
     int query_s;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -16,7 +16,6 @@
 #include <tuple>
 #include "robin_hood.h"
 #include "xxhash.h"
-#include <inttypes.h>
 
 uint64_t hash(std::string kmer);
 static inline uint64_t hash64(uint64_t key, uint64_t mask);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -441,11 +441,11 @@ std::pair<mers_vector, kmer_lookup> create_index(mapping_params& map_param, std:
 //        std::cerr << "Completed thread: " << omp_get_thread_num() << " chr size: " << ref_lengths[i] << " acc map:" << acc_map[i] << std::endl;
 //    }
 
-    uint64_t unique_mers = 0;
     auto start_sorting = high_resolution_clock::now();
 //    std::cerr << "Reserving flat vector size: " << approx_vec_size << std::endl;
 //    all_mers_vector_tmp.reserve(approx_vec_size); // reserve size corresponding to sum of lengths of all sequences divided by expected sampling
-    process_flat_vector(flat_vector, unique_mers);
+    std::sort(flat_vector.begin(), flat_vector.end());
+    uint64_t unique_mers = count_unique_elements(flat_vector);
     std::chrono::duration<double> elapsed_sorting_seeds = high_resolution_clock::now() - start_sorting;
     std::cerr << "Time sorting seeds: " << elapsed_sorting_seeds.count() << " s\n" <<  std::endl;
     std::cerr << "Unique strobemers: " << unique_mers  <<  std::endl;
@@ -456,7 +456,8 @@ std::pair<mers_vector, kmer_lookup> create_index(mapping_params& map_param, std:
     auto start_hash_index = high_resolution_clock::now();
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
     mers_index.reserve(unique_mers);
-    map_param.filter_cutoff = index_vector(flat_vector, mers_index, map_param.f); // construct index over flat array
+    // construct index over flat array
+    map_param.filter_cutoff = index_vector(flat_vector, mers_index, map_param.f);
     std::chrono::duration<double> elapsed_hash_index = high_resolution_clock::now() - start_hash_index;
     std::cerr << "Total time generating hash table index: " << elapsed_hash_index.count() << " s\n" <<  std::endl;
 
@@ -465,11 +466,6 @@ std::pair<mers_vector, kmer_lookup> create_index(mapping_params& map_param, std:
     /* destroy vector */
 //    flat_vector.clear();
 
-
-////////////////////////////////////////////////////////////////////////
-
-
-//    std::cerr << "Wrote index to disc" << std::endl;
     return make_pair(flat_vector, mers_index);
 }
 


### PR DESCRIPTION
This contains a couple of changes only related by the fact that I did them while trying to understand some functions.

Quite a few functions in strobealign use function arguments not only for passing in parameters, but also for returning values (passed by reference). This makes it a bit hard to understand what’s going on. Some functions even take multiple parameters that are passed by reference, but some of them are inputs and some of them are outputs. At the call site, one cannot see which parameters are modified and which aren’t. One improvement is to mark the inputs as `const`, which I’ve done here in some places.