### PR TITLE
Use std::{max,min,abs} instead of ternary operators

### DIFF
--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -30,8 +30,6 @@ using namespace klibpp;
 
 
 typedef robin_hood::unordered_map<int, std::string > idx_to_acc;
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
 struct aln_info {
     std::string cigar;


### PR DESCRIPTION
This makes the intention clearer, the code shorter and avoids repeating expressions.

This isn’t complete; I got to about line 1800 in aln.cpp.