### PR TITLE
Reduce usage of ternary operators

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -9,6 +9,7 @@
 #include <math.h>   /* pow */
 #include <fstream>
 #include <cassert>
+#include <algorithm>
 
 #include "logger.hpp"
 
@@ -97,9 +98,9 @@ unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, 
     logger.debug() << "Filtered cutoff index: " << index_cutoff << std::endl;
     unsigned int filter_cutoff;
     if (!strobemer_counts.empty()){
-        filter_cutoff =  index_cutoff < strobemer_counts.size() ?  strobemer_counts[index_cutoff] : strobemer_counts.back();
-        filter_cutoff = filter_cutoff > 30 ? filter_cutoff : 30; // cutoff is around 30-50 on hg38. No reason to have a lower cutoff than this if aligning to a smaller genome or contigs.
-        filter_cutoff = filter_cutoff > 100 ? 100 : filter_cutoff; // limit upper cutoff for normal NAM finding - use rescue mode instead
+        filter_cutoff = index_cutoff < strobemer_counts.size() ?  strobemer_counts[index_cutoff] : strobemer_counts.back();
+        filter_cutoff = std::max(30U, filter_cutoff); // cutoff is around 30-50 on hg38. No reason to have a lower cutoff than this if aligning to a smaller genome or contigs.
+        filter_cutoff = std::min(100U, filter_cutoff); // limit upper cutoff for normal NAM finding - use rescue mode instead
     } else {
         filter_cutoff = 30;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,20 +227,18 @@ int main (int argc, char **argv)
     adjust_mapping_params_depending_on_read_length(map_param, opt);
 
     if (!opt.max_seed_len_set){
-        map_param.max_dist = map_param.r - 70 > map_param.k ? map_param.r - 70 : map_param.k;
-        if (map_param.max_dist > 255){
-            map_param.max_dist = 255;
-        }
+        map_param.max_dist = std::max(map_param.r - 70, map_param.k);
+        map_param.max_dist = std::min(255, map_param.max_dist);
     } else {
         map_param.max_dist = opt.max_seed_len - map_param.k; //convert to distance in start positions
     }
 
 
     if ( (map_param.c < 64) && (map_param.c > 0)){
-        map_param.q = pow (2, map_param.c) - 1;
+        map_param.q = pow(2, map_param.c) - 1;
     } else{
         logger.warning() << "Warning wrong value for parameter c, setting c=8" << std::endl;
-        map_param.q = pow (2, 8) - 1;
+        map_param.q = pow(2, 8) - 1;
     }
 
     map_param.w_min = std::max(1, map_param.k/(map_param.k-map_param.s+1) + map_param.l);


### PR DESCRIPTION
and use std::{max,min,abs} instead.

The remaining usages of the ternary operator are either less easily replaced or are readable.

See #57, this finishes what was begun there.