### PR TITLE
Feat/save index to file

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -310,7 +310,7 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
 //            int ref_d;
 //            for(size_t j = offset; j < offset+count; ++j) {
 //                auto r = ref_mers[j];
-//                ref_d = std::get<3>(r) + k - std::get<2>(r);
+//                ref_d = std::get<2>(r) + k - std::get<1>(r); //I changed this code from std::get<3>(r) + k - std::get<2>(r); - but it is probably old, 3 should not be possible since we only had 3 members in the tuple
 //                int diff = (h.query_e - h.query_s) - ref_d > 0 ? (h.query_e - h.query_s) -  ref_d : ref_d - (h.query_e - h.query_s);
 //                if (diff <= min_diff ){
 //                    min_diff = diff;
@@ -320,15 +320,15 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
             for(size_t j = offset; j < offset+count; ++j)
             {
                 auto r = ref_mers[j];
-                h.ref_s = std::get<1>(r);
-                auto p = std::get<2>(r);
+                h.ref_s = std::get<0>(r);
+                auto p = std::get<1>(r);
                 int bit_alloc = 8;
                 int r_id = (p >> bit_alloc);
                 int mask=(1<<bit_alloc) - 1;
                 int offset = (p & mask);
                 h.ref_e = h.ref_s + offset + k;
 //                h.count = count;
-//                hits_per_ref[std::get<1>(r)].push_back(h);
+//                hits_per_ref[std::get<0>(r)].push_back(h);
 
                 int diff = (h.query_e - h.query_s) - (h.ref_e - h.ref_s) > 0 ? (h.query_e - h.query_s) - (h.ref_e - h.ref_s) : (h.ref_e - h.ref_s) - (h.query_e - h.query_s);
                 if (diff <= min_diff ){
@@ -362,7 +362,7 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
 //            int ref_d;
 //            for(size_t j = offset; j < offset+count; ++j) {
 //                auto r = ref_mers[j];
-//                ref_d = std::get<3>(r) + k - std::get<2>(r);
+//                ref_d = std::get<2>(r) + k - std::get<1>(r); //same problem here, I changed from 3 to 2 etc., but it doesn't seem right
 //                int diff = (h.query_e - h.query_s) - ref_d > 0 ? (h.query_e - h.query_s) -  ref_d : ref_d - (h.query_e - h.query_s);
 //                if (diff <= min_diff ){
 //                    min_diff = diff;
@@ -372,8 +372,8 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
             for(size_t j = offset; j < offset+count; ++j)
             {
                 auto r = ref_mers[j];
-                h.ref_s = std::get<1>(r);
-                auto p = std::get<2>(r);
+                h.ref_s = std::get<0>(r);
+                auto p = std::get<1>(r);
                 int bit_alloc = 8;
                 int r_id = (p >> bit_alloc);
                 int mask=(1<<bit_alloc) - 1;
@@ -547,7 +547,7 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
             auto count = std::get<1>(mer);
 //            if (count == 1){
 //                auto r = ref_mers[offset];
-//                unsigned int ref_id = std::get<0>(r);
+//                unsigned int ref_id = std::get<0>(r); //The indexes in this code are not fixed after removal of the 64-bit hash
 //                unsigned int ref_s = std::get<1>(r);
 //                unsigned int ref_e = std::get<2>(r) + k; //ref_s + read_length/2;
 //
@@ -565,7 +565,7 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
 //                int ref_d;
 //                for(size_t j = offset; j < offset+count; ++j) {
 //                    auto r = ref_mers[j];
-//                    ref_d = std::get<3>(r) + k - std::get<2>(r);
+//                    ref_d = std::get<3>(r) + k - std::get<2>(r);//The indexes in this code are not fixed after removal of the 64-bit hash
 //                    int diff = (h.query_e - h.query_s) - ref_d > 0 ? (h.query_e - h.query_s) -  ref_d : ref_d - (h.query_e - h.query_s);
 //                    if (diff <= min_diff ){
 //                        min_diff = diff;
@@ -577,11 +577,11 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
                 {
                     auto r = ref_mers[j];
 //                    unsigned int  ref_id,ref_s,ref_e; std::tie(ref_id,ref_s,ref_e) = r;
-//                    unsigned int ref_id = std::get<0>(r);
+//                    unsigned int ref_id = std::get<0>(r);//The indexes in this code are not fixed after removal of the 64-bit hash
 //                    unsigned int ref_s = std::get<1>(r);
 //                    unsigned int ref_e = std::get<2>(r) + k; //ref_s + read_length/2;
-                    h.ref_s = std::get<1>(r);
-                    auto p = std::get<2>(r);
+                    h.ref_s = std::get<0>(r);
+                    auto p = std::get<1>(r);
                     int bit_alloc = 8;
                     int r_id = (p >> bit_alloc);
                     int mask=(1<<bit_alloc) - 1;

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -453,7 +453,7 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
 //                continue;
 //            }
             // Add the hit to open matches
-            if (not is_added){
+            if (!is_added){
                 nam n;
                 n.nam_id = nam_id_cnt;
                 nam_id_cnt ++;
@@ -708,7 +708,7 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
 //                continue;
 //            }
             // Add the hit to open matches
-            if (not is_added){
+            if (!is_added){
                 nam n;
                 n.nam_id = nam_id_cnt;
                 nam_id_cnt ++;

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -529,7 +529,7 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
 //    std::vector<std::vector<hit>> hits_per_ref(10);
 //    int read_length = read.length();
 //    std::cerr << " "  <<  std::endl;
-    std::pair<float,int> info (0,0); // (nr_nonrepetitive_hits/total_hits, max_nam_n_hits)
+    std::pair<float,int> info (0.0f,0); // (nr_nonrepetitive_hits/total_hits, max_nam_n_hits)
     int nr_good_hits = 0, total_hits = 0;
     hit h;
     for (auto &q : query_mers)
@@ -1887,7 +1887,7 @@ static inline void align_SE_secondary_hits(alignment_params &aln_params, std::st
             best_align_sw_score = sw_score;
         }
 
-        std::tuple<double, alignment> t (sam_aln.sw_score, sam_aln);
+        std::tuple<int, alignment> t (sam_aln.sw_score, sam_aln);
         alignments.push_back(t);
         cnt ++;
     }

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -29,7 +29,6 @@ using namespace klibpp;
 //#include <thread>
 
 
-typedef robin_hood::unordered_map<int, std::string > idx_to_acc;
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -283,10 +283,10 @@ void read_index(st_index& index, std::string filename) {
 
     for (int i = 0; i < sz; ++i) {
         ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));
-        char* buf = new char[sz2];//Comes at a slight performance cost to allocate each round in the loop.
-        ifs.read(buf, sz2);
-        acc_map[i] = std::string(buf, sz2);
-        delete[] buf; //ignore that this will not be called in case of an exception in read - to save performance
+        std::shared_ptr<char> buf_ptr(new char[sz2], std::default_delete<char[]>());//Comes at a slight performance cost to allocate each round in the loop.
+        char* buf = buf_ptr.get();
+        ifs.read(buf_ptr.get(), sz2);
+        acc_map[i] = std::string(buf_ptr.get(), sz2);
     }
 
     //read flat_vector:

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -203,8 +203,7 @@ unsigned int index_vector(mers_vector &flat_vector, kmer_lookup &mers_index, flo
 void write_index(const st_index& index, std::string filename) {
     std::ofstream ofs(filename, std::ios::binary);
 
-    //write ref_seqs
-    ////////////////
+    //write ref_seqs:
     uint64_t s1 = uint64_t(index.ref_seqs.size());
     ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
     //For each string, write length and then the string
@@ -215,14 +214,13 @@ void write_index(const st_index& index, std::string filename) {
         ofs.write(index.ref_seqs[i].c_str(), index.ref_seqs[i].length());
     }
     
-    //write ref_lengths - write everything in one large chunk
-    ////////////////
+    //write ref_lengths:
+    //write everything in one large chunk
     s1 = uint64_t(index.ref_lengths.size());
     ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
     ofs.write(reinterpret_cast<const char*>(&index.ref_lengths[0]), index.ref_lengths.size()*sizeof(index.ref_lengths[0]));
 
-    //write acc_map
-    ////////////////
+    //write acc_map:
     //TODO: Change acc_map to a vector - the keys are just 0,1,2, ... n anyways, so faster access and less complicated with a vector
     //we convert to a vector for now - remove this code later when we have replaced it
     std::vector<std::string> v; 
@@ -231,7 +229,6 @@ void write_index(const st_index& index, std::string filename) {
         [](const robin_hood::pair<idx_to_acc::key_type, idx_to_acc::mapped_type>& p) {
         return p.second;
     });
-
     //now write
     s1 = uint64_t(v.size());
     ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
@@ -242,14 +239,12 @@ void write_index(const st_index& index, std::string filename) {
         ofs.write(v[i].c_str(), v[i].length());
     }
 
-    //write flat_vector
-    ////////////////
+    //write flat_vector:
     s1 = uint64_t(index.flat_vector.size());
     ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
     ofs.write(reinterpret_cast<const char*>(&index.flat_vector[0]), index.flat_vector.size() * sizeof(index.flat_vector[0]));
 
-    //write mers_index
-    ////////////////
+    //write mers_index:
     s1 = uint64_t(index.mers_index.size());
     ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
     for (auto& p : index.mers_index) {
@@ -260,8 +255,7 @@ void write_index(const st_index& index, std::string filename) {
 
 void read_index(st_index& index, std::string filename) {
     std::ifstream ifs(filename, std::ios::binary);
-    //read ref_seqs
-    ////////////////
+    //read ref_seqs:
     index.ref_seqs.clear();
     uint64_t sz = 0;
     ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
@@ -284,8 +278,7 @@ void read_index(st_index& index, std::string filename) {
     index.ref_lengths.resize(sz); //annoyingly, this initializes the memory to zero (which is a waste of performance), but ignore that for now
     ifs.read(reinterpret_cast<char*>(&index.ref_lengths[0]), sz*sizeof(index.ref_lengths[0]));
 
-    //read acc_map
-    ////////////////
+    //read acc_map:
     //TODO: update the code to vector later
     index.acc_map.clear();
     ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
@@ -300,15 +293,13 @@ void read_index(st_index& index, std::string filename) {
         delete[] buf; //ignore that this will not be called in case of an exception in read - to save performance
     }
 
-    //read flat_vector
-    ////////////////
+    //read flat_vector:
     index.flat_vector.clear();
     ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
     index.flat_vector.resize(sz); //annoyingly, this initializes the memory to zero (which is a waste of performance), but let's ignore that for now
     ifs.read(reinterpret_cast<char*>(&index.flat_vector[0]), sz*sizeof(index.flat_vector[0]));
 
-    //read mers_index
-    ////////////////
+    //read mers_index:
     index.mers_index.clear();
     ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
     index.mers_index.reserve(sz);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -312,7 +312,7 @@ void read_index(st_index& index, std::string filename) {
 	ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
 	index.mers_index.reserve(sz);
 	//read in big chunks
-	const uint64_t chunk_size = 2 ^ 22;//4 M => chunks of ~50 MB
+	const uint64_t chunk_size = pow(2,20);//4 M => chunks of ~10 MB - The chunk size seem not to be that important
 	auto buf_size = std::min(sz, chunk_size) * (sizeof(kmer_lookup::key_type) + sizeof(kmer_lookup::mapped_type));
 	char* buf2 = new char[buf_size];
 	auto left_to_read = sz;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -11,6 +11,7 @@
 #include <bitset>
 #include <climits>
 #include <inttypes.h>
+#include <fstream>
 
 
 /**********************************************************
@@ -199,6 +200,128 @@ unsigned int index_vector(mers_vector &flat_vector, kmer_lookup &mers_index, flo
 }
 
 
+void write_index(const st_index& index, std::string filename) {
+	std::ofstream ofs(filename, std::ios::binary);
+
+	//write ref_seqs
+	////////////////
+	uint64_t s1 = uint64_t(index.ref_seqs.size());
+	ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
+	//For each string, write length and then the string
+	uint32_t s2 = 0;
+	for (std::size_t i = 0; i < index.ref_seqs.size(); ++i) {
+		s2 = uint32_t(index.ref_seqs[i].length());
+		ofs.write(reinterpret_cast<char*>(&s2), sizeof(s2));
+		ofs.write(index.ref_seqs[i].c_str(), index.ref_seqs[i].length());
+	}
+	
+	//write ref_lengths - write everything in one large chunk
+	////////////////
+	s1 = uint64_t(index.ref_lengths.size());
+	ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
+	ofs.write(reinterpret_cast<const char*>(&index.ref_lengths[0]), index.ref_lengths.size()*sizeof(index.ref_lengths[0]));
+
+	//write acc_map
+	////////////////
+	//TODO: Change acc_map to a vector - the keys are just 0,1,2, ... n anyways, so faster access and less complicated with a vector
+	//we convert to a vector for now - remove this code later when we have replaced it
+	std::vector<std::string> v; 
+	std::transform(index.acc_map.begin(), index.acc_map.end(),
+		std::back_inserter(v),
+		[](const robin_hood::pair<idx_to_acc::key_type, idx_to_acc::mapped_type>& p) {
+		return p.second;
+	});
+
+	//now write
+	s1 = uint64_t(v.size());
+	ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
+	//For each string, write length and then the string
+	for (std::size_t i = 0; i < v.size(); ++i) {
+		s2 = uint32_t(v[i].length());
+		ofs.write(reinterpret_cast<char*>(&s2), sizeof(s2));
+		ofs.write(v[i].c_str(), v[i].length());
+	}
+
+	//write flat_vector
+	////////////////
+	s1 = uint64_t(index.flat_vector.size());
+	ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
+	ofs.write(reinterpret_cast<const char*>(&index.flat_vector[0]), index.flat_vector.size() * sizeof(index.flat_vector[0]));
+
+	//write mers_index
+	////////////////
+	s1 = uint64_t(index.mers_index.size());
+	ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
+	for (auto& p : index.mers_index) {
+		ofs.write(reinterpret_cast<const char*>(&p.first), sizeof(p.first));
+		ofs.write(reinterpret_cast<const char*>(&p.second), sizeof(p.second));
+	}
+};
+
+void read_index(st_index& index, std::string filename) {
+	std::ifstream ifs(filename, std::ios::binary);
+	//read ref_seqs
+	////////////////
+	index.ref_seqs.clear();
+	uint64_t sz = 0;
+	ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
+	index.ref_seqs.reserve(sz);
+	uint32_t sz2 = 0;
+	auto& refseqs = index.ref_seqs;
+	for (uint64_t i = 0; i < sz; ++i) {
+		ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));
+		char* buf = new char[sz2]; //The vector is short with large strings, so allocating this way should be ok.
+		ifs.read(buf, sz2);
+		//we could potentially use std::move here to avoid reallocation, something like std::string(std::move(buf), sz2), but it has to be investigated more
+		refseqs.push_back(std::string(buf, sz2)); 
+		delete[] buf;
+	}
+
+	//read ref_lengths
+	////////////////
+	index.ref_lengths.clear();
+	ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
+	index.ref_lengths.resize(sz); //annoyingly, this initializes the memory to zero (which is a waste of performance), but ignore that for now
+	ifs.read(reinterpret_cast<char*>(&index.ref_lengths[0]), sz*sizeof(index.ref_lengths[0]));
+
+	//read acc_map
+	////////////////
+	//TODO: update the code to vector later
+	index.acc_map.clear();
+	ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
+	//index.acc_map.reserve(sz);
+	char buf[1000];//potentially risky, but ascension names are usually around 10 chars
+	auto& acc_map = index.acc_map;
+
+	for (int i = 0; i < sz; ++i) {
+		ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));
+		ifs.read(buf, sz2);
+		acc_map[i] = std::string(buf, sz2);
+	}
+
+	//read flat_vector
+	////////////////
+	index.flat_vector.clear();
+	ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
+	index.flat_vector.resize(sz); //annoyingly, this initializes the memory to zero (which is a waste of performance), but let's ignore that for now
+	ifs.read(reinterpret_cast<char*>(&index.flat_vector[0]), sz*sizeof(index.flat_vector[0]));
+
+	//read mers_index
+	////////////////
+	index.mers_index.clear();
+	ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
+	index.mers_index.reserve(sz);
+	//read everything in one big chunk
+	auto buf_size = sz * (sizeof(kmer_lookup::key_type) + sizeof(kmer_lookup::mapped_type));
+	char* buf2 = new char[buf_size];
+	ifs.read(buf2, buf_size);
+	//Add the elements directly from the buffer
+	for (int i = 0; i < sz; ++i) {
+		auto start = buf2 + i * (sizeof(kmer_lookup::key_type) + sizeof(kmer_lookup::mapped_type));
+		index.mers_index[*reinterpret_cast<kmer_lookup::key_type*>(start)] = *reinterpret_cast<kmer_lookup::mapped_type*>(start + sizeof(kmer_lookup::key_type));
+	}
+	delete[] buf2;
+};
 
 
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -290,13 +290,14 @@ void read_index(st_index& index, std::string filename) {
 	index.acc_map.clear();
 	ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
 	//index.acc_map.reserve(sz);
-	char buf[1000];//potentially risky, but ascension names are usually around 10 chars
 	auto& acc_map = index.acc_map;
 
 	for (int i = 0; i < sz; ++i) {
 		ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));
+		char* buf = new char[sz2];//Comes at a slight performance cost to allocate each round in the loop.
 		ifs.read(buf, sz2);
 		acc_map[i] = std::string(buf, sz2);
+		delete[] buf;
 	}
 
 	//read flat_vector

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -297,7 +297,7 @@ void read_index(st_index& index, std::string filename) {
 		char* buf = new char[sz2];//Comes at a slight performance cost to allocate each round in the loop.
 		ifs.read(buf, sz2);
 		acc_map[i] = std::string(buf, sz2);
-		delete[] buf;
+		delete[] buf; //ignore that this will not be called in case of an exception in read - to save performance
 	}
 
 	//read flat_vector
@@ -315,7 +315,8 @@ void read_index(st_index& index, std::string filename) {
 	//read in big chunks
 	const uint64_t chunk_size = pow(2,20);//4 M => chunks of ~10 MB - The chunk size seem not to be that important
 	auto buf_size = std::min(sz, chunk_size) * (sizeof(kmer_lookup::key_type) + sizeof(kmer_lookup::mapped_type));
-	char* buf2 = new char[buf_size];
+	std::shared_ptr<char> buf_ptr(new char[buf_size], std::default_delete<char[]>());
+	char* buf2 = buf_ptr.get();
 	auto left_to_read = sz;
 	while (left_to_read > 0) {
 		auto to_read = std::min(left_to_read, chunk_size);
@@ -327,7 +328,6 @@ void read_index(st_index& index, std::string filename) {
 		}
 		left_to_read -= to_read;
 	}
-	delete[] buf2;
 };
 
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -253,7 +253,7 @@ void read_index(st_index& index, std::string filename) {
     auto& refseqs = index.ref_seqs;
     for (uint64_t i = 0; i < sz; ++i) {
         ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));
-        std::shared_ptr<char> buf_ptr(new char[sz2], std::default_delete<char[]>());//The vector is short with large strings, so allocating this way should be ok.
+        std::unique_ptr<char> buf_ptr(new char[sz2]);//The vector is short with large strings, so allocating this way should be ok.
         ifs.read(buf_ptr.get(), sz2);
         //we could potentially use std::move here to avoid reallocation, something like std::string(std::move(buf), sz2), but it has to be investigated more
         refseqs.push_back(std::string(buf_ptr.get(), sz2));
@@ -274,7 +274,7 @@ void read_index(st_index& index, std::string filename) {
 
     for (int i = 0; i < sz; ++i) {
         ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));
-        std::shared_ptr<char> buf_ptr(new char[sz2], std::default_delete<char[]>());
+        std::unique_ptr<char> buf_ptr(new char[sz2]);
         char* buf = buf_ptr.get();
         ifs.read(buf_ptr.get(), sz2);
         acc_map.push_back(std::string(buf_ptr.get(), sz2));
@@ -293,7 +293,7 @@ void read_index(st_index& index, std::string filename) {
     //read in big chunks
     const uint64_t chunk_size = pow(2,20);//4 M => chunks of ~10 MB - The chunk size seem not to be that important
     auto buf_size = std::min(sz, chunk_size) * (sizeof(kmer_lookup::key_type) + sizeof(kmer_lookup::mapped_type));
-    std::shared_ptr<char> buf_ptr(new char[buf_size], std::default_delete<char[]>());
+    std::unique_ptr<char> buf_ptr(new char[buf_size]);
     char* buf2 = buf_ptr.get();
     auto left_to_read = sz;
     while (left_to_read > 0) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -260,11 +260,10 @@ void read_index(st_index& index, std::string filename) {
     auto& refseqs = index.ref_seqs;
     for (uint64_t i = 0; i < sz; ++i) {
         ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));
-        char* buf = new char[sz2]; //The vector is short with large strings, so allocating this way should be ok.
-        ifs.read(buf, sz2);
+        std::shared_ptr<char> buf_ptr(new char[sz2], std::default_delete<char[]>());//The vector is short with large strings, so allocating this way should be ok.
+        ifs.read(buf_ptr.get(), sz2);
         //we could potentially use std::move here to avoid reallocation, something like std::string(std::move(buf), sz2), but it has to be investigated more
-        refseqs.push_back(std::string(buf, sz2)); 
-        delete[] buf;
+        refseqs.push_back(std::string(buf_ptr.get(), sz2));
     }
 
     //read ref_lengths
@@ -283,7 +282,7 @@ void read_index(st_index& index, std::string filename) {
 
     for (int i = 0; i < sz; ++i) {
         ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));
-        std::shared_ptr<char> buf_ptr(new char[sz2], std::default_delete<char[]>());//Comes at a slight performance cost to allocate each round in the loop.
+        std::shared_ptr<char> buf_ptr(new char[sz2], std::default_delete<char[]>());
         char* buf = buf_ptr.get();
         ifs.read(buf_ptr.get(), sz2);
         acc_map[i] = std::string(buf_ptr.get(), sz2);

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -25,7 +25,7 @@ typedef std::vector< std::tuple<uint64_t, unsigned int, int >> mers_vector;
 //typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int>> mers_vector_reduced;
 typedef robin_hood::unordered_map< uint64_t, std::tuple<unsigned int, unsigned int >> kmer_lookup;
 typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool>> mers_vector_read;
-typedef robin_hood::unordered_map<int, std::string > idx_to_acc;
+typedef std::vector<std::string > idx_to_acc;
 
 struct st_index {
     std::vector<std::string> ref_seqs;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -25,8 +25,17 @@ static inline uint64_t hash64(uint64_t key, uint64_t mask);
 typedef std::vector< std::tuple<uint64_t, unsigned int, int >> mers_vector;
 //typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int>> mers_vector_reduced;
 typedef robin_hood::unordered_map< uint64_t, std::tuple<unsigned int, unsigned int >> kmer_lookup;
-
 typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool>> mers_vector_read;
+typedef robin_hood::unordered_map<int, std::string > idx_to_acc;
+
+struct st_index {
+	std::vector<std::string> ref_seqs;
+	std::vector<unsigned int> ref_lengths;
+	idx_to_acc acc_map;
+	mers_vector flat_vector;
+	kmer_lookup mers_index;
+};
+
 
 //static inline void make_string_to_hashvalues(std::string &seq, std::vector<uint64_t> &string_hashes, int k, uint64_t kmask);
 static inline void get_next_strobe(std::vector<uint64_t> &string_hashes, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next,  unsigned int w_start, unsigned int w_end, uint64_t q);
@@ -36,6 +45,11 @@ static inline void get_next_strobe(std::vector<uint64_t> &string_hashes, uint64_
 mers_vector seq_to_randstrobes2(int n, int k, int w_min, int w_max, std::string &seq, int ref_index, int s, int t, uint64_t q, int max_dist);
 mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int s, int t, uint64_t q, int max_dist);
 //mers_vector seq_to_randstrobes3(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int w);
+
+void write_index(const st_index& index, std::string filename);
+
+void read_index(st_index& index, std::string filename);
+
 
 void process_flat_vector(mers_vector &flat_vector, uint64_t &unique_elements);
 unsigned int index_vector(mers_vector  &mers_vector, kmer_lookup &mers_index, float f);

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -29,11 +29,11 @@ typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int, unsigned i
 typedef robin_hood::unordered_map<int, std::string > idx_to_acc;
 
 struct st_index {
-	std::vector<std::string> ref_seqs;
-	std::vector<unsigned int> ref_lengths;
-	idx_to_acc acc_map;
-	mers_vector flat_vector;
-	kmer_lookup mers_index;
+    std::vector<std::string> ref_seqs;
+    std::vector<unsigned int> ref_lengths;
+    idx_to_acc acc_map;
+    mers_vector flat_vector;
+    kmer_lookup mers_index;
 };
 
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -21,13 +21,18 @@ uint64_t hash(std::string kmer);
 static inline uint64_t hash64(uint64_t key, uint64_t mask);
 
 
-typedef std::vector< std::tuple<uint64_t, unsigned int, int >> mers_vector;
+typedef std::vector< uint64_t > hash_vector; //only used during index generation
+typedef std::vector< std::tuple<uint32_t, int32_t >> mers_vector;
+typedef std::vector< std::tuple<uint64_t, uint32_t, int32_t >> ind_mers_vector; //only used during index generation
 //typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int>> mers_vector_reduced;
 typedef robin_hood::unordered_map< uint64_t, std::tuple<unsigned int, unsigned int >> kmer_lookup;
 typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool>> mers_vector_read;
 typedef std::vector<std::string > idx_to_acc;
 
 struct st_index {
+    st_index() : filter_cutoff(0) {}
+    unsigned int filter_cutoff; //This also exists in mapping_params, but is calculated during index generation, 
+                                //therefore stored here since it needs to be saved with the index.
     std::vector<std::string> ref_seqs;
     std::vector<unsigned int> ref_lengths;
     idx_to_acc acc_map;
@@ -41,15 +46,15 @@ static inline void get_next_strobe(const std::vector<uint64_t> &string_hashes, u
 
 
 //mers_vector seq_to_kmers(int k, std::string &seq, unsigned int ref_index);
-mers_vector seq_to_randstrobes2(int n, int k, int w_min, int w_max, std::string &seq, int ref_index, int s, int t, uint64_t q, int max_dist);
+void seq_to_randstrobes2(ind_mers_vector& flat_vector, int n, int k, int w_min, int w_max, std::string &seq, int ref_index, int s, int t, uint64_t q, int max_dist);
 mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int s, int t, uint64_t q, int max_dist);
 //mers_vector seq_to_randstrobes3(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int w);
 
 void write_index(const st_index& index, std::string filename);
 void read_index(st_index& index, std::string filename);
 
-uint64_t count_unique_elements(const mers_vector &flat_vector);
-unsigned int index_vector(const mers_vector &flat_vector, kmer_lookup &mers_index, float f);
+uint64_t count_unique_elements(const hash_vector& h_vector);
+unsigned int index_vector(const hash_vector& h_vector, kmer_lookup &mers_index, float f);
 
 struct hit {
     int query_s;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ static uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsi
     uint64_t total_ref_seq_size = 0;
     std::ifstream file(fn);
     std::string line, seq;
-    int ref_index = 0;
+    acc_map.clear();
 
     if (!file.good()) {
         std::cerr << "Unable to read from file " << fn << std::endl;
@@ -48,7 +48,7 @@ static uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsi
     while (getline(file, line)) {
         if (line[0] == '>') {
 //            std::cerr << ref_index << " " << line << std::endl;
-            if (seq.length() > 0){
+            if (seq.length() > 0) {
 //                seqs[ref_index -1] = seq;
                 seqs.push_back(seq);
                 lengths.push_back(seq.length());
@@ -56,9 +56,8 @@ static uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsi
 //                std::cerr << ref_index - 1 << " here " << seq << " " << seq.length() << " " << seq.size() << std::endl;
 //                generate_kmers(h, k, seq, ref_index);
             }
-//            acc_map[ref_index] = line.substr(1, line.length() -1); //line;
-            acc_map[ref_index] = line.substr(1, line.find(' ') -1); // cutting at first space;
-            ref_index++;
+//            acc_map.push_back(line.substr(1, line.length() -1); //line;
+            acc_map.push_back(line.substr(1, line.find(' ') -1)); // cutting at first space;
             seq = "";
         }
         else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,7 +291,7 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     args::ValueFlag<int> R(parser, "INT", "Rescue level. Perform additional search for reads with many repetitive seeds filtered out. This search includes seeds of R*repetitive_seed_size_filter (default: R=2). Higher R than default makes StrobeAlign significantly slower but more accurate. R <= 1 deactivates rescue and is the fastest.", {'R'});
 
     // <ref.fa> <reads1.fast[a/q.gz]> [reads2.fast[a/q.gz]]
-    args::Positional<std::string> ref_filename(parser, "reference", "A pregenerated strobomers index file (.sti) or a reference in FASTA format", args::Options::Required);
+    args::Positional<std::string> ref_filename(parser, "reference", "A pregenerated strobemers index file (.sti) or a reference in FASTA format", args::Options::Required);
     args::Positional<std::string> reads1_filename(parser, "reads1", "Reads 1 in FASTA or FASTQ format, optionally gzip compressed");
     args::Positional<std::string> reads2_filename(parser, "reads2", "Reads 2 in FASTA or FASTQ format, optionally gzip compressed");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,8 +242,8 @@ struct CommandLineOptions {
     bool r_set { false };
     bool max_seed_len_set { false };
     bool s_set{ false };
-	bool only_gen_index{ false };
-	std::string index_out_filename;
+    bool only_gen_index{ false };
+    std::string index_out_filename;
 };
 
 
@@ -264,7 +264,7 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     args::Flag x(parser, "x", "Only map reads, no base level alignment (produces paf file)", {'x'});
     args::ValueFlag<int> N(parser, "INT", "retain at most INT secondary alignments (is upper bounded by -M, and depends on -S) [0]", {'N'});
     args::ValueFlag<std::string> L(parser, "STR", "Print statistics of indexing to logfile [log.csv]", {'L'});
-	args::ValueFlag<std::string> i(parser, "index", "Generates an index (.sti) file", { 'i' });
+    args::ValueFlag<std::string> i(parser, "index", "Generates an index (.sti) file", { 'i' });
 
     args::Group seeding(parser, "Seeding:");
     //args::ValueFlag<int> n(parser, "INT", "number of strobes [2]", {'n'});
@@ -340,7 +340,7 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     if (x) { map_param.is_sam_out = false; }
     if (N) { map_param.max_secondary = args::get(N); }
     if (L) { opt.logfile_name = args::get(L); opt.index_log = true; }
-	if (i) { opt.only_gen_index = true; opt.index_out_filename = args::get(i); }
+    if (i) { opt.only_gen_index = true; opt.index_out_filename = args::get(i); }
 
     // Seeding
     if (r) { map_param.r = args::get(r); opt.r_set = true; }
@@ -376,11 +376,11 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
         opt.is_SE = true;
     }
 
-	//If not generating index, fastq1 is mandatory:
-	if (opt.reads_filename1.empty() && !opt.only_gen_index) {
-		std::cerr << "Reads file (fastq) must be specified." << std::endl;
+    //If not generating index, fastq1 is mandatory:
+    if (opt.reads_filename1.empty() && !opt.only_gen_index) {
+        std::cerr << "Reads file (fastq) must be specified." << std::endl;
 //		exit(1);
-	}
+    }
 
     return std::make_pair(opt, map_param);
 }
@@ -564,176 +564,176 @@ int main (int argc, char **argv)
 
     //////////// CREATE INDEX OF REF SEQUENCES /////////////////
 
-	st_index index;
+    st_index index;
 
-	if (opt.ref_filename.substr(opt.ref_filename.length() - 4) != ".sti") { //assume it is a fasta file if not named ".sti"
-		//Generate index from FASTA
-	
-		// Record index creation start time
-		auto start = high_resolution_clock::now();
-		auto start_read_refs = start;
-		uint64_t total_ref_seq_size = read_references(index.ref_seqs, index.ref_lengths, index.acc_map, opt.ref_filename);
-		std::chrono::duration<double> elapsed_read_refs = high_resolution_clock::now() - start_read_refs;
-		std::cerr << "Time reading references: " << elapsed_read_refs.count() << " s\n" << std::endl;
+    if (opt.ref_filename.substr(opt.ref_filename.length() - 4) != ".sti") { //assume it is a fasta file if not named ".sti"
+        //Generate index from FASTA
+    
+        // Record index creation start time
+        auto start = high_resolution_clock::now();
+        auto start_read_refs = start;
+        uint64_t total_ref_seq_size = read_references(index.ref_seqs, index.ref_lengths, index.acc_map, opt.ref_filename);
+        std::chrono::duration<double> elapsed_read_refs = high_resolution_clock::now() - start_read_refs;
+        std::cerr << "Time reading references: " << elapsed_read_refs.count() << " s\n" << std::endl;
 
-		if (total_ref_seq_size == 0) {
-			std::cerr << "No reference sequences found, aborting.." << std::endl;
-			return 1;
-		}
+        if (total_ref_seq_size == 0) {
+            std::cerr << "No reference sequences found, aborting.." << std::endl;
+            return 1;
+        }
 
-		std::tie(index.flat_vector, index.mers_index) = create_index(map_param, index.ref_seqs, total_ref_seq_size);
+        std::tie(index.flat_vector, index.mers_index) = create_index(map_param, index.ref_seqs, total_ref_seq_size);
 
-		// Record index creation end time
-		std::chrono::duration<double> elapsed = high_resolution_clock::now() - start;
-		std::cerr << "Total time indexing: " << elapsed.count() << " s\n" << std::endl;
+        // Record index creation end time
+        std::chrono::duration<double> elapsed = high_resolution_clock::now() - start;
+        std::cerr << "Total time indexing: " << elapsed.count() << " s\n" << std::endl;
 
-		if (opt.index_log) {
-			std::cerr << "Printing log stats" << std::endl;
-			print_diagnostics(index.flat_vector, index.mers_index, opt.logfile_name, map_param.k, map_param.max_dist + map_param.k);
-			std::cerr << "Finished printing log stats" << std::endl;
-		}
-		
-		// If the program was called with the -i flag, write the index to file
-		if (opt.only_gen_index) { // If the program was called with the -i flag, we do not do the alignment
-			auto start_write_index = high_resolution_clock::now();
-			write_index(index, opt.index_out_filename);
-			std::chrono::duration<double> elapsed_write_index = high_resolution_clock::now() - start_write_index;
-			std::cerr << "Total time writing index: " << elapsed_write_index.count() << " s\n" << std::endl;
-		}
-	}
-	else {
-		//load index from file
-		auto start_read_index = high_resolution_clock::now();
-		read_index(index, opt.ref_filename);
-		std::chrono::duration<double> elapsed_read_index = high_resolution_clock::now() - start_read_index;
-		std::cerr << "Total time reading index: " << elapsed_read_index.count() << " s\n" << std::endl;
+        if (opt.index_log) {
+            std::cerr << "Printing log stats" << std::endl;
+            print_diagnostics(index.flat_vector, index.mers_index, opt.logfile_name, map_param.k, map_param.max_dist + map_param.k);
+            std::cerr << "Finished printing log stats" << std::endl;
+        }
+        
+        // If the program was called with the -i flag, write the index to file
+        if (opt.only_gen_index) { // If the program was called with the -i flag, we do not do the alignment
+            auto start_write_index = high_resolution_clock::now();
+            write_index(index, opt.index_out_filename);
+            std::chrono::duration<double> elapsed_write_index = high_resolution_clock::now() - start_write_index;
+            std::cerr << "Total time writing index: " << elapsed_write_index.count() << " s\n" << std::endl;
+        }
+    }
+    else {
+        //load index from file
+        auto start_read_index = high_resolution_clock::now();
+        read_index(index, opt.ref_filename);
+        std::chrono::duration<double> elapsed_read_index = high_resolution_clock::now() - start_read_index;
+        std::cerr << "Total time reading index: " << elapsed_read_index.count() << " s\n" << std::endl;
 
-	}
+    }
 
-	///////////////////////////// MAP ///////////////////////////////////////
-	
-	if (!(opt.only_gen_index && opt.reads_filename1.empty())) { // If the program was called with the -i flag and the fastqs are not specified, we don't run any alignment
+    ///////////////////////////// MAP ///////////////////////////////////////
+    
+    if (!(opt.only_gen_index && opt.reads_filename1.empty())) { // If the program was called with the -i flag and the fastqs are not specified, we don't run any alignment
 
-		// Record matching time
-		auto start_aln_part = high_resolution_clock::now();
+        // Record matching time
+        auto start_aln_part = high_resolution_clock::now();
 
-		//    std::ifstream query_file(reads_filename);
+        //    std::ifstream query_file(reads_filename);
 
-		map_param.rescue_cutoff = map_param.R < 100 ? map_param.R * map_param.filter_cutoff : 1000;
-		std::cerr << "Using rescue cutoff: " << map_param.rescue_cutoff << std::endl;
+        map_param.rescue_cutoff = map_param.R < 100 ? map_param.R * map_param.filter_cutoff : 1000;
+        std::cerr << "Using rescue cutoff: " << map_param.rescue_cutoff << std::endl;
 
-		std::streambuf* buf;
-		std::ofstream of;
+        std::streambuf* buf;
+        std::ofstream of;
 
-		if (!opt.write_to_stdout) {
-			of.open(opt.output_file_name);
-			buf = of.rdbuf();
-		}
-		else {
-			buf = std::cout.rdbuf();
-		}
+        if (!opt.write_to_stdout) {
+            of.open(opt.output_file_name);
+            buf = of.rdbuf();
+        }
+        else {
+            buf = std::cout.rdbuf();
+        }
 
-		std::ostream out(buf);
-		//    std::ofstream out;
-		//    out.open(opt.output_file_name);
+        std::ostream out(buf);
+        //    std::ofstream out;
+        //    out.open(opt.output_file_name);
 
-		//    std::stringstream sam_output;
-		//    std::stringstream paf_output;
+        //    std::stringstream sam_output;
+        //    std::stringstream paf_output;
 
-		if (map_param.is_sam_out) {
-			out << sam_header(index.acc_map, index.ref_lengths);
-		}
+        if (map_param.is_sam_out) {
+            out << sam_header(index.acc_map, index.ref_lengths);
+        }
 
-		std::unordered_map<std::thread::id, logging_variables> log_stats_vec(opt.n_threads);
+        std::unordered_map<std::thread::id, logging_variables> log_stats_vec(opt.n_threads);
 
 
-		std::cerr << "Running in " << (opt.is_SE ? "single-end" : "paired-end") << " mode" << std::endl;
+        std::cerr << "Running in " << (opt.is_SE ? "single-end" : "paired-end") << " mode" << std::endl;
 
-		if (opt.is_SE) {
-			gzFile fp = gzopen(opt.reads_filename1.c_str(), "r");
-			auto ks = make_ikstream(fp, gzread);
+        if (opt.is_SE) {
+            gzFile fp = gzopen(opt.reads_filename1.c_str(), "r");
+            auto ks = make_ikstream(fp, gzread);
 
-			////////// ALIGNMENT START //////////
+            ////////// ALIGNMENT START //////////
 
-			int input_chunk_size = 100000;
-			// Create Buffers
-			InputBuffer input_buffer = { {}, {}, {}, {}, {}, ks, ks, false, 0, input_chunk_size };
-			OutputBuffer output_buffer = { {}, {}, {}, 0, out };
+            int input_chunk_size = 100000;
+            // Create Buffers
+            InputBuffer input_buffer = { {}, {}, {}, {}, {}, ks, ks, false, 0, input_chunk_size };
+            OutputBuffer output_buffer = { {}, {}, {}, 0, out };
 
-			std::vector<std::thread> workers;
-			for (int i = 0; i < opt.n_threads; ++i) {
-				std::thread consumer(perform_task_SE, std::ref(input_buffer), std::ref(output_buffer),
-					std::ref(log_stats_vec), std::ref(aln_params),
-					std::ref(map_param), std::ref(index.ref_lengths), std::ref(index.ref_seqs),
-					std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(index.acc_map));
-				workers.push_back(std::move(consumer));
-			}
+            std::vector<std::thread> workers;
+            for (int i = 0; i < opt.n_threads; ++i) {
+                std::thread consumer(perform_task_SE, std::ref(input_buffer), std::ref(output_buffer),
+                    std::ref(log_stats_vec), std::ref(aln_params),
+                    std::ref(map_param), std::ref(index.ref_lengths), std::ref(index.ref_seqs),
+                    std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(index.acc_map));
+                workers.push_back(std::move(consumer));
+            }
 
-			for (size_t i = 0; i < workers.size(); ++i) {
-				workers[i].join();
-			}
+            for (size_t i = 0; i < workers.size(); ++i) {
+                workers[i].join();
+            }
 
-			gzclose(fp);
-		}
-		else {
-			gzFile fp1 = gzopen(opt.reads_filename1.c_str(), "r");
-			auto ks1 = make_ikstream(fp1, gzread);
-			gzFile fp2 = gzopen(opt.reads_filename2.c_str(), "r");
-			auto ks2 = make_ikstream(fp2, gzread);
-			std::unordered_map<std::thread::id, i_dist_est> isize_est_vec(opt.n_threads);
+            gzclose(fp);
+        }
+        else {
+            gzFile fp1 = gzopen(opt.reads_filename1.c_str(), "r");
+            auto ks1 = make_ikstream(fp1, gzread);
+            gzFile fp2 = gzopen(opt.reads_filename2.c_str(), "r");
+            auto ks2 = make_ikstream(fp2, gzread);
+            std::unordered_map<std::thread::id, i_dist_est> isize_est_vec(opt.n_threads);
 
-			////////// ALIGNMENT START //////////
-			/////////////////////////////////////
+            ////////// ALIGNMENT START //////////
+            /////////////////////////////////////
 
-			int input_chunk_size = 100000;
-			// Create Buffers
-			InputBuffer input_buffer = { {}, {}, {}, {}, {}, ks1, ks2, false, 0, input_chunk_size };
-			OutputBuffer output_buffer = { {}, {}, {}, 0, out };
+            int input_chunk_size = 100000;
+            // Create Buffers
+            InputBuffer input_buffer = { {}, {}, {}, {}, {}, ks1, ks2, false, 0, input_chunk_size };
+            OutputBuffer output_buffer = { {}, {}, {}, 0, out };
 
-			std::vector<std::thread> workers;
-			for (int i = 0; i < opt.n_threads; ++i) {
-				std::thread consumer(perform_task_PE, std::ref(input_buffer), std::ref(output_buffer),
-					std::ref(log_stats_vec), std::ref(isize_est_vec), std::ref(aln_params),
-					std::ref(map_param), std::ref(index.ref_lengths), std::ref(index.ref_seqs),
-					std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(index.acc_map));
-				workers.push_back(std::move(consumer));
-			}
+            std::vector<std::thread> workers;
+            for (int i = 0; i < opt.n_threads; ++i) {
+                std::thread consumer(perform_task_PE, std::ref(input_buffer), std::ref(output_buffer),
+                    std::ref(log_stats_vec), std::ref(isize_est_vec), std::ref(aln_params),
+                    std::ref(map_param), std::ref(index.ref_lengths), std::ref(index.ref_seqs),
+                    std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(index.acc_map));
+                workers.push_back(std::move(consumer));
+            }
 
-			for (size_t i = 0; i < workers.size(); ++i) {
-				workers[i].join();
-			}
+            for (size_t i = 0; i < workers.size(); ++i) {
+                workers[i].join();
+            }
 
-			/////////////////////////////////////
-			/////////////////////////////////////
+            /////////////////////////////////////
+            /////////////////////////////////////
 
-			gzclose(fp1);
-			gzclose(fp2);
-		}
-		std::cerr << "Done!\n";
+            gzclose(fp1);
+            gzclose(fp2);
+        }
+        std::cerr << "Done!\n";
 
-		logging_variables tot_log_vars;
-		for (auto& it : log_stats_vec) {
-			tot_log_vars += it.second;
-		}
-		// Record mapping end time
-		std::chrono::duration<double> tot_aln_part = high_resolution_clock::now() - start_aln_part;
+        logging_variables tot_log_vars;
+        for (auto& it : log_stats_vec) {
+            tot_log_vars += it.second;
+        }
+        // Record mapping end time
+        std::chrono::duration<double> tot_aln_part = high_resolution_clock::now() - start_aln_part;
 
-		std::cerr << "Total mapping sites tried: " << tot_log_vars.tot_all_tried << std::endl
-			<< "Total calls to ssw: " << tot_log_vars.tot_ksw_aligned << std::endl
-			<< "Calls to ksw (rescue mode): " << tot_log_vars.tot_rescued << std::endl
-			<< "Did not fit strobe start site: " << tot_log_vars.did_not_fit << std::endl
-			<< "Tried rescue: " << tot_log_vars.tried_rescue << std::endl
-			<< "Total time mapping: " << tot_aln_part.count() << " s." << std::endl
-			<< "Total time reading read-file(s): " << tot_log_vars.tot_read_file.count() / opt.n_threads << " s." << std::endl
-			<< "Total time creating strobemers: " << tot_log_vars.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl
-			<< "Total time finding NAMs (non-rescue mode): " << tot_log_vars.tot_find_nams.count() / opt.n_threads << " s." << std::endl
-			<< "Total time finding NAMs (rescue mode): " << tot_log_vars.tot_time_rescue.count() / opt.n_threads << " s." << std::endl;
-		//<< "Total time finding NAMs ALTERNATIVE (candidate sites): " << tot_find_nams_alt.count()/opt.n_threads  << " s." <<  std::endl;
-		std::cerr << "Total time sorting NAMs (candidate sites): " << tot_log_vars.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
-			<< "Total time reverse compl seq: " << tot_log_vars.tot_rc.count() / opt.n_threads << " s." << std::endl
-			<< "Total time base level alignment (ssw): " << tot_log_vars.tot_extend.count() / opt.n_threads << " s." << std::endl
-			<< "Total time writing alignment to files: " << tot_log_vars.tot_write_file.count() << " s." << std::endl;
+        std::cerr << "Total mapping sites tried: " << tot_log_vars.tot_all_tried << std::endl
+            << "Total calls to ssw: " << tot_log_vars.tot_ksw_aligned << std::endl
+            << "Calls to ksw (rescue mode): " << tot_log_vars.tot_rescued << std::endl
+            << "Did not fit strobe start site: " << tot_log_vars.did_not_fit << std::endl
+            << "Tried rescue: " << tot_log_vars.tried_rescue << std::endl
+            << "Total time mapping: " << tot_aln_part.count() << " s." << std::endl
+            << "Total time reading read-file(s): " << tot_log_vars.tot_read_file.count() / opt.n_threads << " s." << std::endl
+            << "Total time creating strobemers: " << tot_log_vars.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl
+            << "Total time finding NAMs (non-rescue mode): " << tot_log_vars.tot_find_nams.count() / opt.n_threads << " s." << std::endl
+            << "Total time finding NAMs (rescue mode): " << tot_log_vars.tot_time_rescue.count() / opt.n_threads << " s." << std::endl;
+        //<< "Total time finding NAMs ALTERNATIVE (candidate sites): " << tot_find_nams_alt.count()/opt.n_threads  << " s." <<  std::endl;
+        std::cerr << "Total time sorting NAMs (candidate sites): " << tot_log_vars.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
+            << "Total time reverse compl seq: " << tot_log_vars.tot_rc.count() / opt.n_threads << " s." << std::endl
+            << "Total time base level alignment (ssw): " << tot_log_vars.tot_extend.count() / opt.n_threads << " s." << std::endl
+            << "Total time writing alignment to files: " << tot_log_vars.tot_write_file.count() << " s." << std::endl;
 
-		/////////////////////// FIND AND OUTPUT NAMs ///////////////////////////////
-	}
+        /////////////////////// FIND AND OUTPUT NAMs ///////////////////////////////
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -470,7 +470,9 @@ std::pair<mers_vector, kmer_lookup>  create_index(mapping_params& map_param, std
     }
     uint64_t unique_mers = count_unique_elements(h_vector);
     std::cerr << "Unique strobemers: " << unique_mers << std::endl;
-    ind_flat_vector.clear(); //deallocate the vector used for sorting
+    ind_mers_vector().swap(ind_flat_vector);   //deallocate the vector used for sorting - ind_flat_vector.clear() will not deallocate, 
+                                               //swap with an empty vector will. I tested (in debug mode), the buffer gets deleted
+
     std::chrono::duration<double> elapsed_copy_flat_vector = high_resolution_clock::now() - start_copy_flat_vector;
     std::cerr << "Time copying flat vector: " << elapsed_copy_flat_vector.count() << " s\n" << std::endl;
 


### PR DESCRIPTION
I did two things:
1) Collected the index into a struct.
2) Added the possibility to read/write the index from/to disk. 

I have not created test cases (I don't know how in this project) but have tested the code, it produces identical output for phix compared to previous runs.

I tested to run on the human transcriptome:
Read of reference: 4.3 s
Generation of index: 31.1 s
Writing index: 6.8 s - this is a bit slow, it is probably possible to speed it up but I left it for now.
Reading index: 3.6 s
Index size: 1.5 GB - the kallisto index for the same is 2.4 GB, somewhat the same order of magnitude, the fasta file is 350 MB.

I developed the code in Visual Studio, worked fine. I have not tested to compile with GCC, but it should work. Would be good if someone with that environment up could test it quickly.

There are three things we discovered that should be changed later at some point, but it is better to do these as separate actions:
* idx_to_acc - change this to a vector, no point in having a map with <i,data>, where i is just the index - access will be identical, i.e., index.acc_map[i]
* Remove the first uint64_t in the mers_vector - according to Kristoffer it should not be needed, which will reduce the memory taken up by the index (and file size).
* I think we should rename unsigned int etc. to uint32_t - the number of bits in types like int has traditionally been different between machine architectures to optimize speed, so the size is a bit unclear, although it is pretty safe to assume they will be 32 bits.

I can fix these things once this is approved.