### PR TITLE
Refactor mapq computation

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1810,13 +1810,12 @@ static inline int get_MAPQ(const std::vector<nam> &all_nams, const nam &n_max) {
     if (all_nams.size() <= 1) {
         return 60;
     }
-    // MAPQ = 40(1−s2/s1) ·min{1,|M|/10} · log s1
-
     nam n_second = all_nams[1];
     float s2 = n_second.score;
-    float min_matches;
-    min_matches  = (float)n_max.n_hits/10 > 1 ? (float)n_max.n_hits/10 : 1;
-    return 40*(1 - s2/s1)*min_matches*log(s1) < 60 ? 40*(1 - s2/s1)*min_matches*log(s1) : 60 ;
+    // MAPQ = 40(1−s2/s1) ·min{1,|M|/10} · log s1
+    float min_matches = std::max(n_max.n_hits / 10.0, 1.0);
+    int uncapped_mapq = 40 * (1 - s2 / s1) * min_matches * log(s1);
+    return std::min(uncapped_mapq, 60);
 }
 
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1805,9 +1805,9 @@ static inline void get_alignment(alignment_params &aln_params, nam &n, const std
 }
 
 
-static inline void get_MAPQ(std::vector<nam> &all_nams, nam &n_max, int &mapq){
+static inline int get_MAPQ(const std::vector<nam> &all_nams, const nam &n_max) {
     float s1 = n_max.score;
-    mapq = 60; // MAPQ = 40(1−s2/s1) ·min{1,|M|/10} · log s1
+    int mapq = 60; // MAPQ = 40(1−s2/s1) ·min{1,|M|/10} · log s1
     if (all_nams.size() > 1) {
         nam n_second = all_nams[1];
         float s2 = n_second.score;
@@ -1815,6 +1815,7 @@ static inline void get_MAPQ(std::vector<nam> &all_nams, nam &n_max, int &mapq){
         min_matches  = (float)n_max.n_hits/10 > 1 ? (float)n_max.n_hits/10 : 1;
         mapq = 40*(1 - s2/s1)*min_matches*log(s1) < 60 ? 40*(1 - s2/s1)*min_matches*log(s1) : 60 ;
     }
+    return mapq;
 }
 
 
@@ -2259,8 +2260,8 @@ inline void align_PE(alignment_params &aln_params, Sam &sam, std::vector<nam> &a
             get_alignment(aln_params, n_max2, ref_len_map, ref_seqs, read2, read2_rc, sam_aln2, k, rc_already_comp2, log_vars.did_not_fit, log_vars.tot_ksw_aligned);
             log_vars.tot_all_tried ++;
 //            std::cerr<< "6" << std::endl;
-            get_MAPQ(all_nams1, n_max1, mapq1);
-            get_MAPQ(all_nams2, n_max2, mapq2);
+            mapq1 = get_MAPQ(all_nams1, n_max1);
+            mapq2 = get_MAPQ(all_nams2, n_max2);
 //            std::cerr<< "7" << std::endl;
             sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1_rc, read2_rc, mapq1, mapq2, mu, sigma, true);
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1807,15 +1807,16 @@ static inline void get_alignment(alignment_params &aln_params, nam &n, const std
 
 static inline int get_MAPQ(const std::vector<nam> &all_nams, const nam &n_max) {
     float s1 = n_max.score;
-    int mapq = 60; // MAPQ = 40(1−s2/s1) ·min{1,|M|/10} · log s1
-    if (all_nams.size() > 1) {
-        nam n_second = all_nams[1];
-        float s2 = n_second.score;
-        float min_matches;
-        min_matches  = (float)n_max.n_hits/10 > 1 ? (float)n_max.n_hits/10 : 1;
-        mapq = 40*(1 - s2/s1)*min_matches*log(s1) < 60 ? 40*(1 - s2/s1)*min_matches*log(s1) : 60 ;
+    if (all_nams.size() <= 1) {
+        return 60;
     }
-    return mapq;
+    // MAPQ = 40(1−s2/s1) ·min{1,|M|/10} · log s1
+
+    nam n_second = all_nams[1];
+    float s2 = n_second.score;
+    float min_matches;
+    min_matches  = (float)n_max.n_hits/10 > 1 ? (float)n_max.n_hits/10 : 1;
+    return 40*(1 - s2/s1)*min_matches*log(s1) < 60 ? 40*(1 - s2/s1)*min_matches*log(s1) : 60 ;
 }
 
 


### PR DESCRIPTION
As part of the discussion in PR #79, I tried to understand what `get_MAPQ' does. This refactors that function so I can better understand it.

There’s this line:
```
min_matches  = (float)n_max.n_hits/10 > 1 ? (float)n_max.n_hits/10 : 1;
```
It uses the ternary operator to compute a maximum, which is why I replaced this with `std::max` in this PR. However, the given formula uses `min`, an the variable name also hints that a minimum is wanted. Our tests don’t cover this, so I don’t know what is actually correct.