### PR TITLE
Less verbose default logging output

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -18,6 +18,7 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
 
     args::Group io(parser, "Input/output:");
     args::ValueFlag<std::string> o(parser, "STR", "redirect output to file [stdout]", {'o'});
+    args::Flag v(parser, "v", "Verbose output", {'v'});
     args::Flag x(parser, "x", "Only map reads, no base level alignment (produces paf file)", {'x'});
     args::ValueFlag<int> N(parser, "INT", "retain at most INT secondary alignments (is upper bounded by -M, and depends on -S) [0]", {'N'});
     args::ValueFlag<std::string> L(parser, "STR", "Print statistics of indexing to logfile [log.csv]", {'L'});
@@ -94,6 +95,7 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
 
     // Input/output
     if (o) { opt.output_file_name = args::get(o); opt.write_to_stdout = false; }
+    if (v) { opt.verbose = true; }
     if (x) { map_param.is_sam_out = false; }
     if (N) { map_param.max_secondary = args::get(N); }
     if (L) { opt.logfile_name = args::get(L); opt.index_log = true; }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -14,6 +14,7 @@ struct CommandLineOptions {
     int max_seed_len;
     std::string output_file_name;
     std::string logfile_name { "log.csv" };
+    bool verbose { false };
     int n_threads { 3 };
     std::string ref_filename; //This is either a fasta file or an index file - if fasta, indexing will be run
     std::string reads_filename1;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -14,6 +14,10 @@
 #include <fstream>
 #include <cassert>
 
+#include "logger.hpp"
+
+static Logger& logger = Logger::get();
+
 /**********************************************************
  *
  * hash kmer into uint64
@@ -112,7 +116,7 @@ uint64_t count_unique_elements(const hash_vector& h_vector){
 
 unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, float f){
 
-    std::cerr << "Flat vector size: " << h_vector.size() << std::endl;
+    logger.debug() << "Flat vector size: " << h_vector.size() << std::endl;
 //    kmer_lookup mers_index;
     unsigned int offset = 0;
     unsigned int prev_offset = 0;
@@ -159,23 +163,24 @@ unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, 
     std::tuple<unsigned int, unsigned int> s(prev_offset, count);
     mers_index[curr_k] = s;
     float frac_unique = ((float) tot_occur_once )/ mers_index.size();
-    std::cerr << "Total strobemers count: " << offset << std::endl;
-    std::cerr << "Total strobemers occur once: " << tot_occur_once << std::endl;
-    std::cerr << "Fraction Unique: " << frac_unique << std::endl;
-    std::cerr << "Total strobemers highly abundant > 100: " << tot_high_ab << std::endl;
-    std::cerr << "Total strobemers mid abundance (between 2-100): " << tot_mid_ab << std::endl;
-    std::cerr << "Total distinct strobemers stored: " << mers_index.size() << std::endl;
+    logger.debug()
+        << "Total strobemers count: " << offset << std::endl
+        << "Total strobemers occur once: " << tot_occur_once << std::endl
+        << "Fraction Unique: " << frac_unique << std::endl
+        << "Total strobemers highly abundant > 100: " << tot_high_ab << std::endl
+        << "Total strobemers mid abundance (between 2-100): " << tot_mid_ab << std::endl
+        << "Total distinct strobemers stored: " << mers_index.size() << std::endl;
     if (tot_high_ab >= 1) {
-        std::cerr << "Ratio distinct to highly abundant: " << mers_index.size() / tot_high_ab << std::endl;
+        logger.debug() << "Ratio distinct to highly abundant: " << mers_index.size() / tot_high_ab << std::endl;
     }
     if (tot_mid_ab >= 1) {
-        std::cerr << "Ratio distinct to non distinct: " << mers_index.size() / (tot_high_ab + tot_mid_ab) << std::endl;
+        logger.debug() << "Ratio distinct to non distinct: " << mers_index.size() / (tot_high_ab + tot_mid_ab) << std::endl;
     }
     // get count for top -f fraction of strobemer count to filter them out
     std::sort(strobemer_counts.begin(), strobemer_counts.end(), std::greater<int>());
 
     unsigned int index_cutoff = mers_index.size()*f;
-    std::cerr << "Filtered cutoff index: " << index_cutoff << std::endl;
+    logger.debug() << "Filtered cutoff index: " << index_cutoff << std::endl;
     unsigned int filter_cutoff;
     if (!strobemer_counts.empty()){
         filter_cutoff =  index_cutoff < strobemer_counts.size() ?  strobemer_counts[index_cutoff] : strobemer_counts.back();
@@ -184,9 +189,7 @@ unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, 
     } else {
         filter_cutoff = 30;
     }
-    std::cerr << "Filtered cutoff count: " << filter_cutoff << std::endl;
-    std::cerr << "" << std::endl;
-    std::cerr << "" << std::endl;
+    logger.debug() << "Filtered cutoff count: " << filter_cutoff << std::endl << std::endl;
     return filter_cutoff;
 }
 

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -1,0 +1,94 @@
+#ifndef LOGGER_HPP
+#define LOGGER_HPP
+
+#include <ostream>
+#include <iostream>
+
+
+/*
+
+Very simple logging.
+
+Usage:
+
+logger = Logger::get();  // returns the logging singleton
+logger.set_level(LOG_INFO);
+logger.info() << "info message" << std::endl; // printed
+logger.debug() << "debug message" << std::endl; // not printed
+
+*/
+
+
+enum LOG_LEVELS {
+    LOG_DEBUG = 1,
+    LOG_INFO = 2,
+    LOG_WARNING = 3,
+    LOG_ERROR = 4,
+};
+
+class Logger;
+
+class LogStream {
+public:
+    LogStream(int level, Logger& logger): level(level), logger(logger) { }
+    template <typename T>
+    LogStream& operator<<(const T& val);
+    LogStream& operator<<(std::ostream& (*f)(std::ostream&));
+private:
+    int level;
+    Logger& logger;
+};
+
+
+class Logger {
+public:
+    static Logger& get() {
+        static Logger instance;
+        return instance;
+    }
+    Logger(Logger const&) = delete;
+    void operator=(Logger const&) = delete;
+
+    void set_level(int level) { this->level = level; }
+    LogStream& debug() { return _debug; }
+    LogStream& info() { return _info; }
+    LogStream& warning() { return _warning; }
+    LogStream& error() { return _error; }
+
+private:
+    Logger()
+        : level(0)
+        , _os(std::cerr)
+        , _debug(LogStream(LOG_DEBUG, *this))
+        , _info(LogStream(LOG_INFO, *this))
+        , _warning(LogStream(LOG_WARNING, *this))
+        , _error(LogStream(LOG_ERROR, *this))
+    { }
+    int level;
+    std::ostream& _os;
+    LogStream _debug;
+    LogStream _info;
+    LogStream _warning;
+    LogStream _error;
+
+    friend class LogStream;
+};
+
+
+template <typename T>
+LogStream& LogStream::operator<<(const T& val) {
+    if (level >= logger.level) {
+        logger._os << val;
+    }
+    return *this;
+}
+
+// This overload is required for supporting std::endl
+inline LogStream& LogStream::operator<<(std::ostream& (*f)(std::ostream&)) {
+    if (level >= logger.level) {
+        f(logger._os);
+    }
+    return *this;
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,10 +23,15 @@
 #include "index.hpp"
 #include "pc.hpp"
 #include "aln.hpp"
+#include "logger.hpp"
 #include "version.hpp"
 
 using namespace klibpp;
 using std::chrono::high_resolution_clock;
+
+
+static Logger& logger = Logger::get();
+
 
 static void print_diagnostics(mers_vector &ref_mers, kmer_lookup &mers_index, std::string logfile_name, int k, int m) {
     // Prins to csv file the statistics on the number of seeds of a particular length and what fraction of them them are unique in the index:
@@ -302,10 +307,10 @@ int main (int argc, char **argv)
     mapping_params map_param;
     std::tie(opt, map_param) = parse_command_line_arguments(argc, argv);
 
+    logger.set_level(opt.verbose ? LOG_DEBUG : LOG_INFO);
     if (!opt.r_set) {
         map_param.r = estimate_read_length(opt.reads_filename1, opt.reads_filename2);
     }
-
     adjust_mapping_params_depending_on_read_length(map_param, opt);
 
     if (!opt.max_seed_len_set){


### PR DESCRIPTION
I think the log output is a bit "intimidating" and contains some lines that an end user doesn’t need to see. This PR silences some of these messages by default and adds a command-line option `-v` (verbose) that can be used to re-enable them.

This is achieved by introducing a very simple `Logger` class. Instead of writing to `std::cerr` unconditionally, each message is written to `logger.debug()` or `logger.info()` (`logger.warning()` and `logger.error()` are also available). Only messages at least as high as the current log level are printed, and the default log level is set to `LOG_INFO`. The `-v` option sets the current log level to `LOG_DEBUG`. We could also add a `--quiet` option later that would set the log level to `LOG_WARNING` and therefore hide even the info-level messages.