### PR TITLE
Pass "References" objects when appropriate

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -637,7 +637,7 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
 }
 
 
-inline void output_hits_paf_PE(std::string &paf_output, const nam &n, const std::string &query_name, const ref_names &reference_names, int k, int read_len, const ref_lengths &ref_len_map) {
+inline void output_hits_paf_PE(std::string &paf_output, const nam &n, const std::string &query_name, const References& references, int k, int read_len) {
     if (n.ref_s < 0 ) {
         return;
     }
@@ -651,9 +651,9 @@ inline void output_hits_paf_PE(std::string &paf_output, const nam &n, const std:
     paf_output.append("\t");
     paf_output.append(n.is_rc ? "-" : "+");
     paf_output.append("\t");
-    paf_output.append(reference_names[n.ref_id]);
+    paf_output.append(references.names[n.ref_id]);
     paf_output.append("\t");
-    paf_output.append(std::to_string(ref_len_map[n.ref_id]));
+    paf_output.append(std::to_string(references.lengths[n.ref_id]));
     paf_output.append("\t");
     paf_output.append(std::to_string(n.ref_s));
     paf_output.append("\t");
@@ -666,14 +666,14 @@ inline void output_hits_paf_PE(std::string &paf_output, const nam &n, const std:
 }
 
 
-inline void output_hits_paf(std::string &paf_output, const std::vector<nam> &all_nams, const std::string& query_name, const ref_names &reference_names, int k, int read_len, const ref_lengths &ref_len_map) {
+inline void output_hits_paf(std::string &paf_output, const std::vector<nam> &all_nams, const std::string& query_name, const References& references, int k, int read_len) {
     // Output results
     if (all_nams.size() == 0) {
         return;
     }
     // Only output single best hit based on: number of randstrobe-matches times span of the merged match.
     nam n = all_nams[0];
-    output_hits_paf_PE(paf_output, n, query_name, reference_names, k, read_len, ref_len_map);
+    output_hits_paf_PE(paf_output, n, query_name, references, k, read_len);
 }
 
 
@@ -2854,13 +2854,13 @@ void align_PE_read(KSeq &record1, KSeq &record2, std::string &outstring, logging
                               nam_read1,
                               nam_read2);
         output_hits_paf_PE(outstring, nam_read1, record1.name,
-                           references.names,
+                           references,
                            map_param.k,
-                           record1.seq.length(), references.lengths);
+                           record1.seq.length());
         output_hits_paf_PE(outstring, nam_read2, record2.name,
-                           references.names,
+                           references,
                            map_param.k,
-                           record2.seq.length(), references.lengths);
+                           record2.seq.length());
         joint_NAM_scores.clear();
     } else {
         Sam sam(outstring, references.names);
@@ -2930,8 +2930,8 @@ void align_SE_read(KSeq &record, std::string &outstring, logging_variables &log_
 
         auto extend_start = std::chrono::high_resolution_clock::now();
         if (!map_param.is_sam_out) {
-            output_hits_paf(outstring, nams, record.name, references.names, map_param.k,
-                            record.seq.length(), references.lengths);
+            output_hits_paf(outstring, nams, record.name, references, map_param.k,
+                            record.seq.length());
         } else {
             Sam sam(outstring, references.names);
             if (map_param.max_secondary > 0){

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -2863,7 +2863,7 @@ void align_PE_read(KSeq &record1, KSeq &record2, std::string &outstring, logging
                            record2.seq.length());
         joint_NAM_scores.clear();
     } else {
-        Sam sam(outstring, references.names);
+        Sam sam(outstring, references);
         align_PE(aln_params, sam, nams1, nams2, record1,
                  record2,
                  map_param.k,
@@ -2933,7 +2933,7 @@ void align_SE_read(KSeq &record, std::string &outstring, logging_variables &log_
             output_hits_paf(outstring, nams, record.name, references, map_param.k,
                             record.seq.length());
         } else {
-            Sam sam(outstring, references.names);
+            Sam sam(outstring, references);
             if (map_param.max_secondary > 0){
                 // I created an entire new function here, duplicating a lot of the code as outputting secondary hits is has some overhead to the
                 // original align_SE function (storing a vector of hits and sorting them)

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -820,7 +820,7 @@ static inline bool sort_highest_sw_scores_single(const std::tuple<int, alignment
 }
 
 
-inline void align_SE(const alignment_params &aln_params, Sam& sam, std::vector<nam> &all_nams, const KSeq& record, int k, const std::vector<unsigned int> &ref_len_map, const std::vector<std::string> &ref_seqs, logging_variables &log_vars, float dropoff, int max_tries) {
+inline void align_SE(const alignment_params &aln_params, Sam& sam, std::vector<nam> &all_nams, const KSeq& record, int k, const References& references, logging_variables &log_vars, float dropoff, int max_tries) {
     auto query_acc = record.name;
     auto read = record.seq;
     auto qual = record.qual;
@@ -891,8 +891,8 @@ inline void align_SE(const alignment_params &aln_params, Sam& sam, std::vector<n
         std::string read_end_kmer;
         std::string read_rc_start_kmer;
         std::string read_rc_end_kmer;
-        ref_start_kmer = ref_seqs[n.ref_id].substr(n.ref_s, k);
-        ref_end_kmer = ref_seqs[n.ref_id].substr(n.ref_e-k, k);
+        ref_start_kmer = references.sequences[n.ref_id].substr(n.ref_s, k);
+        ref_end_kmer = references.sequences[n.ref_id].substr(n.ref_e-k, k);
 
         if (!n.is_rc) {
             read_start_kmer = read.substr(n.query_s, k);
@@ -962,10 +962,10 @@ inline void align_SE(const alignment_params &aln_params, Sam& sam, std::vector<n
         // deal with any read hanging of ends of reference not to get 'std::out_of_range' what(): basic_string::substr
         int ref_tmp_start = n.ref_s - n.query_s;
         int ref_tmp_segm_size = read_len + diff;
-        int ref_len = ref_len_map[n.ref_id];
+        int ref_len = references.lengths[n.ref_id];
         int ref_start = std::max(0, ref_tmp_start);
         int ref_segm_size = ref_tmp_segm_size < ref_len - ref_start ? ref_tmp_segm_size : ref_len - 1 - ref_start;
-        std::string ref_segm = ref_seqs[n.ref_id].substr(ref_start, ref_segm_size);
+        std::string ref_segm = references.sequences[n.ref_id].substr(ref_start, ref_segm_size);
 
         int soft_left = 50;
         int soft_right = 50;
@@ -1042,9 +1042,9 @@ inline void align_SE(const alignment_params &aln_params, Sam& sam, std::vector<n
             int a = n.ref_s - n.query_s - extra_ref_left;
             int ref_start = std::max(0, a);
             int b = n.ref_e + (read_len - n.query_e)+ extra_ref_right;
-            int ref_len = ref_len_map[n.ref_id];
+            int ref_len = references.lengths[n.ref_id];
             int ref_end = std::min(ref_len, b);
-            ref_segm = ref_seqs[n.ref_id].substr(ref_start, ref_end - ref_start);
+            ref_segm = references.sequences[n.ref_id].substr(ref_start, ref_end - ref_start);
 //            ksw_extz_t ez;
 //            const char *ref_ptr = ref_segm.c_str();
 //            const char *read_ptr = r_tmp.c_str();
@@ -1085,7 +1085,7 @@ inline void align_SE(const alignment_params &aln_params, Sam& sam, std::vector<n
 }
 
 
-static inline void align_SE_secondary_hits(alignment_params &aln_params, Sam& sam, std::vector<nam> &all_nams, const KSeq& record, int k, std::vector<unsigned int> &ref_len_map, std::vector<std::string> &ref_seqs, logging_variables &log_vars, float dropoff, int max_tries, int max_secondary ) {
+static inline void align_SE_secondary_hits(alignment_params &aln_params, Sam& sam, std::vector<nam> &all_nams, const KSeq& record, int k, const References& references, logging_variables &log_vars, float dropoff, int max_tries, int max_secondary ) {
 
     auto query_acc = record.name;
     auto read = record.seq;
@@ -1139,8 +1139,8 @@ static inline void align_SE_secondary_hits(alignment_params &aln_params, Sam& sa
         std::string read_end_kmer;
         std::string read_rc_start_kmer;
         std::string read_rc_end_kmer;
-        ref_start_kmer = ref_seqs[n.ref_id].substr(n.ref_s, k);
-        ref_end_kmer = ref_seqs[n.ref_id].substr(n.ref_e-k, k);
+        ref_start_kmer = references.sequences[n.ref_id].substr(n.ref_s, k);
+        ref_end_kmer = references.sequences[n.ref_id].substr(n.ref_e-k, k);
 
         if (!n.is_rc) {
             read_start_kmer = read.substr(n.query_s, k);
@@ -1210,11 +1210,11 @@ static inline void align_SE_secondary_hits(alignment_params &aln_params, Sam& sa
         // deal with any read hanging of ends of reference not to get 'std::out_of_range' what(): basic_string::substr
         int ref_tmp_start = n.ref_s - n.query_s;
         int ref_tmp_segm_size = read_len + diff;
-        int ref_len = ref_len_map[n.ref_id];
+        int ref_len = references.lengths[n.ref_id];
         int ref_start = std::max(ref_tmp_start, 0);
         int ref_segm_size = ref_tmp_segm_size < ref_len - ref_start ? ref_tmp_segm_size : ref_len - 1 - ref_start;
 
-        std::string ref_segm = ref_seqs[n.ref_id].substr(ref_start, ref_segm_size);
+        std::string ref_segm = references.sequences[n.ref_id].substr(ref_start, ref_segm_size);
 
 //        // decide if read should be fw or rc aligned to reference here by checking exact match of first and last strobe in the NAM
 //
@@ -1308,9 +1308,9 @@ static inline void align_SE_secondary_hits(alignment_params &aln_params, Sam& sa
             int a = n.ref_s - n.query_s - extra_ref_left;
             int ref_start = std::max(0, a);
             int b = n.ref_e + (read_len - n.query_e)+ extra_ref_right;
-            int ref_len = ref_len_map[n.ref_id];
+            int ref_len = references.lengths[n.ref_id];
             int ref_end = std::min(ref_len, b);
-            ref_segm = ref_seqs[n.ref_id].substr(ref_start, ref_end - ref_start);
+            ref_segm = references.sequences[n.ref_id].substr(ref_start, ref_end - ref_start);
 //            ksw_extz_t ez;
 //            const char *ref_ptr = ref_segm.c_str();
 //            const char *read_ptr = r_tmp.c_str();
@@ -2879,7 +2879,7 @@ void align_PE_read(KSeq &record1, KSeq &record2, std::string &outstring, logging
 
 
 void align_SE_read(KSeq &record, std::string &outstring, logging_variables &log_vars, alignment_params &aln_params,
-                   mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &reference_names ){
+                   mapping_params &map_param, const References& references, kmer_lookup &mers_index, mers_vector &flat_vector) {
 
         std::string seq, seq_rc;
         unsigned int q_id = 0;
@@ -2902,7 +2902,7 @@ void align_SE_read(KSeq &record, std::string &outstring, logging_variables &log_
 
         // Find NAMs
         auto nam_start = std::chrono::high_resolution_clock::now();
-        info = find_nams(nams, hits_per_ref, query_mers, flat_vector, mers_index, map_param.k, ref_seqs, record.seq, map_param.filter_cutoff);
+        info = find_nams(nams, hits_per_ref, query_mers, flat_vector, mers_index, map_param.k, references.sequences, record.seq, map_param.filter_cutoff);
         hits_per_ref.clear();
         auto nam_finish = std::chrono::high_resolution_clock::now();
         log_vars.tot_find_nams += nam_finish - nam_start;
@@ -2912,7 +2912,7 @@ void align_SE_read(KSeq &record, std::string &outstring, logging_variables &log_
             if ((nams.size() == 0) || (info.first < 0.7)) {
                 log_vars.tried_rescue += 1;
                 nams.clear();
-                find_nams_rescue(hits_fw, hits_rc, nams, hits_per_ref, query_mers, flat_vector, mers_index, map_param.k, ref_seqs,
+                find_nams_rescue(hits_fw, hits_rc, nams, hits_per_ref, query_mers, flat_vector, mers_index, map_param.k, references.sequences,
                                         record.seq, map_param.rescue_cutoff);
                 hits_per_ref.clear();
                 hits_fw.clear();
@@ -2930,20 +2930,20 @@ void align_SE_read(KSeq &record, std::string &outstring, logging_variables &log_
 
         auto extend_start = std::chrono::high_resolution_clock::now();
         if (!map_param.is_sam_out) {
-            output_hits_paf(outstring, nams, record.name, reference_names, map_param.k,
-                            record.seq.length(), ref_lengths);
+            output_hits_paf(outstring, nams, record.name, references.names, map_param.k,
+                            record.seq.length(), references.lengths);
         } else {
-            Sam sam(outstring, reference_names);
+            Sam sam(outstring, references.names);
             if (map_param.max_secondary > 0){
                 // I created an entire new function here, duplicating a lot of the code as outputting secondary hits is has some overhead to the
                 // original align_SE function (storing a vector of hits and sorting them)
                 // Such overhead is not present in align_PE - which implements both options in the same function.
 
                 align_SE_secondary_hits(aln_params, sam, nams, record, map_param.k,
-                         ref_lengths, ref_seqs, log_vars, map_param.dropoff_threshold, map_param.maxTries, map_param.max_secondary);
+                         references, log_vars, map_param.dropoff_threshold, map_param.maxTries, map_param.max_secondary);
             } else {
                 align_SE(aln_params, sam, nams, record, map_param.k,
-                         ref_lengths, ref_seqs, log_vars,  map_param.dropoff_threshold, map_param.maxTries);
+                         references, log_vars,  map_param.dropoff_threshold, map_param.maxTries);
             }
         }
         auto extend_finish = std::chrono::high_resolution_clock::now();

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -19,7 +19,7 @@ struct aln_info {
 
 void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, logging_variables& log_vars, i_dist_est& isize_est, alignment_params& aln_params, mapping_params& map_param, const References& references, kmer_lookup& mers_index, mers_vector& flat_vector);
 
-void align_SE_read(klibpp::KSeq& record, std::string& outstring, logging_variables& log_vars, alignment_params& aln_params, mapping_params& map_param, std::vector< unsigned int >& ref_lengths, std::vector< std::string >& ref_seqs, kmer_lookup& mers_index, mers_vector& flat_vector, ref_names& acc_map );
+void align_SE_read(klibpp::KSeq& record, std::string& outstring, logging_variables& log_vars, alignment_params& aln_params, mapping_params& map_param, const References& references, kmer_lookup& mers_index, mers_vector& flat_vector);
 
 
 #endif

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -17,8 +17,7 @@ struct aln_info {
 };
 
 
-void align_PE_read(klibpp::KSeq &record1, klibpp::KSeq &record2, std::string &sam_out, logging_variables &log_vars, i_dist_est &isize_est, alignment_params &aln_params,
-                          mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &reference_names);
+void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, logging_variables& log_vars, i_dist_est& isize_est, alignment_params& aln_params, mapping_params& map_param, const References& references, kmer_lookup& mers_index, mers_vector& flat_vector);
 
 void align_SE_read(klibpp::KSeq& record, std::string& outstring, logging_variables& log_vars, alignment_params& aln_params, mapping_params& map_param, std::vector< unsigned int >& ref_lengths, std::vector< std::string >& ref_seqs, kmer_lookup& mers_index, mers_vector& flat_vector, ref_names& acc_map );
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -20,8 +20,6 @@
 #include "randstrobes.hpp"
 
 
-uint64_t hash(const std::string& kmer);
-
 typedef std::vector< std::tuple<uint32_t, int32_t >> mers_vector;
 //typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int>> mers_vector_reduced;
 typedef robin_hood::unordered_map< uint64_t, std::tuple<unsigned int, unsigned int >> kmer_lookup;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -392,8 +392,8 @@ int main (int argc, char **argv)
             for (int i = 0; i < opt.n_threads; ++i) {
                 std::thread consumer(perform_task_SE, std::ref(input_buffer), std::ref(output_buffer),
                     std::ref(log_stats_vec), std::ref(aln_params),
-                    std::ref(map_param), std::ref(references.lengths), std::ref(references.sequences),
-                    std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(references.names));
+                    std::ref(map_param), std::ref(references),
+                    std::ref(index.mers_index), std::ref(index.flat_vector));
                 workers.push_back(std::move(consumer));
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -422,8 +422,8 @@ int main (int argc, char **argv)
             for (int i = 0; i < opt.n_threads; ++i) {
                 std::thread consumer(perform_task_PE, std::ref(input_buffer), std::ref(output_buffer),
                     std::ref(log_stats_vec), std::ref(isize_est_vec), std::ref(aln_params),
-                    std::ref(map_param), std::ref(references.lengths), std::ref(references.sequences),
-                    std::ref(index.mers_index), std::ref(index.flat_vector), std::ref(references.names));
+                    std::ref(map_param), std::ref(references),
+                    std::ref(index.mers_index), std::ref(index.flat_vector));
                 workers.push_back(std::move(consumer));
             }
 

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -71,8 +71,8 @@ void OutputBuffer::output_records(std::string &sam_alignments) {
 
 inline bool align_reads_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,  std::vector<KSeq> &records1,  std::vector<KSeq> &records2,
                          logging_variables &log_vars, i_dist_est &isize_est, alignment_params &aln_params,
-                        mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs,
-                        kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ) {
+                        mapping_params &map_param, const References& references,
+                        kmer_lookup &mers_index, mers_vector &flat_vector) {
 
     // If no more reads to align
     if (records1.empty() && input_buffer.finished_reading){
@@ -85,9 +85,8 @@ inline bool align_reads_PE(InputBuffer &input_buffer, OutputBuffer &output_buffe
         auto record1 = records1[i];
         auto record2 = records2[i];
 
-        align_PE_read(record1, record2, sam_out,  log_vars, isize_est, aln_params,
-                      map_param, ref_lengths, ref_seqs,
-                      mers_index, flat_vector, acc_map );
+        align_PE_read(record1, record2, sam_out, log_vars, isize_est, aln_params,
+                      map_param, references, mers_index, flat_vector);
     }
 //    std::cerr << isize_est_vec[thread_id].mu << " " << isize_est_vec[thread_id].sigma << "\n";
 //    std::cerr << log_stats_vec[thread_id].tot_all_tried << " " << log_stats_vec[thread_id].tot_ksw_aligned << "\n";
@@ -100,8 +99,8 @@ inline bool align_reads_PE(InputBuffer &input_buffer, OutputBuffer &output_buffe
 
 void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                   std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec, alignment_params &aln_params,
-                  mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs,
-                  kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ){
+                  mapping_params &map_param, const References& references,
+                  kmer_lookup &mers_index, mers_vector &flat_vector){
     bool eof = false;
     while (true){
         std::vector<KSeq> records1;
@@ -114,7 +113,7 @@ void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
         input_buffer.read_records_PE(records1, records2, log_stats_vec[thread_id]);
         eof = align_reads_PE(input_buffer, output_buffer, records1, records2,
                            log_stats_vec[thread_id], isize_est_vec[thread_id],
-                          aln_params, map_param, ref_lengths, ref_seqs, mers_index, flat_vector,  acc_map);
+                          aln_params, map_param, references, mers_index, flat_vector);
 
         if (eof){
             break;

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -125,8 +125,8 @@ void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
 
 inline bool align_reads_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,  std::vector<KSeq> &records,
                            logging_variables &log_vars, alignment_params &aln_params,
-                           mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs,
-                           kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ) {
+                           mapping_params &map_param, const References& references,
+                           kmer_lookup &mers_index, mers_vector &flat_vector) {
 
     // If no more reads to align
     if (records.empty() && input_buffer.finished_reading){
@@ -139,8 +139,8 @@ inline bool align_reads_SE(InputBuffer &input_buffer, OutputBuffer &output_buffe
         auto record1 = records[i];
 
         align_SE_read(record1, sam_out,  log_vars, aln_params,
-                      map_param, ref_lengths, ref_seqs,
-                      mers_index, flat_vector, acc_map );
+                      map_param, references,
+                      mers_index, flat_vector);
     }
 //    std::cerr << isize_est_vec[thread_id].mu << " " << isize_est_vec[thread_id].sigma << "\n";
 //    std::cerr << log_stats_vec[thread_id].tot_all_tried << " " << log_stats_vec[thread_id].tot_ksw_aligned << "\n";
@@ -152,8 +152,8 @@ inline bool align_reads_SE(InputBuffer &input_buffer, OutputBuffer &output_buffe
 
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                      std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, alignment_params &aln_params,
-                     mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs,
-                     kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map ){
+                     mapping_params &map_param, const References& references,
+                     kmer_lookup &mers_index, mers_vector &flat_vector) {
     bool eof = false;
     while (true){
         std::vector<KSeq> records1;
@@ -165,7 +165,7 @@ void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
         input_buffer.read_records_SE(records1, log_stats_vec[thread_id]);
         eof = align_reads_SE(input_buffer, output_buffer, records1,
                              log_stats_vec[thread_id],
-                             aln_params, map_param, ref_lengths, ref_seqs, mers_index, flat_vector,  acc_map);
+                             aln_params, map_param, references, mers_index, flat_vector);
 
         if (eof){
             break;

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -69,5 +69,5 @@ void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
 
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                      std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, alignment_params &aln_params,
-                     mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map );
+                     mapping_params &map_param, const References& references, kmer_lookup &mers_index, mers_vector &flat_vector);
 #endif // pc_hpp_

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -65,7 +65,7 @@ public:
 
 void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                   std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec, alignment_params &aln_params,
-                  mapping_params &map_param, std::vector<unsigned int> &ref_lengths, std::vector<std::string> &ref_seqs, kmer_lookup &mers_index, mers_vector &flat_vector, ref_names &acc_map );
+                  mapping_params &map_param, const References& references, kmer_lookup &mers_index, mers_vector &flat_vector);
 
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                      std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, alignment_params &aln_params,

--- a/src/refs.hpp
+++ b/src/refs.hpp
@@ -7,10 +7,11 @@
 #include <numeric>
 #include <vector>
 
-typedef std::vector<unsigned int> ref_lengths;
-typedef std::vector<std::string> ref_names;
 
 class References {
+    typedef std::vector<unsigned int> ref_lengths;
+    typedef std::vector<std::string> ref_names;
+
 public:
     References() { }
     References(

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -57,7 +57,7 @@ void Sam::add(
     sam_string.append("\t");
     sam_string.append(std::to_string(flags));  // FLAG
     sam_string.append("\t");
-    sam_string.append(reference_names[sam_aln.ref_id]);  // RNAME
+    sam_string.append(references.names[sam_aln.ref_id]);  // RNAME
     sam_string.append("\t");
     sam_string.append(std::to_string(sam_aln.ref_start));  // POS
     sam_string.append("\t");
@@ -220,8 +220,8 @@ void Sam::add_pair(
         mate_name1 = "=";
         mate_name2 = "=";
     } else{
-        mate_name1 = reference_names[sam_aln1.ref_id];
-        mate_name2 = reference_names[sam_aln2.ref_id];
+        mate_name1 = references.names[sam_aln1.ref_id];
+        mate_name2 = references.names[sam_aln2.ref_id];
     }
 
 //    if ( (sam_aln1.is_unaligned) && (sam_aln2.is_unaligned) ){
@@ -244,8 +244,8 @@ void Sam::add_pair(
 //        f1 |= MUNMAP;
 //        f1 -= 32;
 //    }
-    std::string ref1 = reference_names[sam_aln1.ref_id];
-    std::string ref2 = reference_names[sam_aln2.ref_id];
+    std::string ref1 = references.names[sam_aln1.ref_id];
+    std::string ref2 = references.names[sam_aln2.ref_id];
     int ed1 = sam_aln1.ed;
     int ed2 = sam_aln2.ed;
 

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -39,9 +39,9 @@ enum SamFlags {
 class Sam {
 
 public:
-    Sam(std::string& sam_string, const ref_names& reference_names)
+    Sam(std::string& sam_string, const References& references)
         : sam_string(sam_string)
-        , reference_names(reference_names) { }
+        , references(references) { }
 
     /* Add an alignment */
     void add(const alignment& sam_aln, const klibpp::KSeq& record, const std::string& sequence_rc, bool is_secondary = false);
@@ -53,7 +53,7 @@ public:
 
 private:
     std::string& sam_string;
-    const ref_names& reference_names;
+    const References& references;
 };
 
 


### PR DESCRIPTION
Instead of passing reference lengths/names/sequences as separate parameters, pass a "References" object into various functions.