### PR TITLE
Add a References class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ endif()
 
 add_compile_options(-Wall -Wextra)
 
-set(SOURCES
-  src/fasta.cpp
+add_library(salib STATIC ${SOURCES}
+  src/refs.cpp
   src/cmdline.cpp
   src/index.cpp
   src/sam.cpp
@@ -34,8 +34,6 @@ set(SOURCES
   ext/ssw_cpp.cpp
   ext/ssw.c
 )
-
-add_library(salib STATIC ${SOURCES})
 target_include_directories(salib PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
 target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads)
 IF(ENABLE_AVX)

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -12,7 +12,7 @@ static inline bool score(const nam &a, const nam &b)
     return ( a.score > b.score );
 }
 
-inline aln_info ssw_align(const std::string &ref, const std::string &query, int read_len, int match_score, int mismatch_penalty, int gap_opening_penalty, int gap_extending_penalty) {
+inline aln_info ssw_align(const std::string &ref, const std::string &query, int match_score, int mismatch_penalty, int gap_opening_penalty, int gap_extending_penalty) {
 
     aln_info aln;
     int32_t maskLen = strlen(query.c_str())/2;
@@ -1522,7 +1522,7 @@ inline void align_SE(const alignment_params &aln_params, Sam& sam, std::vector<n
             aln_info info;
 //            std::cout << "Extra ref: " << extra_ref << " " << read_diff << " " << ref_diff << " " << ref_start << " " << ref_end << std::endl;
 //            info = ksw_align(ref_ptr, ref_segm.size(), read_ptr, r_tmp.size(), 1, 4, 6, 1, ez);
-            info = ssw_align(ref_segm, r_tmp, read_len, aln_params.match, aln_params.mismatch, aln_params.gap_open, aln_params.gap_extend);
+            info = ssw_align(ref_segm, r_tmp, aln_params.match, aln_params.mismatch, aln_params.gap_open, aln_params.gap_extend);
 //            info.ed = info.global_ed; // read_len - info.sw_score;
             int diff_to_best = std::abs(best_align_sw_score - info.sw_score);
             min_mapq_diff = std::min(min_mapq_diff, diff_to_best);
@@ -1788,7 +1788,7 @@ static inline void align_SE_secondary_hits(alignment_params &aln_params, Sam& sa
             aln_info info;
 //            std::cout << "Extra ref: " << extra_ref << " " << read_diff << " " << ref_diff << " " << ref_start << " " << ref_end << std::endl;
 //            info = ksw_align(ref_ptr, ref_segm.size(), read_ptr, r_tmp.size(), 1, 4, 6, 1, ez);
-            info = ssw_align(ref_segm, r_tmp, read_len, aln_params.match, aln_params.mismatch, aln_params.gap_open, aln_params.gap_extend);
+            info = ssw_align(ref_segm, r_tmp, aln_params.match, aln_params.mismatch, aln_params.gap_open, aln_params.gap_extend);
 //            info.ed = info.global_ed; // read_len - info.sw_score;
             sw_score = info.sw_score;
             log_vars.tot_ksw_aligned ++;
@@ -1878,11 +1878,7 @@ static inline void align_segment(alignment_params &aln_params, std::string &read
     }
 
     aln_info info;
-//    std::cerr << "PERFORM SSW: "<< std::endl;
-//    std::cerr << ref_segm << std::endl;
-//    std::cerr << read_segm << std::endl;
-//    std::cerr << read_segm_len << " " << ref_segm_len << std::endl;
-    info = ssw_align(ref_segm, read_segm, read_segm_len, aln_params.match, aln_params.mismatch, aln_params.gap_open, aln_params.gap_extend);
+    info = ssw_align(ref_segm, read_segm, aln_params.match, aln_params.mismatch, aln_params.gap_open, aln_params.gap_extend);
     tot_ksw_aligned ++;
     sam_aln_segm.cigar = info.cigar;
     sam_aln_segm.ed = info.ed;
@@ -2809,7 +2805,6 @@ static inline void rescue_mate(alignment_params &aln_params , nam &n, const std:
 //        std::cerr << "RESCUE: Caught Bug3! ref start: " << ref_start << " ref end: " << ref_end << " ref len:  " << ref_len << std::endl;
         return;
     }
-//    std::cerr << "Reached here: a:" << a << " b: " << b <<  " ref_len: " << ref_len << " ref_start: " << ref_start << " ref_end - ref_start: " << ref_end - ref_start << " sub ref str len: " << ref_start + ref_end - ref_start << std::endl;
     std::string ref_segm = ref_seqs[n.ref_id].substr(ref_start, ref_end - ref_start);
     aln_info info;
 
@@ -2837,16 +2832,10 @@ static inline void rescue_mate(alignment_params &aln_params , nam &n, const std:
         sam_aln.not_proper = true;
 //        std::cerr << "Avoided!" << std::endl;
         return;
-//        std::cerr << "LOOOOOOL!" << std::endl;
 //        std::cerr << "Aligning anyway at: " << ref_start << " to " << ref_end << "ref len:" << ref_len << " ref_id:" << n.ref_id << std::endl;
-//        std::cerr << "read: " << r_tmp << std::endl;
-//        std::cerr << "ref: " << ref_segm << std::endl;
     }
 
-//    std::cerr << "Aligning at: " << ref_start << " to " << ref_end << "ref len:" << ref_len << " ref_id:" << n.ref_id << std::endl;
-//    std::cerr << "read: " << r_tmp << std::endl;
-//    std::cerr << "ref: " << ref_segm << std::endl;
-    info = ssw_align(ref_segm, r_tmp, read_len, aln_params.match, aln_params.mismatch, aln_params.gap_open, aln_params.gap_extend);
+    info = ssw_align(ref_segm, r_tmp, aln_params.match, aln_params.mismatch, aln_params.gap_open, aln_params.gap_extend);
 
 //    if (info.ed == 100000){
 //        std::cerr<< "________________________________________" << std::endl;
@@ -2876,7 +2865,6 @@ static inline void rescue_mate(alignment_params &aln_params , nam &n, const std:
     tot_ksw_aligned ++;
     tot_rescued ++;
 }
-
 
 
 inline void align_PE(alignment_params &aln_params, Sam &sam, std::vector<nam> &all_nams1, std::vector<nam> &all_nams2,

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1,29 +1,10 @@
-#include <iostream>
-#include <fstream>
-#include <vector>
-#include <string>
-#include <assert.h>
-#include <math.h>
-#include <chrono>  // for high_resolution_clock
-//#include <omp.h>
-#include <zlib.h>
-#include <sstream>
-#include <algorithm>
-#include <numeric>
-#include <inttypes.h>
-
-#include "kseq++.hpp"
-using namespace klibpp;
-#include "robin_hood.h"
-#include "index.hpp"
-//#include "ksw2.h"
-#include "ssw_cpp.h"
-#include "pc.hpp"
 #include "aln.hpp"
-#include "sam.hpp"
 
-#include <chrono>
-#include <thread>
+#include <iostream>
+#include <math.h>
+#include <sstream>
+#include "ssw_cpp.h"
+#include "sam.hpp"
 
 
 static inline bool score(const nam &a, const nam &b)
@@ -811,7 +792,7 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
 
 
 
-inline void output_hits_paf(std::string &paf_output, const std::vector<nam> &all_nams, const std::string& query_acc, const idx_to_acc &acc_map, int k, int read_len, const std::vector<unsigned int> &ref_len_map) {
+inline void output_hits_paf(std::string &paf_output, const std::vector<nam> &all_nams, const std::string& query_acc, const ref_names &acc_map, int k, int read_len, const std::vector<unsigned int> &ref_len_map) {
     // Output results
     if (all_nams.size() == 0) {
         return;
@@ -850,7 +831,7 @@ inline void output_hits_paf(std::string &paf_output, const std::vector<nam> &all
     paf_output.append("\t255\n");
 }
 
-inline void output_hits_paf_PE(std::string &paf_output, nam &n, std::string &query_acc, idx_to_acc &acc_map, int k, int read_len, std::vector<unsigned int> &ref_len_map) {
+inline void output_hits_paf_PE(std::string &paf_output, nam &n, std::string &query_acc, ref_names &acc_map, int k, int read_len, std::vector<unsigned int> &ref_len_map) {
     // Output results
     std::string o;
     if (n.ref_s >= 0) {
@@ -3453,7 +3434,7 @@ inline void get_best_map_location(std::vector<std::tuple<int,nam,nam>> joint_NAM
 
 
 void align_PE_read(KSeq &record1, KSeq &record2, std::string &outstring, logging_variables &log_vars, i_dist_est &isize_est, alignment_params &aln_params,
-        mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, idx_to_acc &acc_map ){
+        mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ){
     // Declare variables
     mers_vector_read query_mers1, query_mers2; // pos, chr_id, kmer hash value
 
@@ -3584,7 +3565,7 @@ void align_PE_read(KSeq &record1, KSeq &record2, std::string &outstring, logging
 
 
 void align_SE_read(KSeq &record, std::string &outstring, logging_variables &log_vars, alignment_params &aln_params,
-                   mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, idx_to_acc &acc_map ){
+                   mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ){
 
 
         std::string seq, seq_rc;

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -20,7 +20,7 @@ using namespace klibpp;
 #include "ssw_cpp.h"
 #include "pc.hpp"
 #include "aln.hpp"
-
+#include "sam.hpp"
 
 #include <chrono>
 #include <thread>

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -1,29 +1,14 @@
 #ifndef aln_hpp
 #define aln_hpp
 
-#include <iostream>
-#include <fstream>
-#include <vector>
 #include <string>
-#include <assert.h>
-#include <math.h>
-#include <chrono>  // for high_resolution_clock
-//#include <omp.h>
-#include <zlib.h>
-#include <sstream>
-#include <algorithm>
-#include <numeric>
-#include <inttypes.h>
-
+#include <vector>
 #include "kseq++.hpp"
-using namespace klibpp;
-#include "robin_hood.h"
 #include "index.hpp"
-//#include "ksw2.h"
-#include "ssw_cpp.h"
+#include "refs.hpp"
 
-//#include <chrono>
-//#include <thread>
+using namespace klibpp;
+
 
 struct aln_info {
     std::string cigar;
@@ -36,9 +21,9 @@ struct aln_info {
 
 
 void align_PE_read(KSeq &record1, KSeq &record2, std::string &sam_out, logging_variables &log_vars, i_dist_est &isize_est, alignment_params &aln_params,
-                          mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, idx_to_acc &acc_map );
+                          mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map );
 
-void align_SE_read(KSeq& record, std::string& outstring, logging_variables& log_vars, alignment_params& aln_params, mapping_params& map_param, std::vector< unsigned int >& ref_lengths, std::vector< std::string >& ref_seqs, kmer_lookup& mers_index, mers_vector& flat_vector, idx_to_acc& acc_map );
+void align_SE_read(KSeq& record, std::string& outstring, logging_variables& log_vars, alignment_params& aln_params, mapping_params& map_param, std::vector< unsigned int >& ref_lengths, std::vector< std::string >& ref_seqs, kmer_lookup& mers_index, mers_vector& flat_vector, ref_names& acc_map );
 
 
-#endif // aln_hpp_
+#endif

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -21,7 +21,6 @@ using namespace klibpp;
 #include "index.hpp"
 //#include "ksw2.h"
 #include "ssw_cpp.h"
-#include "sam.hpp"
 
 //#include <chrono>
 //#include <thread>

--- a/src/fasta.cpp
+++ b/src/fasta.cpp
@@ -41,12 +41,9 @@ uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsigned in
         }
     }
     if (seq.length() > 0){
-//        seqs[ref_index -1] = seq;
         seqs.push_back(seq);
         lengths.push_back(seq.length());
         total_ref_seq_size += seq.length();
-//        std::cerr << ref_index -1 << " here2 " << seq << std::endl;
-//        generate_kmers(h, k, seq, ref_index);
     }
 
     return total_ref_seq_size;

--- a/src/fasta.cpp
+++ b/src/fasta.cpp
@@ -1,13 +1,16 @@
 #include <vector>
+#include <fstream>
+#include <sstream>
 #include "fasta.hpp"
 #include "exceptions.hpp"
 
-uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsigned int> &lengths, idx_to_acc &acc_map, std::string fn)
-{
-    uint64_t total_ref_seq_size = 0;
-    std::ifstream file(fn);
+References References::from_fasta(std::string filename) {
+    std::vector<std::string> sequences;
+    std::vector<std::string> names;
+    std::vector<unsigned int> lengths;
+
+    std::ifstream file(filename);
     std::string line, seq;
-    acc_map.clear();
 
     if (!file.good()) {
         throw InvalidFasta("Cannot read from FASTA file");
@@ -23,17 +26,11 @@ uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsigned in
 
     while (getline(file, line)) {
         if (line[0] == '>') {
-//            std::cerr << ref_index << " " << line << std::endl;
             if (seq.length() > 0) {
-//                seqs[ref_index -1] = seq;
-                seqs.push_back(seq);
+                sequences.push_back(seq);
                 lengths.push_back(seq.length());
-                total_ref_seq_size += seq.length();
-//                std::cerr << ref_index - 1 << " here " << seq << " " << seq.length() << " " << seq.size() << std::endl;
-//                generate_kmers(h, k, seq, ref_index);
             }
-//            acc_map.push_back(line.substr(1, line.length() -1); //line;
-            acc_map.push_back(line.substr(1, line.find(' ') -1)); // cutting at first space;
+            names.push_back(line.substr(1, line.find(' ') - 1)); // cut at first space
             seq = "";
         }
         else {
@@ -41,19 +38,9 @@ uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsigned in
         }
     }
     if (seq.length() > 0){
-        seqs.push_back(seq);
+        sequences.push_back(seq);
         lengths.push_back(seq.length());
-        total_ref_seq_size += seq.length();
     }
 
-    return total_ref_seq_size;
-}
-
-
-References References::from_fasta(std::string path) {
-    std::vector<std::string> sequences;
-    std::vector<std::string> names;
-    std::vector<unsigned int> lengths;
-    read_references(sequences, lengths, names, path);
     return References(std::move(sequences), std::move(names), std::move(lengths));
 }

--- a/src/fasta.cpp
+++ b/src/fasta.cpp
@@ -48,3 +48,12 @@ uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsigned in
 
     return total_ref_seq_size;
 }
+
+
+References References::from_fasta(std::string path) {
+    std::vector<std::string> sequences;
+    std::vector<std::string> names;
+    std::vector<unsigned int> lengths;
+    read_references(sequences, lengths, names, path);
+    return References(std::move(sequences), std::move(names), std::move(lengths));
+}

--- a/src/fasta.hpp
+++ b/src/fasta.hpp
@@ -3,24 +3,42 @@
 
 #include <cstdint>
 #include <string>
-#include "aln.hpp"  // idx_to_acc
+#include <stdexcept>
+#include <numeric>
 
-uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsigned int> &lengths, idx_to_acc &acc_map, std::string fn);
+#include <iostream>
 
 
 class References {
 public:
+    References() { }
     References(
         std::vector<std::string>&& sequences,
         std::vector<std::string>&& names,
         std::vector<unsigned int>&& lengths
-    ) : sequences(std::move(sequences)), names(std::move(names)), lengths(std::move(lengths)) { }
+    ) : sequences(std::move(sequences)), names(std::move(names)), lengths(std::move(lengths)) {
+
+        _total_length = std::accumulate(this->lengths.begin(), this->lengths.end(), (size_t)0);
+        if (sequences.size() != names.size() || names.size() != lengths.size()) {
+            throw std::invalid_argument("lengths do not match");
+        }
+    }
 
     static References from_fasta(std::string path);
 
-    const std::vector<std::string> sequences;
-    const std::vector<std::string> names;
-    const std::vector<unsigned int> lengths;
+    size_t size() const {
+        return sequences.size();
+    }
+
+    size_t total_length() const {
+        return _total_length;
+    }
+
+    std::vector<std::string> sequences;
+    std::vector<std::string> names;
+    std::vector<unsigned int> lengths;
+private:
+    size_t _total_length;
 };
 
 #endif

--- a/src/fasta.hpp
+++ b/src/fasta.hpp
@@ -7,4 +7,20 @@
 
 uint64_t read_references(std::vector<std::string> &seqs, std::vector<unsigned int> &lengths, idx_to_acc &acc_map, std::string fn);
 
+
+class References {
+public:
+    References(
+        std::vector<std::string>&& sequences,
+        std::vector<std::string>&& names,
+        std::vector<unsigned int>&& lengths
+    ) : sequences(std::move(sequences)), names(std::move(names)), lengths(std::move(lengths)) { }
+
+    static References from_fasta(std::string path);
+
+    const std::vector<std::string> sequences;
+    const std::vector<std::string> names;
+    const std::vector<unsigned int> lengths;
+};
+
 #endif

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -114,10 +114,8 @@ uint64_t count_unique_elements(const hash_vector& h_vector){
     return unique_elements;
 }
 
-unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, float f){
-
+unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, float f) {
     logger.debug() << "Flat vector size: " << h_vector.size() << std::endl;
-//    kmer_lookup mers_index;
     unsigned int offset = 0;
     unsigned int prev_offset = 0;
     unsigned int count = 0;
@@ -131,7 +129,6 @@ unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, 
     uint64_t curr_k;
 
     for ( auto &t : h_vector) {
-//        std::cerr << t << std::endl;
         curr_k = t;
         if (curr_k == prev_k){
             count ++;
@@ -143,7 +140,6 @@ unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, 
             else if (count > 100){
                 tot_high_ab ++;
                 strobemer_counts.push_back(count);
-//                std::cerr << count << std::endl;
             }
             else{
                 tot_mid_ab ++;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4,8 +4,8 @@
 //
 //  Created by Kristoffer Sahlin on 4/21/21.
 //
-
 #include "index.hpp"
+
 #include <iostream>
 #include <math.h>       /* pow */
 #include <bitset>
@@ -190,37 +190,37 @@ unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, 
 }
 
 
-void write_index(const st_index& index, std::string filename) {
+void write_index(const st_index& index, const References& references, const std::string& filename) {
     std::ofstream ofs(filename, std::ios::binary);
 
     //write filter_cutoff
     ofs.write(reinterpret_cast<const char*>(&index.filter_cutoff), sizeof(index.filter_cutoff));
 
     //write ref_seqs:
-    uint64_t s1 = uint64_t(index.ref_seqs.size());
+    uint64_t s1 = uint64_t(references.sequences.size());
     ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
     //For each string, write length and then the string
     uint32_t s2 = 0;
-    for (std::size_t i = 0; i < index.ref_seqs.size(); ++i) {
-        s2 = uint32_t(index.ref_seqs[i].length());
+    for (std::size_t i = 0; i < references.sequences.size(); ++i) {
+        s2 = uint32_t(references.sequences[i].length());
         ofs.write(reinterpret_cast<char*>(&s2), sizeof(s2));
-        ofs.write(index.ref_seqs[i].c_str(), index.ref_seqs[i].length());
+        ofs.write(references.sequences[i].c_str(), references.sequences[i].length());
     }
     
     //write ref_lengths:
     //write everything in one large chunk
-    s1 = uint64_t(index.ref_lengths.size());
+    s1 = uint64_t(references.lengths.size());
     ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
-    ofs.write(reinterpret_cast<const char*>(&index.ref_lengths[0]), index.ref_lengths.size()*sizeof(index.ref_lengths[0]));
+    ofs.write(reinterpret_cast<const char*>(&references.lengths[0]), references.lengths.size()*sizeof(references.lengths[0]));
 
     //write acc_map:
-    s1 = uint64_t(index.acc_map.size());
+    s1 = uint64_t(references.names.size());
     ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
     //For each string, write length and then the string
-    for (std::size_t i = 0; i < index.acc_map.size(); ++i) {
-        s2 = uint32_t(index.acc_map[i].length());
+    for (std::size_t i = 0; i < references.names.size(); ++i) {
+        s2 = uint32_t(references.names[i].length());
         ofs.write(reinterpret_cast<char*>(&s2), sizeof(s2));
-        ofs.write(index.acc_map[i].c_str(), index.acc_map[i].length());
+        ofs.write(references.names[i].c_str(), references.names[i].length());
     }
 
     //write flat_vector:
@@ -237,18 +237,18 @@ void write_index(const st_index& index, std::string filename) {
     }
 };
 
-void read_index(st_index& index, std::string filename) {
+void read_index(st_index& index, References& references, const std::string& filename) {
     std::ifstream ifs(filename, std::ios::binary);
     //read filter_cutoff
     ifs.read(reinterpret_cast<char*>(&index.filter_cutoff), sizeof(index.filter_cutoff));
 
     //read ref_seqs:
-    index.ref_seqs.clear();
+    references.sequences.clear();
     uint64_t sz = 0;
     ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
-    index.ref_seqs.reserve(sz);
+    references.sequences.reserve(sz);
     uint32_t sz2 = 0;
-    auto& refseqs = index.ref_seqs;
+    auto& refseqs = references.sequences;
     for (uint64_t i = 0; i < sz; ++i) {
         ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));
         std::unique_ptr<char> buf_ptr(new char[sz2]);//The vector is short with large strings, so allocating this way should be ok.
@@ -259,16 +259,16 @@ void read_index(st_index& index, std::string filename) {
 
     //read ref_lengths
     ////////////////
-    index.ref_lengths.clear();
+    references.lengths.clear();
     ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
-    index.ref_lengths.resize(sz); //annoyingly, this initializes the memory to zero (which is a waste of performance), but ignore that for now
-    ifs.read(reinterpret_cast<char*>(&index.ref_lengths[0]), sz*sizeof(index.ref_lengths[0]));
+    references.lengths.resize(sz); //annoyingly, this initializes the memory to zero (which is a waste of performance), but ignore that for now
+    ifs.read(reinterpret_cast<char*>(&references.lengths[0]), sz*sizeof(references.lengths[0]));
 
     //read acc_map:
-    index.acc_map.clear();
+    references.names.clear();
     ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
-    index.acc_map.reserve(sz);
-    auto& acc_map = index.acc_map;
+    references.names.reserve(sz);
+    auto& acc_map = references.names;
 
     for (int i = 0; i < sz; ++i) {
         ifs.read(reinterpret_cast<char*>(&sz2), sizeof(sz2));

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -27,7 +27,7 @@ typedef std::vector< std::tuple<uint64_t, uint32_t, int32_t >> ind_mers_vector; 
 //typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int>> mers_vector_reduced;
 typedef robin_hood::unordered_map< uint64_t, std::tuple<unsigned int, unsigned int >> kmer_lookup;
 typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool>> mers_vector_read;
-typedef std::vector<std::string> idx_to_acc;
+
 
 struct st_index {
     st_index() : filter_cutoff(0) {}

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -26,7 +26,7 @@ typedef std::vector< std::tuple<uint64_t, uint32_t, int32_t >> ind_mers_vector; 
 //typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int>> mers_vector_reduced;
 typedef robin_hood::unordered_map< uint64_t, std::tuple<unsigned int, unsigned int >> kmer_lookup;
 typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool>> mers_vector_read;
-typedef std::vector<std::string > idx_to_acc;
+typedef std::vector<std::string> idx_to_acc;
 
 struct st_index {
     st_index() : filter_cutoff(0) {}

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -17,7 +17,7 @@
 #include "robin_hood.h"
 #include "xxhash.h"
 #include "exceptions.hpp"
-#include "fasta.hpp"
+#include "refs.hpp"
 
 uint64_t hash(std::string kmer);
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -17,6 +17,7 @@
 #include "robin_hood.h"
 #include "xxhash.h"
 #include "exceptions.hpp"
+#include "fasta.hpp"
 
 uint64_t hash(std::string kmer);
 
@@ -32,9 +33,6 @@ struct st_index {
     st_index() : filter_cutoff(0) {}
     unsigned int filter_cutoff; //This also exists in mapping_params, but is calculated during index generation, 
                                 //therefore stored here since it needs to be saved with the index.
-    std::vector<std::string> ref_seqs;
-    std::vector<unsigned int> ref_lengths;
-    idx_to_acc acc_map;
     mers_vector flat_vector;
     kmer_lookup mers_index;
 };
@@ -45,8 +43,8 @@ void seq_to_randstrobes2(ind_mers_vector& flat_vector, int n, int k, int w_min, 
 mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int s, int t, uint64_t q, int max_dist);
 //mers_vector seq_to_randstrobes3(int n, int k, int w_min, int w_max, std::string &seq, unsigned int ref_index, int w);
 
-void write_index(const st_index& index, std::string filename);
-void read_index(st_index& index, std::string filename);
+void write_index(const st_index& index, const References& references, const std::string& filename);
+void read_index(st_index& index, References& references, const std::string& filename);
 
 uint64_t count_unique_elements(const hash_vector& h_vector);
 unsigned int index_vector(const hash_vector& h_vector, kmer_lookup &mers_index, float f);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@
 #include "kseq++.hpp"
 #include "robin_hood.h"
 #include "ssw_cpp.h"
-#include "fasta.hpp"
+#include "refs.hpp"
 #include "exceptions.hpp"
 #include "cmdline.hpp"
 #include "index.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -464,7 +464,7 @@ int main (int argc, char **argv)
             int input_chunk_size = 100000;
             // Create Buffers
             InputBuffer input_buffer(ks, ks, input_chunk_size);
-            OutputBuffer output_buffer = { {}, {}, {}, 0, out };
+            OutputBuffer output_buffer(out);
 
             std::vector<std::thread> workers;
             for (int i = 0; i < opt.n_threads; ++i) {
@@ -494,7 +494,7 @@ int main (int argc, char **argv)
             int input_chunk_size = 100000;
             // Create Buffers
             InputBuffer input_buffer(ks1, ks2, input_chunk_size);
-            OutputBuffer output_buffer = { {}, {}, {}, 0, out };
+            OutputBuffer output_buffer(out);
 
             std::vector<std::thread> workers;
             for (int i = 0; i < opt.n_threads; ++i) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,9 +214,7 @@ std::pair<mers_vector, kmer_lookup>  create_index(mapping_params& map_param, std
     int approx_vec_size = total_ref_seq_size / (map_param.k-map_param.s+1);
     logger.debug() << "ref vector approximate size: " << approx_vec_size << std::endl;
     ind_flat_vector.reserve(approx_vec_size);
-    for(size_t i = 0; i < ref_seqs.size(); ++i)
-    {
-//        std::cerr << i << " " << i_mod << std::endl;
+    for(size_t i = 0; i < ref_seqs.size(); ++i) {
         seq_to_randstrobes2(ind_flat_vector, map_param.n, map_param.k, map_param.w_min, map_param.w_max, ref_seqs[i], i, map_param.s, map_param.t_syncmer, map_param.q, map_param.max_dist);
     }
     logger.debug() << "Ref vector actual size: " << ind_flat_vector.size() << std::endl;
@@ -289,13 +287,10 @@ std::pair<mers_vector, kmer_lookup>  create_index(mapping_params& map_param, std
 /*
  * Return formatted SAM header as a string
  */
-std::string sam_header(idx_to_acc& acc_map, const std::vector<unsigned int>& ref_lengths) {
+std::string sam_header(References& references) {
     std::stringstream out;
-    int nr_ref = acc_map.size();
-    for (int i = 0; i < nr_ref; ++i) {
-//        for (auto &it : acc_map) {
-//            out << "@SQ\tSN:" << it.second << "\tLN:" << ref_lengths[it.first] << "\n";
-        out << "@SQ\tSN:" << acc_map[i] << "\tLN:" << ref_lengths[i] << "\n";
+    for (auto i = 0; i < references.size(); ++i) {
+        out << "@SQ\tSN:" << references.names[i] << "\tLN:" << references.lengths[i] << "\n";
     }
     out << "@PG\tID:strobealign\tPN:strobealign\tVN:" VERSION_STRING "\tCL:strobealign\n";
     return out.str();
@@ -368,29 +363,29 @@ int main (int argc, char **argv)
     //////////// CREATE INDEX OF REF SEQUENCES /////////////////
 
     st_index index;
-
+    References references;
     if (opt.ref_filename.substr(opt.ref_filename.length() - 4) != ".sti") { //assume it is a fasta file if not named ".sti"
         //Generate index from FASTA
     
         // Record index creation start time
         auto start = high_resolution_clock::now();
         auto start_read_refs = start;
-        uint64_t total_ref_seq_size;
         try {
-            total_ref_seq_size = read_references(index.ref_seqs, index.ref_lengths, index.acc_map, opt.ref_filename);
+            references = References::from_fasta(opt.ref_filename);
         } catch (const InvalidFasta& e) {
             logger.error() << "strobealign: " << e.what() << std::endl;
             return EXIT_FAILURE;
         }
+
         std::chrono::duration<double> elapsed_read_refs = high_resolution_clock::now() - start_read_refs;
         logger.info() << "Time reading references: " << elapsed_read_refs.count() << " s" << std::endl;
 
-        if (total_ref_seq_size == 0) {
-            logger.error() << "No reference sequences found, aborting.." << std::endl;
+        if (references.total_length() == 0) {
+            logger.error() << "No reference sequences found, aborting" << std::endl;
             return EXIT_FAILURE;
         }
 
-        std::tie(index.flat_vector, index.mers_index) = create_index(map_param, index.ref_seqs, total_ref_seq_size);
+        std::tie(index.flat_vector, index.mers_index) = create_index(map_param, references.sequences, references.total_length());
         index.filter_cutoff = map_param.filter_cutoff;
 
         // Record index creation end time
@@ -405,7 +400,7 @@ int main (int argc, char **argv)
         // If the program was called with the -i flag, write the index to file
         if (opt.only_gen_index) { // If the program was called with the -i flag, we do not do the alignment
             auto start_write_index = high_resolution_clock::now();
-            write_index(index, opt.index_out_filename);
+            write_index(index, references, opt.index_out_filename);
             std::chrono::duration<double> elapsed_write_index = high_resolution_clock::now() - start_write_index;
             logger.info() << "Total time writing index: " << elapsed_write_index.count() << " s\n" << std::endl;
         }
@@ -413,7 +408,7 @@ int main (int argc, char **argv)
     else {
         //load index from file
         auto start_read_index = high_resolution_clock::now();
-        read_index(index, opt.ref_filename);
+        read_index(index, references, opt.ref_filename);
         std::chrono::duration<double> elapsed_read_index = high_resolution_clock::now() - start_read_index;
         logger.info() << "Total time reading index: " << elapsed_read_index.count() << " s\n" << std::endl;
 
@@ -452,7 +447,7 @@ int main (int argc, char **argv)
         //    std::stringstream paf_output;
 
         if (map_param.is_sam_out) {
-            out << sam_header(index.acc_map, index.ref_lengths);
+            out << sam_header(references);
         }
 
         std::unordered_map<std::thread::id, logging_variables> log_stats_vec(opt.n_threads);
@@ -475,8 +470,8 @@ int main (int argc, char **argv)
             for (int i = 0; i < opt.n_threads; ++i) {
                 std::thread consumer(perform_task_SE, std::ref(input_buffer), std::ref(output_buffer),
                     std::ref(log_stats_vec), std::ref(aln_params),
-                    std::ref(map_param), std::ref(index.ref_lengths), std::ref(index.ref_seqs),
-                    std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(index.acc_map));
+                    std::ref(map_param), std::ref(references.lengths), std::ref(references.sequences),
+                    std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(references.names));
                 workers.push_back(std::move(consumer));
             }
 
@@ -505,8 +500,8 @@ int main (int argc, char **argv)
             for (int i = 0; i < opt.n_threads; ++i) {
                 std::thread consumer(perform_task_PE, std::ref(input_buffer), std::ref(output_buffer),
                     std::ref(log_stats_vec), std::ref(isize_est_vec), std::ref(aln_params),
-                    std::ref(map_param), std::ref(index.ref_lengths), std::ref(index.ref_seqs),
-                    std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(index.acc_map));
+                    std::ref(map_param), std::ref(references.lengths), std::ref(references.sequences),
+                    std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(references.names));
                 workers.push_back(std::move(consumer));
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -463,7 +463,7 @@ int main (int argc, char **argv)
 
             int input_chunk_size = 100000;
             // Create Buffers
-            InputBuffer input_buffer = { {}, {}, {}, {}, {}, ks, ks, false, 0, input_chunk_size };
+            InputBuffer input_buffer(ks, ks, input_chunk_size);
             OutputBuffer output_buffer = { {}, {}, {}, 0, out };
 
             std::vector<std::thread> workers;
@@ -493,7 +493,7 @@ int main (int argc, char **argv)
 
             int input_chunk_size = 100000;
             // Create Buffers
-            InputBuffer input_buffer = { {}, {}, {}, {}, {}, ks1, ks2, false, 0, input_chunk_size };
+            InputBuffer input_buffer(ks1, ks2, input_chunk_size);
             OutputBuffer output_buffer = { {}, {}, {}, 0, out };
 
             std::vector<std::thread> workers;

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -72,7 +72,7 @@ void OutputBuffer::output_records(std::string &sam_alignments) {
 inline bool align_reads_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,  std::vector<KSeq> &records1,  std::vector<KSeq> &records2,
                          logging_variables &log_vars, i_dist_est &isize_est, alignment_params &aln_params,
                         mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs,
-                        kmer_lookup &mers_index, mers_vector &flat_vector, idx_to_acc &acc_map ) {
+                        kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ) {
 
     // If no more reads to align
     if (records1.empty() && input_buffer.finished_reading){
@@ -101,7 +101,7 @@ inline bool align_reads_PE(InputBuffer &input_buffer, OutputBuffer &output_buffe
 void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                   std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec, alignment_params &aln_params,
                   mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs,
-                  kmer_lookup &mers_index, mers_vector &flat_vector, idx_to_acc &acc_map ){
+                  kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ){
     bool eof = false;
     while (true){
         std::vector<KSeq> records1;
@@ -127,7 +127,7 @@ void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
 inline bool align_reads_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,  std::vector<KSeq> &records,
                            logging_variables &log_vars, alignment_params &aln_params,
                            mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs,
-                           kmer_lookup &mers_index, mers_vector &flat_vector, idx_to_acc &acc_map ) {
+                           kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ) {
 
     // If no more reads to align
     if (records.empty() && input_buffer.finished_reading){
@@ -154,7 +154,7 @@ inline bool align_reads_SE(InputBuffer &input_buffer, OutputBuffer &output_buffe
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                      std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, alignment_params &aln_params,
                      mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs,
-                     kmer_lookup &mers_index, mers_vector &flat_vector, idx_to_acc &acc_map ){
+                     kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ){
     bool eof = false;
     while (true){
         std::vector<KSeq> records1;

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -1,7 +1,6 @@
 #ifndef pc_hpp
 #define pc_hpp
 
-// The declarations in the pc.hpp file
 #include <thread>
 #include <condition_variable>
 #include <mutex>
@@ -12,19 +11,18 @@
 #include <vector>
 #include <sstream>
 #include <unordered_map>
+#include <zlib.h>
 
 #include "robin_hood.h"
-#include <zlib.h>
 #include "kseq++.hpp"
-using namespace klibpp;
 #include "ssw_cpp.h"
 #include "index.hpp"
 #include "aln.hpp"
+#include "refs.hpp"
 
+using namespace klibpp;
 
 class InputBuffer {
-    // InputBuffer fields
-
 
 public:
     // Fields for concurrency input
@@ -42,16 +40,12 @@ public:
 
     void read_records_PE(std::vector<KSeq> &records1, std::vector<KSeq> &records2, logging_variables &log_vars);
     void read_records_SE(std::vector<KSeq> &records1, logging_variables &log_vars);
-
 };
 
 
 class OutputBuffer {
-    // OutputBuffer fields
-
 
 public:
-
     // Fields for concurrency input
     std::mutex mtx;
     std::condition_variable not_empty;
@@ -61,16 +55,15 @@ public:
     std::ostream &out;
 
     void output_records(std::string &sam_alignments);
-
 };
 
 
 
 void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                   std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec, alignment_params &aln_params,
-                  mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, idx_to_acc &acc_map );
+                  mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map );
 
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                      std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, alignment_params &aln_params,
-                     mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, idx_to_acc &acc_map );
+                     mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map );
 #endif // pc_hpp_

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -25,6 +25,11 @@ using namespace klibpp;
 class InputBuffer {
 
 public:
+    typedef klibpp::KStream<gzFile_s*, int (*)(gzFile_s*, void*, unsigned int), klibpp::mode::In_> input_stream_t;
+
+    InputBuffer(input_stream_t& ks1, input_stream_t& ks2, int chunk_size)
+    : ks1(ks1), ks2(ks2), X(chunk_size) { }
+
     // Fields for concurrency input
     std::mutex mtx;
     std::condition_variable not_empty;
@@ -32,8 +37,8 @@ public:
 
     std::queue<std::vector<KSeq>> q1;
     std::queue<std::vector<KSeq>> q2;
-    klibpp::KStream<gzFile_s*, int (*)(gzFile_s*, void*, unsigned int), klibpp::mode::In_> &ks1;
-    klibpp::KStream<gzFile_s*, int (*)(gzFile_s*, void*, unsigned int), klibpp::mode::In_> &ks2;
+    input_stream_t &ks1;
+    input_stream_t &ks2;
     bool finished_reading = false;
     int buffer_size = 0;
     int X = 100000; // input read chunk size

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -51,7 +51,8 @@ public:
 class OutputBuffer {
 
 public:
-    // Fields for concurrency input
+    OutputBuffer(std::ostream& out) : out(out) { }
+
     std::mutex mtx;
     std::condition_variable not_empty;
     std::condition_variable not_full;

--- a/src/refs.cpp
+++ b/src/refs.cpp
@@ -1,7 +1,7 @@
+#include "refs.hpp"
 #include <vector>
 #include <fstream>
 #include <sstream>
-#include "fasta.hpp"
 #include "exceptions.hpp"
 
 References References::from_fasta(std::string filename) {

--- a/src/refs.cpp
+++ b/src/refs.cpp
@@ -6,8 +6,8 @@
 
 References References::from_fasta(std::string filename) {
     std::vector<std::string> sequences;
-    std::vector<std::string> names;
-    std::vector<unsigned int> lengths;
+    ref_names names;
+    ref_lengths lengths;
 
     std::ifstream file(filename);
     std::string line, seq;

--- a/src/refs.hpp
+++ b/src/refs.hpp
@@ -7,14 +7,16 @@
 #include <numeric>
 #include <vector>
 
+typedef std::vector<unsigned int> ref_lengths;
+typedef std::vector<std::string> ref_names;
 
 class References {
 public:
     References() { }
     References(
         std::vector<std::string>&& sequences,
-        std::vector<std::string>&& names,
-        std::vector<unsigned int>&& lengths
+        ref_names&& names,
+        ref_lengths&& lengths
     ) : sequences(std::move(sequences)), names(std::move(names)), lengths(std::move(lengths)) {
 
         _total_length = std::accumulate(this->lengths.begin(), this->lengths.end(), (size_t)0);
@@ -34,8 +36,8 @@ public:
     }
 
     std::vector<std::string> sequences;
-    std::vector<std::string> names;
-    std::vector<unsigned int> lengths;
+    ref_names names;
+    ref_lengths lengths;
 private:
     size_t _total_length;
 };

--- a/src/refs.hpp
+++ b/src/refs.hpp
@@ -5,8 +5,7 @@
 #include <string>
 #include <stdexcept>
 #include <numeric>
-
-#include <iostream>
+#include <vector>
 
 
 class References {

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -1,6 +1,6 @@
-#include <ostream>
 #include "sam.hpp"
-
+#include <algorithm>
+#include <ostream>
 
 /*
  * SAM columns
@@ -55,7 +55,7 @@ void Sam::add(
     sam_string.append("\t");
     sam_string.append(std::to_string(flags));  // FLAG
     sam_string.append("\t");
-    sam_string.append(acc_map[sam_aln.ref_id]);  // RNAME
+    sam_string.append(reference_names[sam_aln.ref_id]);  // RNAME
     sam_string.append("\t");
     sam_string.append(std::to_string(sam_aln.ref_start));  // POS
     sam_string.append("\t");
@@ -220,8 +220,8 @@ void Sam::add_pair(
         mate_name1 = "=";
         mate_name2 = "=";
     } else{
-        mate_name1 = acc_map[sam_aln1.ref_id];
-        mate_name2 = acc_map[sam_aln2.ref_id];
+        mate_name1 = reference_names[sam_aln1.ref_id];
+        mate_name2 = reference_names[sam_aln2.ref_id];
     }
 
 //    if ( (sam_aln1.is_unaligned) && (sam_aln2.is_unaligned) ){
@@ -244,8 +244,8 @@ void Sam::add_pair(
 //        f1 |= MUNMAP;
 //        f1 -= 32;
 //    }
-    std::string ref1 = acc_map[sam_aln1.ref_id];
-    std::string ref2 = acc_map[sam_aln2.ref_id];
+    std::string ref1 = reference_names[sam_aln1.ref_id];
+    std::string ref2 = reference_names[sam_aln2.ref_id];
     int ed1 = sam_aln1.ed;
     int ed2 = sam_aln2.ed;
 

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -1,5 +1,6 @@
 #include <ostream>
-#include "aln.hpp"
+#include "sam.hpp"
+
 
 /*
  * SAM columns

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 #include "kseq++.hpp"
-#include "index.hpp"
+#include "refs.hpp"
 
 using namespace klibpp;
 
@@ -41,7 +41,9 @@ enum SamFlags {
 class Sam {
 
 public:
-    Sam(std::string& sam_string, idx_to_acc& acc_map) : sam_string(sam_string), acc_map(acc_map) { }
+    Sam(std::string& sam_string, const ref_names& reference_names)
+        : sam_string(sam_string)
+        , reference_names(reference_names) { }
 
     /* Add an alignment */
     void add(const alignment& sam_aln, const KSeq& record, const std::string& sequence_rc, bool is_secondary = false);
@@ -53,7 +55,7 @@ public:
 
 private:
     std::string& sam_string;
-    const idx_to_acc& acc_map;
+    const ref_names& reference_names;
 };
 
 

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -2,8 +2,11 @@
 #define SAM_HPP
 
 #include <string>
-
+#include "kseq++.hpp"
 #include "index.hpp"
+
+using namespace klibpp;
+
 
 struct alignment {
     std::string cigar;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -16,3 +16,12 @@ TEST_CASE("read_references") {
     CHECK(reference_names[0] == "NC_001422.1");
     CHECK(lengths[0] == 5386);
 }
+
+TEST_CASE("References") {
+    auto references = References::from_fasta("tests/phix.fasta");
+    CHECK(references.names.size() == 1);
+    CHECK(references.lengths.size() == 1);
+    CHECK(references.sequences.size() == 1);
+    CHECK(references.names[0] == "NC_001422.1");
+    CHECK(references.lengths[0] == 5386);
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,7 +1,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-#include "fasta.hpp"
+#include "refs.hpp"
 
 TEST_CASE("References::from_fasta") {
     auto references = References::from_fasta("tests/phix.fasta");

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -3,25 +3,12 @@
 
 #include "fasta.hpp"
 
-TEST_CASE("read_references") {
-    std::vector<std::string> seqs;
-    std::vector<unsigned int> lengths;
-    idx_to_acc reference_names;
-    uint64_t n = read_references(seqs, lengths, reference_names, "tests/phix.fasta");
-
-    CHECK(n == 5386);
-    CHECK(reference_names.size() == 1);
-    CHECK(lengths.size() == 1);
-    CHECK(seqs.size() == 1);
-    CHECK(reference_names[0] == "NC_001422.1");
-    CHECK(lengths[0] == 5386);
-}
-
-TEST_CASE("References") {
+TEST_CASE("References::from_fasta") {
     auto references = References::from_fasta("tests/phix.fasta");
     CHECK(references.names.size() == 1);
     CHECK(references.lengths.size() == 1);
     CHECK(references.sequences.size() == 1);
     CHECK(references.names[0] == "NC_001422.1");
     CHECK(references.lengths[0] == 5386);
+    CHECK(references.total_length() == 5386);
 }


### PR DESCRIPTION
A `References` instance stores the sequences read from a FASTA file. It has fields for the sequences, their names and their lengths. Instead of separately passing sequnce names and lengths to functions, this allows us to pass a single `references` object.

* `read_references` is now the static method `References::from_fasta` that returns a `References` instance.
* Moved sequences, names and lengths out of `st_index`. Instead, the `write_index`/`read_index` functions get a `References` object as additional parameter.
* Get rid of `total_ref_seq_size`. Instead, total reference size is computed within the `References` constructor and can be retrieved with the `total_length()` method.