### PR TITLE
Ensure no tab characters are present in sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for tab characters
+        run: "! grep -P -R '\\t' src/ tests/*.cpp"
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -138,7 +138,7 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     //If not generating index, fastq1 is mandatory:
     if (opt.reads_filename1.empty() && !opt.only_gen_index) {
         std::cerr << "Reads file (fastq) must be specified." << std::endl;
-//		exit(1);
+        // exit(1);
     }
 
     return std::make_pair(opt, map_param);


### PR DESCRIPTION
... and fix one occurrence. This adds a simple linting job to the Actions workflow, which should help us avoid usage of mixed tabs and spaces for indentation.
