### PR TITLE
Add some structs to replace tuples

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -91,15 +91,15 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
 //    std::vector<std::pair<int, int>> repetitive_fw, repetitive_rc;
     for (auto &q : query_mers)
     {
-        auto mer_hashv = std::get<0>(q);
+        auto mer_hashv = q.hash;
         if (mers_index.find(mer_hashv) != mers_index.end()){ //  In  index
             total_hits ++;
             auto ref_hit = mers_index[mer_hashv];
             auto offset = std::get<0>(ref_hit);
             auto count = std::get<1>(ref_hit);
-            auto query_s = std::get<2>(q);
-            auto query_e = query_s + std::get<3>(q) + k;
-            is_rc = std::get<4>(q);
+            auto query_s = q.position;
+            auto query_e = query_s + q.offset_strobe + k;
+            is_rc = q.is_reverse;
             if (is_rc){
                 std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, bool> s(count, offset, query_s, query_e, is_rc);
                 hits_rc.push_back(s);
@@ -392,12 +392,12 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
 //    for (size_t i = 0; i < query_mers.size(); ++i)
     {
 //        std::cerr << "Q " << h.query_s << " " << h.query_e << " read length:" << read_length << std::endl;
-        auto mer_hashv = std::get<0>(q);
+        auto mer_hashv = q.hash;
         if (mers_index.find(mer_hashv) != mers_index.end()){ //  In  index
             total_hits ++;
-            h.query_s = std::get<2>(q);
-            h.query_e = h.query_s + std::get<3>(q) + k; // h.query_s + read_length/2;
-            h.is_rc = std::get<4>(q);
+            h.query_s = q.position;
+            h.query_e = h.query_s + q.offset_strobe + k; // h.query_s + read_length/2;
+            h.is_rc = q.is_reverse;
             auto mer = mers_index[mer_hashv];
             auto offset = std::get<0>(mer);
             auto count = std::get<1>(mer);

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -187,8 +187,8 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
             for(size_t j = offset; j < offset+count; ++j)
             {
                 auto r = ref_mers[j];
-                h.ref_s = std::get<0>(r);
-                auto p = std::get<1>(r);
+                h.ref_s = r.position;
+                auto p = r.packed;
                 int bit_alloc = 8;
                 int r_id = (p >> bit_alloc);
                 int mask=(1<<bit_alloc) - 1;
@@ -236,8 +236,8 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
             for(size_t j = offset; j < offset+count; ++j)
             {
                 auto r = ref_mers[j];
-                h.ref_s = std::get<0>(r);
-                auto p = std::get<1>(r);
+                h.ref_s = r.position;
+                auto p = r.packed;
                 int bit_alloc = 8;
                 int r_id = (p >> bit_alloc);
                 int mask=(1<<bit_alloc) - 1;
@@ -436,8 +436,8 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
 //                    unsigned int ref_id = std::get<0>(r);//The indexes in this code are not fixed after removal of the 64-bit hash
 //                    unsigned int ref_s = std::get<1>(r);
 //                    unsigned int ref_e = std::get<2>(r) + k; //ref_s + read_length/2;
-                    h.ref_s = std::get<0>(r);
-                    auto p = std::get<1>(r);
+                    h.ref_s = r.position;
+                    auto p = r.packed;
                     int bit_alloc = 8;
                     int r_id = (p >> bit_alloc);
                     int mask=(1<<bit_alloc) - 1;

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -95,8 +95,8 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
         if (mers_index.find(mer_hashv) != mers_index.end()){ //  In  index
             total_hits ++;
             auto ref_hit = mers_index[mer_hashv];
-            auto offset = std::get<0>(ref_hit);
-            auto count = std::get<1>(ref_hit);
+            auto offset = ref_hit.offset;
+            auto count = ref_hit.count;
             auto query_s = q.position;
             auto query_e = query_s + q.offset_strobe + k;
             is_rc = q.is_reverse;
@@ -399,8 +399,8 @@ static inline std::pair<float,int> find_nams(std::vector<nam> &final_nams, robin
             h.query_e = h.query_s + q.offset_strobe + k; // h.query_s + read_length/2;
             h.is_rc = q.is_reverse;
             auto mer = mers_index[mer_hashv];
-            auto offset = std::get<0>(mer);
-            auto count = std::get<1>(mer);
+            auto offset = mer.offset;
+            auto count = mer.count;
 //            if (count == 1){
 //                auto r = ref_mers[offset];
 //                unsigned int ref_id = std::get<0>(r); //The indexes in this code are not fixed after removal of the 64-bit hash

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -8,6 +8,20 @@
 
 using namespace klibpp;
 
+
+struct Hit {
+    unsigned int count;
+    unsigned int offset;
+    unsigned int query_s;
+    unsigned int query_e;
+    bool is_rc;
+
+    bool operator< (const Hit& rhs) {
+        return std::tie(count, offset, query_s, query_e, is_rc)
+            < std::tie(rhs.count, rhs.offset, rhs.query_s, rhs.query_e, rhs.is_rc);
+    }
+};
+
 static inline bool score(const nam &a, const nam &b) {
     return a.score > b.score;
 }
@@ -83,7 +97,7 @@ static inline bool sort_hits(const hit &a, const hit &b)
     return (a.query_s < b.query_s) || ( (a.query_s == b.query_s) && (a.ref_s < b.ref_s) );
 }
 
-static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, bool>> hits_fw, std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, bool>> hits_rc, std::vector<nam> &final_nams, robin_hood::unordered_map< unsigned int, std::vector<hit>> &hits_per_ref, const mers_vector_read &query_mers, const mers_vector &ref_mers, kmer_lookup &mers_index, int k, const std::vector<std::string> &ref_seqs, const std::string &read, unsigned int filter_cutoff ){
+static inline void find_nams_rescue(std::vector<Hit> hits_fw, std::vector<Hit> hits_rc, std::vector<nam> &final_nams, robin_hood::unordered_map< unsigned int, std::vector<hit>> &hits_per_ref, const mers_vector_read &query_mers, const mers_vector &ref_mers, kmer_lookup &mers_index, int k, const std::vector<std::string> &ref_seqs, const std::string &read, unsigned int filter_cutoff ){
 //    std::pair<float,int> info (0,0); // (nr_nonrepetitive_hits/total_hits, max_nam_n_hits)
     int nr_good_hits = 0, total_hits = 0;
     bool is_rc = true, no_rep_fw = true, no_rep_rc = true;
@@ -101,7 +115,7 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
             auto query_e = query_s + q.offset_strobe + k;
             is_rc = q.is_reverse;
             if (is_rc){
-                std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, bool> s(count, offset, query_s, query_e, is_rc);
+                Hit s{count, offset, query_s, query_e, is_rc};
                 hits_rc.push_back(s);
 //                if (count > filter_cutoff){
 //                    if (no_rep_rc){ //initialize
@@ -120,7 +134,7 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
 //                    nr_good_hits ++;
 //                }
             } else{
-                std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, bool> s(count, offset, query_s, query_e, is_rc);
+                Hit s{count, offset, query_s, query_e, is_rc};
                 hits_fw.push_back(s);
 //                if (count > filter_cutoff){
 //                    if (no_rep_fw){ //initialize
@@ -139,8 +153,6 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
 //                    nr_good_hits ++;
 //                }
             }
-
-
         }
     }
 //    if (!no_rep_fw) {
@@ -164,12 +176,11 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
     for (auto &q : hits_fw)
     {
 //        std::cerr << "Q " << h.query_s << " " << h.query_e << " read length:" << read_length << std::endl;
-        auto count = std::get<0>(q);
-        auto offset = std::get<1>(q);
-        h.query_s = std::get<2>(q);
-        h.query_e = std::get<3>(q); // h.query_s + read_length/2;
-        h.is_rc = std::get<4>(q);
-
+        auto count = q.count;
+        auto offset = q.offset;
+        h.query_s = q.query_s;
+        h.query_e = q.query_e; // h.query_s + read_length/2;
+        h.is_rc = q.is_rc;
 
         if ( ((count <= filter_cutoff) || (cnt < 5)) && (count <= 1000) ){
 //            std::cerr << "Found FORWARD: " << count << ", q_start: " <<  h.query_s << ", q_end: " << h.query_e << std::endl;
@@ -214,11 +225,11 @@ static inline void find_nams_rescue(std::vector<std::tuple<unsigned int, unsigne
     cnt = 0;
     for (auto &q : hits_rc)
     {
-        auto count = std::get<0>(q);
-        auto offset = std::get<1>(q);
-        h.query_s = std::get<2>(q);
-        h.query_e = std::get<3>(q); // h.query_s + read_length/2;
-        h.is_rc = std::get<4>(q);
+        auto count = q.count;
+        auto offset = q.offset;
+        h.query_s = q.query_s;
+        h.query_e = q.query_e; // h.query_s + read_length/2;
+        h.is_rc = q.is_rc;
 
         if ( ((count <= filter_cutoff) || (cnt < 5)) && (count <= 1000) ){
 //            std::cerr << "Found REVERSE: " << count << ", q_start: " <<  h.query_s << ", q_end: " << h.query_e << std::endl;
@@ -2791,14 +2802,13 @@ void align_PE_read(KSeq &record1, KSeq &record2, std::string &outstring, Alignme
 
     if (map_param.R > 1) {
         auto rescue_start = std::chrono::high_resolution_clock::now();
-        std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, bool>> hits_fw;
-        std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, bool>> hits_rc;
+        std::vector<Hit> hits_fw;
+        std::vector<Hit> hits_rc;
         if ((nams1.size() == 0) || (info1.first < 0.7)) {
             hits_fw.reserve(5000);
             hits_rc.reserve(5000);
             statistics.tried_rescue += 1;
             nams1.clear();
-//                        std::cerr << "Rescue is_sam_out read 1: " << record1.name << info1.first <<  std::endl;
             find_nams_rescue(hits_fw, hits_rc, nams1, hits_per_ref, query_mers1,
                                      flat_vector,
                                      mers_index, map_param.k, references.sequences,
@@ -2827,7 +2837,6 @@ void align_PE_read(KSeq &record1, KSeq &record2, std::string &outstring, Alignme
         auto rescue_finish = std::chrono::high_resolution_clock::now();
         statistics.tot_time_rescue += rescue_finish - rescue_start;
     }
-
 
 
     //Sort hits based on start choordinate on query sequence
@@ -2887,8 +2896,8 @@ void align_SE_read(KSeq &record, std::string &outstring, AlignmentStatistics &st
         mers_vector_read query_mers; // pos, chr_id, kmer hash value
         std::vector<nam> nams; // (r_id, r_pos_start, r_pos_end, q_pos_start, q_pos_end)
         robin_hood::unordered_map< unsigned int, std::vector<hit>> hits_per_ref;
-        std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, bool>> hits_fw;
-        std::vector<std::tuple<unsigned int, unsigned int, unsigned int, unsigned int, bool>> hits_rc;
+        std::vector<Hit> hits_fw;
+        std::vector<Hit> hits_rc;
         hits_per_ref.reserve(100);
         hits_fw.reserve(5000);
         hits_rc.reserve(5000);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -238,7 +238,7 @@ void StrobemerIndex::populate(const References& references, mapping_params& map_
         flat_vector.reserve(ind_flat_vector.size());
         h_vector.reserve(ind_flat_vector.size());
         for (std::size_t i = 0; i < ind_flat_vector.size(); ++i) {
-            flat_vector.push_back(std::make_tuple(ind_flat_vector[i].position, ind_flat_vector[i].packed));
+            flat_vector.push_back(ReferenceMer{ind_flat_vector[i].position, ind_flat_vector[i].packed});
             h_vector.push_back(ind_flat_vector[i].hash);
         }
         std::chrono::duration<double> elapsed_copy_flat_vector = high_resolution_clock::now() - start_copy_flat_vector;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -64,7 +64,7 @@ unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, 
                 strobemer_counts.push_back(count);
             }
 
-            std::tuple<unsigned int, unsigned int> s(prev_offset, count);
+            KmerLookupEntry s{prev_offset, count};
             mers_index[prev_k] = s;
             count = 1;
             prev_k = curr_k;
@@ -74,7 +74,7 @@ unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, 
     }
 
     // last k-mer
-    std::tuple<unsigned int, unsigned int> s(prev_offset, count);
+    KmerLookupEntry s{prev_offset, count};
     mers_index[curr_k] = s;
     float frac_unique = ((float) tot_occur_once )/ mers_index.size();
     logger.debug()

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -238,8 +238,8 @@ void StrobemerIndex::populate(const References& references, mapping_params& map_
         flat_vector.reserve(ind_flat_vector.size());
         h_vector.reserve(ind_flat_vector.size());
         for (std::size_t i = 0; i < ind_flat_vector.size(); ++i) {
-            flat_vector.push_back(std::make_tuple(std::get<1>(ind_flat_vector[i]), std::get<2>(ind_flat_vector[i])));
-            h_vector.push_back(std::get<0>(ind_flat_vector[i]));
+            flat_vector.push_back(std::make_tuple(ind_flat_vector[i].position, ind_flat_vector[i].packed));
+            h_vector.push_back(ind_flat_vector[i].hash);
         }
         std::chrono::duration<double> elapsed_copy_flat_vector = high_resolution_clock::now() - start_copy_flat_vector;
         logger.info() << "Time copying flat vector: " << elapsed_copy_flat_vector.count() << " s" << std::endl;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -25,8 +25,13 @@ struct ReferenceMer {
 };
 
 typedef std::vector<ReferenceMer> mers_vector;
-//typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int>> mers_vector_reduced;
-typedef robin_hood::unordered_map< uint64_t, std::tuple<unsigned int, unsigned int >> kmer_lookup;
+
+struct KmerLookupEntry {
+    unsigned int offset;
+    unsigned int count;
+};
+
+typedef robin_hood::unordered_map<uint64_t, KmerLookupEntry> kmer_lookup;
 
 
 struct hit {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -19,8 +19,12 @@
 #include "refs.hpp"
 #include "randstrobes.hpp"
 
+struct ReferenceMer {
+    uint32_t position;
+    int32_t packed;
+};
 
-typedef std::vector< std::tuple<uint32_t, int32_t >> mers_vector;
+typedef std::vector<ReferenceMer> mers_vector;
 //typedef std::vector< std::tuple<uint64_t, unsigned int, unsigned int>> mers_vector_reduced;
 typedef robin_hood::unordered_map< uint64_t, std::tuple<unsigned int, unsigned int >> kmer_lookup;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,13 +63,12 @@ static void print_diagnostics(mers_vector &ref_mers, kmer_lookup &mers_index, st
 
         for (size_t j = offset; j < offset + count; ++j) {
             auto r = ref_mers[j];
-            auto p = std::get<1>(r);
+            auto p = r.packed;
             int bit_alloc = 8;
             int mask=(1<<bit_alloc) - 1;
             int offset = (p & mask);
             seed_length =  offset + k;
             if (seed_length < max_size){
-
                 log_count[seed_length] ++;
                 log_count_squared[seed_length] += count;
                 tot_seed_count ++;
@@ -83,7 +82,6 @@ static void print_diagnostics(mers_vector &ref_mers, kmer_lookup &mers_index, st
             } else {
                logger.info() << "Detected seed size over " << max_size << " bp (can happen, e.g., over centromere): " << seed_length << std::endl;
             }
-
         }
 
         if ( (count == 1) & (seed_length < max_size) ) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,10 +56,8 @@ static void print_diagnostics(mers_vector &ref_mers, kmer_lookup &mers_index, st
     int seed_length;
     for (auto &it : mers_index) {
         auto ref_mer = it.second;
-
-        auto offset = std::get<0>(ref_mer);
-        auto count = std::get<1>(ref_mer);
-
+        auto offset = ref_mer.offset;
+        auto count = ref_mer.count;
 
         for (size_t j = offset; j < offset + count; ++j) {
             auto r = ref_mers[j];

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -279,8 +279,7 @@ void seq_to_randstrobes2(ind_mers_vector& flat_vector, int n, int k, int w_min, 
             get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
-        else{
-//            std::cerr << randstrobes2.size() << " randstrobes generated" << '\n';
+        else {
             return;
         }
 
@@ -293,7 +292,7 @@ void seq_to_randstrobes2(ind_mers_vector& flat_vector, int n, int k, int w_min, 
         int packed = (ref_index << 8);
 //        int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
         packed = packed + (seq_pos_strobe2 - seq_pos_strobe1);
-        std::tuple<uint64_t, uint32_t, int32_t> s(hash_randstrobe2, seq_pos_strobe1, packed);
+        MersIndexEntry s {hash_randstrobe2, seq_pos_strobe1, packed};
         flat_vector.push_back(s);
 //        std::cerr << seq_pos_strobe1 << " " << seq_pos_strobe2 << std::endl;
 //        std::cerr << "FORWARD REF: " << seq_pos_strobe1 << " " << seq_pos_strobe2 << " " << hash_randstrobe2 << std::endl;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -354,10 +354,6 @@ mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, co
 
     // create the randstrobes FW direction!
     for (unsigned int i = 0; i < nr_hashes; i++) {
-
-//        if ((i % 1000000) == 0 ){
-//            std::cerr << i << " strobemers created." << std::endl;
-//        }
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
@@ -389,7 +385,7 @@ mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, co
 
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
         unsigned int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
-        std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool> s (hash_randstrobe2, ref_index, seq_pos_strobe1, offset_strobe, false);
+        QueryMer s {hash_randstrobe2, ref_index, seq_pos_strobe1, offset_strobe, false};
         randstrobes2.push_back(s);
 //        std::cerr << "FORWARD: " << seq_pos_strobe1 << " " << seq_pos_strobe2 << " " << hash_randstrobe2 << std::endl;
 
@@ -411,15 +407,7 @@ mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, co
         pos_to_seq_choord[i] = read_length - pos_to_seq_choord[i] - k;
     }
 
-//    for (unsigned int i = 0; i < nr_hashes; i++) {
-//        std::cerr << "REVERSE: " << pos_to_seq_choord[i] <<std::endl;
-//    }
-
     for (unsigned int i = 0; i < nr_hashes; i++) {
-
-//        if ((i % 1000000) == 0 ){
-//            std::cerr << i << " strobemers created." << std::endl;
-//        }
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
@@ -453,9 +441,8 @@ mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, co
 
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
         unsigned int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
-        std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool> s (hash_randstrobe2, ref_index, seq_pos_strobe1, offset_strobe, true);
+        QueryMer s {hash_randstrobe2, ref_index, seq_pos_strobe1, offset_strobe, true};
         randstrobes2.push_back(s);
-//        std::cerr << "REVERSE: " << seq_pos_strobe1 << " " << seq_pos_strobe2 << " " << hash_randstrobe2 << std::endl;
 
 //        auto strobe1 = seq.substr(seq_pos_strobe1, k);
 //        unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
@@ -467,6 +454,5 @@ mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, co
 //        std::cerr << i << " " << strobe_pos_next << std::endl;
 
     }
-//    std::cerr << randstrobes2.size() << " randstrobes generated" << '\n';
     return randstrobes2;
 }

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -6,7 +6,18 @@
 #include <tuple>
 #include <inttypes.h>
 
-typedef std::vector<std::tuple<uint64_t, uint32_t, int32_t >> ind_mers_vector; //only used during index generation
+// only used during index generation
+struct MersIndexEntry {
+    uint64_t hash;
+    uint32_t position;
+    int32_t packed; // packed representation of ref_index and strobe offset
+
+    bool operator< (const MersIndexEntry& other) const {
+        return std::tie(hash, position, packed) < std::tie(other.hash, other.position, other.packed);
+    }
+};
+
+typedef std::vector<MersIndexEntry> ind_mers_vector;
 typedef std::vector<std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool>> mers_vector_read;
 
 void seq_to_randstrobes2(ind_mers_vector& flat_vector, int n, int k, int w_min, int w_max, const std::string &seq, int ref_index,          int s, int t, uint64_t q, int max_dist);

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -18,7 +18,18 @@ struct MersIndexEntry {
 };
 
 typedef std::vector<MersIndexEntry> ind_mers_vector;
-typedef std::vector<std::tuple<uint64_t, unsigned int, unsigned int, unsigned int, bool>> mers_vector_read;
+
+
+struct QueryMer {
+    uint64_t hash;
+    unsigned int ref_index;
+    unsigned int position;
+    unsigned int offset_strobe;
+    bool is_reverse;
+};
+
+
+typedef std::vector<QueryMer> mers_vector_read;
 
 void seq_to_randstrobes2(ind_mers_vector& flat_vector, int n, int k, int w_min, int w_max, const std::string &seq, int ref_index,          int s, int t, uint64_t q, int max_dist);
 mers_vector_read seq_to_randstrobes2_read(             int n, int k, int w_min, int w_max, const std::string &seq, unsigned int ref_index, int s, int t, uint64_t q, int max_dist);


### PR DESCRIPTION
Accessing tuple fields with `std::get<index>` is error prone and not so readable, so this replaces many tuples with proper structs that have named fields.
* `MersIndexEntry`: an element of `flat_vector` (with fields hash, position, packed)
* `KmerLookupEntry`: an element of `kmer_lookup`
, `QueryMer`: an element of `mers_vector_read`
* `Hit`
I’m not so happy with the names of the structs, yet. In particular, `Hit` collides a bit with the lowercase `hit` struct in `index.hpp`, but I think this is an improvement already and finding better names can be done in a separate step.
