### PR TITLE
Move logging_variables to aln.hpp and rename to AlignmentStatistics

### DIFF
--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -16,10 +16,46 @@ struct aln_info {
     int length;
 };
 
+struct AlignmentStatistics {
+    std::chrono::duration<double> tot_read_file;
+    std::chrono::duration<double> tot_construct_strobemers;
+    std::chrono::duration<double> tot_find_nams;
+    std::chrono::duration<double> tot_time_rescue;
+    std::chrono::duration<double> tot_find_nams_alt;
+    std::chrono::duration<double> tot_sort_nams;
+    std::chrono::duration<double> tot_extend;
+    std::chrono::duration<double> tot_rc;
+    std::chrono::duration<double> tot_write_file;
 
-void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, logging_variables& log_vars, i_dist_est& isize_est, alignment_params& aln_params, mapping_params& map_param, const References& references, kmer_lookup& mers_index, mers_vector& flat_vector);
+    unsigned int tot_ksw_aligned = 0;
+    unsigned int tot_rescued = 0;
+    unsigned int tot_all_tried = 0;
+    unsigned int did_not_fit = 0;
+    unsigned int tried_rescue = 0;
 
-void align_SE_read(klibpp::KSeq& record, std::string& outstring, logging_variables& log_vars, alignment_params& aln_params, mapping_params& map_param, const References& references, kmer_lookup& mers_index, mers_vector& flat_vector);
+    AlignmentStatistics operator+=(const AlignmentStatistics& other) {
+        this->tot_read_file += other.tot_read_file;
+        this->tot_construct_strobemers += other.tot_construct_strobemers;
+        this->tot_find_nams += other.tot_find_nams;
+        this->tot_time_rescue += other.tot_time_rescue;
+        this->tot_find_nams_alt += other.tot_find_nams_alt;
+        this->tot_sort_nams += other.tot_sort_nams;
+        this->tot_extend += other.tot_extend;
+        this->tot_rc += other.tot_rc;
+        this->tot_write_file += other.tot_write_file;
+        this->tot_ksw_aligned += other.tot_ksw_aligned;
+        this->tot_rescued += other.tot_rescued;
+        this->tot_all_tried += other.tot_all_tried;
+        this->did_not_fit += other.did_not_fit;
+        this->tried_rescue += other.tried_rescue;
+        return *this;
+    }
+};
+
+
+void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, AlignmentStatistics& statistics, i_dist_est& isize_est, alignment_params& aln_params, mapping_params& map_param, const References& references, kmer_lookup& mers_index, mers_vector& flat_vector);
+
+void align_SE_read(klibpp::KSeq& record, std::string& outstring, AlignmentStatistics& statistics, alignment_params& aln_params, mapping_params& map_param, const References& references, kmer_lookup& mers_index, mers_vector& flat_vector);
 
 
 #endif

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -67,43 +67,6 @@ struct alignment_params {
 };
 
 
-struct logging_variables {
-    std::chrono::duration<double> tot_read_file;
-    std::chrono::duration<double> tot_construct_strobemers;
-    std::chrono::duration<double> tot_find_nams;
-    std::chrono::duration<double> tot_time_rescue;
-    std::chrono::duration<double> tot_find_nams_alt;
-    std::chrono::duration<double> tot_sort_nams;
-    std::chrono::duration<double> tot_extend;
-    std::chrono::duration<double> tot_rc;
-    std::chrono::duration<double> tot_write_file;
-
-    unsigned int tot_ksw_aligned = 0;
-    unsigned int tot_rescued = 0;
-    unsigned int tot_all_tried = 0;
-    unsigned int did_not_fit = 0;
-    unsigned int tried_rescue = 0;
-
-    logging_variables operator+=(const logging_variables& other) {
-        this->tot_read_file += other.tot_read_file;
-        this->tot_construct_strobemers += other.tot_construct_strobemers;
-        this->tot_find_nams += other.tot_find_nams;
-        this->tot_time_rescue += other.tot_time_rescue;
-        this->tot_find_nams_alt += other.tot_find_nams_alt;
-        this->tot_sort_nams += other.tot_sort_nams;
-        this->tot_extend += other.tot_extend;
-        this->tot_rc += other.tot_rc;
-        this->tot_write_file += other.tot_write_file;
-        this->tot_ksw_aligned += other.tot_ksw_aligned;
-        this->tot_rescued += other.tot_rescued;
-        this->tot_all_tried += other.tot_all_tried;
-        this->did_not_fit += other.did_not_fit;
-        this->tried_rescue += other.tried_rescue;
-        return *this;
-    }
-};
-
-
 struct i_dist_est {
     float sample_size = 1;
     float mu = 300;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,7 +372,7 @@ int main (int argc, char **argv)
             out << sam_header(references);
         }
 
-        std::unordered_map<std::thread::id, logging_variables> log_stats_vec(opt.n_threads);
+        std::unordered_map<std::thread::id, AlignmentStatistics> log_stats_vec(opt.n_threads);
 
 
         logger.info() << "Running in " << (opt.is_SE ? "single-end" : "paired-end") << " mode" << std::endl;
@@ -439,28 +439,28 @@ int main (int argc, char **argv)
         }
         logger.info() << "Done!\n";
 
-        logging_variables tot_log_vars;
+        AlignmentStatistics tot_statistics;
         for (auto& it : log_stats_vec) {
-            tot_log_vars += it.second;
+            tot_statistics += it.second;
         }
         // Record mapping end time
         std::chrono::duration<double> tot_aln_part = high_resolution_clock::now() - start_aln_part;
 
-        logger.info() << "Total mapping sites tried: " << tot_log_vars.tot_all_tried << std::endl
-            << "Total calls to ssw: " << tot_log_vars.tot_ksw_aligned << std::endl
-            << "Calls to ksw (rescue mode): " << tot_log_vars.tot_rescued << std::endl
-            << "Did not fit strobe start site: " << tot_log_vars.did_not_fit << std::endl
-            << "Tried rescue: " << tot_log_vars.tried_rescue << std::endl
+        logger.info() << "Total mapping sites tried: " << tot_statistics.tot_all_tried << std::endl
+            << "Total calls to ssw: " << tot_statistics.tot_ksw_aligned << std::endl
+            << "Calls to ksw (rescue mode): " << tot_statistics.tot_rescued << std::endl
+            << "Did not fit strobe start site: " << tot_statistics.did_not_fit << std::endl
+            << "Tried rescue: " << tot_statistics.tried_rescue << std::endl
             << "Total time mapping: " << tot_aln_part.count() << " s." << std::endl
-            << "Total time reading read-file(s): " << tot_log_vars.tot_read_file.count() / opt.n_threads << " s." << std::endl
-            << "Total time creating strobemers: " << tot_log_vars.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl
-            << "Total time finding NAMs (non-rescue mode): " << tot_log_vars.tot_find_nams.count() / opt.n_threads << " s." << std::endl
-            << "Total time finding NAMs (rescue mode): " << tot_log_vars.tot_time_rescue.count() / opt.n_threads << " s." << std::endl;
+            << "Total time reading read-file(s): " << tot_statistics.tot_read_file.count() / opt.n_threads << " s." << std::endl
+            << "Total time creating strobemers: " << tot_statistics.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl
+            << "Total time finding NAMs (non-rescue mode): " << tot_statistics.tot_find_nams.count() / opt.n_threads << " s." << std::endl
+            << "Total time finding NAMs (rescue mode): " << tot_statistics.tot_time_rescue.count() / opt.n_threads << " s." << std::endl;
         //<< "Total time finding NAMs ALTERNATIVE (candidate sites): " << tot_find_nams_alt.count()/opt.n_threads  << " s." <<  std::endl;
-        logger.info() << "Total time sorting NAMs (candidate sites): " << tot_log_vars.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
-            << "Total time reverse compl seq: " << tot_log_vars.tot_rc.count() / opt.n_threads << " s." << std::endl
-            << "Total time base level alignment (ssw): " << tot_log_vars.tot_extend.count() / opt.n_threads << " s." << std::endl
-            << "Total time writing alignment to files: " << tot_log_vars.tot_write_file.count() << " s." << std::endl;
+        logger.info() << "Total time sorting NAMs (candidate sites): " << tot_statistics.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
+            << "Total time reverse compl seq: " << tot_statistics.tot_rc.count() / opt.n_threads << " s." << std::endl
+            << "Total time base level alignment (ssw): " << tot_statistics.tot_extend.count() / opt.n_threads << " s." << std::endl
+            << "Total time writing alignment to files: " << tot_statistics.tot_write_file.count() << " s." << std::endl;
 
         /////////////////////// FIND AND OUTPUT NAMs ///////////////////////////////
     }

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -41,8 +41,8 @@ public:
     int buffer_size = 0;
     int chunk_size = 100000;
 
-    void read_records_PE(std::vector<klibpp::KSeq> &records1, std::vector<klibpp::KSeq> &records2, logging_variables &log_vars);
-    void read_records_SE(std::vector<klibpp::KSeq> &records1, logging_variables &log_vars);
+    void read_records_PE(std::vector<klibpp::KSeq> &records1, std::vector<klibpp::KSeq> &records2, AlignmentStatistics &statistics);
+    void read_records_SE(std::vector<klibpp::KSeq> &records1, AlignmentStatistics &statistics);
 };
 
 
@@ -64,10 +64,10 @@ public:
 
 
 void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
-                  std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec, alignment_params &aln_params,
+                  std::unordered_map<std::thread::id, AlignmentStatistics> &log_stats_vec, std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec, alignment_params &aln_params,
                   mapping_params &map_param, const References& references, kmer_lookup &mers_index, mers_vector &flat_vector);
 
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
-                     std::unordered_map<std::thread::id, logging_variables> &log_stats_vec, alignment_params &aln_params,
+                     std::unordered_map<std::thread::id, AlignmentStatistics> &log_stats_vec, alignment_params &aln_params,
                      mapping_params &map_param, const References& references, kmer_lookup &mers_index, mers_vector &flat_vector);
 #endif // pc_hpp_


### PR DESCRIPTION
Only by inspecting the code became it clear to me that the values stored in `logging_vars` are actually only for the alignment stage. Renaming it to `AlignmentStatistics` makes this clearer. Also, move the struct to `aln.hpp` because that is the right place (it doesn’t have anything to do with index creation).
