### PR TITLE
Rename alignment::not_proper to is_proper and invert meaning

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1542,7 +1542,7 @@ static inline void get_alignment(
     if (!fits) {
         did_not_fit++;
         aln_did_not_fit = true;
-        sam_aln.not_proper = true;
+        sam_aln.is_proper = false;
     }
 
     std::string r_tmp;
@@ -2155,7 +2155,7 @@ static inline void rescue_mate(const alignment_params &aln_params, nam &n, const
         sam_aln.is_rc = n.is_rc;
         sam_aln.ref_id = n.ref_id;
         sam_aln.is_unaligned = true;
-        sam_aln.not_proper = true;
+        sam_aln.is_proper = false;
 //        std::cerr << "RESCUE: Caught Bug3! ref start: " << ref_start << " ref end: " << ref_end << " ref len:  " << ref_len << std::endl;
         return;
     }
@@ -2183,7 +2183,7 @@ static inline void rescue_mate(const alignment_params &aln_params, nam &n, const
         sam_aln.is_rc = n.is_rc;
         sam_aln.ref_id = n.ref_id;
         sam_aln.is_unaligned = true;
-        sam_aln.not_proper = true;
+        sam_aln.is_proper = false;
 //        std::cerr << "Avoided!" << std::endl;
         return;
 //        std::cerr << "Aligning anyway at: " << ref_start << " to " << ref_end << "ref len:" << ref_len << " ref_id:" << n.ref_id << std::endl;
@@ -2433,19 +2433,15 @@ inline void align_PE(alignment_params &aln_params, Sam &sam, std::vector<nam> &a
     bool r1_r2 = n_max2.is_rc && (a < b) && ((b-a) < 2000); // r1 ---> <---- r2
     bool r2_r1 = n_max1.is_rc && (b < a) && ((a-b) < 2000); // r2 ---> <---- r1
     if (score_dropoff1 < dropoff && score_dropoff2 < dropoff && (n_max1.is_rc ^ n_max2.is_rc) && (r1_r2 || r2_r1)) { //( ((n_max1.ref_s - n_max2.ref_s) < mu + 4*sigma ) || ((n_max2.ref_s - n_max1.ref_s ) < mu + 4*sigma ) ) &&
-//            std::cerr << query_acc1 << std::endl;
         get_alignment(aln_params, n_max1, references, read1, read1_rc, sam_aln1, k, rc_already_comp1, statistics.did_not_fit, statistics.tot_ksw_aligned);
         statistics.tot_all_tried ++;
-//            std::cerr << query_acc2 << std::endl;
         get_alignment(aln_params, n_max2, references, read2, read2_rc, sam_aln2, k, rc_already_comp2, statistics.did_not_fit, statistics.tot_ksw_aligned);
         statistics.tot_all_tried ++;
-//            std::cerr<< "6" << std::endl;
         mapq1 = get_MAPQ(all_nams1, n_max1);
         mapq2 = get_MAPQ(all_nams2, n_max2);
-//            std::cerr<< "7" << std::endl;
         sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1_rc, read2_rc, mapq1, mapq2, mu, sigma, true);
 
-        if ((isize_est.sample_size < 400) && ((sam_aln1.ed + sam_aln2.ed) < 3) && !sam_aln1.not_proper && !sam_aln2.not_proper ){
+        if ((isize_est.sample_size < 400) && ((sam_aln1.ed + sam_aln2.ed) < 3) && sam_aln1.is_proper && sam_aln2.is_proper ){
             isize_est.update(std::abs(sam_aln1.ref_start - sam_aln2.ref_start));
         }
         return;

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -160,10 +160,10 @@ void Sam::add_pair(
     // Commented lines below because we do not longer mark a read as not proper just because of the non-matching hash
     // Proper or non proper reads are further below only decided based on the expected distance and relative orientation they align to
 //    if (sam_aln1.ed < 5){ // Flag alignments previously deemed as 'not proper' (based on matching strobemer hash ) to proper because of small ed
-//        sam_aln1.not_proper = false;
+//        sam_aln1.is_proper = true;
 //    }
 //    if (sam_aln2.ed < 5){ // Flag alignments previously deemed as 'not proper' (based on matching strobemer hash ) to proper because of small ed
-//        sam_aln2.not_proper = false;
+//        sam_aln2.is_proper = true;
 //    }
 
     const int dist = sam_aln2.ref_start - sam_aln1.ref_start;
@@ -181,11 +181,11 @@ void Sam::add_pair(
     bool rel_orientation_good = r1_r2 || r2_r1;
     bool insert_good = std::abs(dist) <= mu + 6 * sigma;
     if (both_aligned && insert_good && rel_orientation_good) {
-        sam_aln1.not_proper = false;
-        sam_aln2.not_proper = false;
+        sam_aln1.is_proper = true;
+        sam_aln2.is_proper = true;
     } else {
-        sam_aln1.not_proper = true;
-        sam_aln2.not_proper = true;
+        sam_aln1.is_proper = false;
+        sam_aln2.is_proper = false;
     }
 
     int f1 = PAIRED | READ1;
@@ -194,7 +194,7 @@ void Sam::add_pair(
         f1 |= SECONDARY;
         f2 |= SECONDARY;
     }
-    if (!sam_aln1.not_proper && !sam_aln2.not_proper) {
+    if (sam_aln1.is_proper && sam_aln2.is_proper) {
         f1 |= PROPER_PAIR;
         f2 |= PROPER_PAIR;
     }

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -16,7 +16,7 @@ struct alignment {
     int ref_id;
     int mapq;
     int aln_length;
-    bool not_proper;
+    bool is_proper = true;
     bool is_rc;
     bool is_unaligned = false;
 };


### PR DESCRIPTION
This avoids double negations. For example, `!sam_aln1.not_proper` now reads as `sam_aln1.is_proper`.