### PR TITLE
Refactor index

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -2582,12 +2582,12 @@ void align_PE_read(
     auto strobe_start = std::chrono::high_resolution_clock::now();
 
     std::transform(record1.seq.begin(), record1.seq.end(), record1.seq.begin(), ::toupper);
-    query_mers1 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min(), index_parameters.w_max(), record1.seq, 0, index_parameters.s, index_parameters.t_syncmer(),
+    query_mers1 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record1.seq, 0, index_parameters.s, index_parameters.t_syncmer,
                                            map_param.q,
                                            map_param.max_dist);
 
     std::transform(record2.seq.begin(), record2.seq.end(), record2.seq.begin(), ::toupper);
-    query_mers2 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min(), index_parameters.w_max(), record2.seq, 0, index_parameters.s, index_parameters.t_syncmer(),
+    query_mers2 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record2.seq, 0, index_parameters.s, index_parameters.t_syncmer,
                                            map_param.q,
                                            map_param.max_dist);
 
@@ -2691,7 +2691,7 @@ void align_SE_read(
         // generate mers here
         std::transform(record.seq.begin(), record.seq.end(), record.seq.begin(), ::toupper);
         auto strobe_start = std::chrono::high_resolution_clock::now();
-        query_mers = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min(), index_parameters.w_max(), record.seq, q_id, index_parameters.s, index_parameters.t_syncmer(), map_param.q, map_param.max_dist);
+        query_mers = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record.seq, q_id, index_parameters.s, index_parameters.t_syncmer, map_param.q, map_param.max_dist);
         auto strobe_finish = std::chrono::high_resolution_clock::now();
         statistics.tot_construct_strobemers += strobe_finish - strobe_start;
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -891,8 +891,18 @@ inline void align_SE(const alignment_params &aln_params, Sam& sam, std::vector<n
 }
 
 
-static inline void align_SE_secondary_hits(alignment_params &aln_params, Sam& sam, std::vector<nam> &all_nams, const KSeq& record, int k, const References& references, AlignmentStatistics &statistics, float dropoff, int max_tries, int max_secondary ) {
-
+static inline void align_SE_secondary_hits(
+    const alignment_params &aln_params,
+    Sam& sam,
+    std::vector<nam> &all_nams,
+    const KSeq& record,
+    int k,
+    const References& references,
+    AlignmentStatistics &statistics,
+    float dropoff,
+    int max_tries,
+    int max_secondary
+) {
     auto query_acc = record.name;
     auto read = record.seq;
     auto qual = record.qual;
@@ -1182,7 +1192,20 @@ static inline void align_SE_secondary_hits(alignment_params &aln_params, Sam& sa
 }
 
 
-static inline void align_segment(alignment_params &aln_params, std::string &read_segm, std::string &ref_segm, int read_segm_len, int ref_segm_len, int ref_start,  int ext_left, int ext_right, bool aln_did_not_fit, bool is_rc, alignment &sam_aln_segm, unsigned int &tot_ksw_aligned) {
+static inline void align_segment(
+    const alignment_params &aln_params,
+    const std::string &read_segm,
+    const std::string &ref_segm,
+    int read_segm_len,
+    int ref_segm_len,
+    int ref_start,
+    int ext_left,
+    int ext_right,
+    bool aln_did_not_fit,
+    bool is_rc,
+    alignment &sam_aln_segm,
+    unsigned int &tot_ksw_aligned
+) {
     int hamming_dist = -1;
     int soft_left = 50;
     int soft_right = 50;
@@ -1215,7 +1238,7 @@ static inline void align_segment(alignment_params &aln_params, std::string &read
 
     aln_info info;
     info = ssw_align(ref_segm, read_segm, aln_params.match, aln_params.mismatch, aln_params.gap_open, aln_params.gap_extend);
-    tot_ksw_aligned ++;
+    tot_ksw_aligned++;
     sam_aln_segm.cigar = info.cigar;
     sam_aln_segm.ed = info.ed;
 //    std::cerr << r_tmp << " " << n.n_hits << " " << n.score << " " <<  diff << " " << sam_aln.ed << " "  <<  n.query_s << " "  << n.query_e << " "<<  n.ref_s << " "  << n.ref_e << " " << n.is_rc << " " << hamming_dist << " " << sam_aln.cigar << " " << info.sw_score << std::endl;
@@ -1245,7 +1268,7 @@ static inline void align_segment(alignment_params &aln_params, std::string &read
 */
 
 static inline void get_alignment(
-    alignment_params &aln_params,
+    const alignment_params &aln_params,
     nam &n,
     const References& references,
     const std::string &read,
@@ -2022,7 +2045,7 @@ static inline void rescue_mate(const alignment_params &aln_params, nam &n, const
 
 void rescue_read(
     std::string& read2, // The read to be rescued
-    alignment_params &aln_params, // TODO should be const
+    const alignment_params &aln_params,
     const References& references,
     std::vector<nam> &all_nams1,
     int max_tries,
@@ -2133,10 +2156,20 @@ void rescue_read(
 
 
 
-inline void align_PE(alignment_params &aln_params, Sam &sam, std::vector<nam> &all_nams1, std::vector<nam> &all_nams2,
-                     const KSeq &record1, const KSeq &record2, int k,
-                     const References& references,
-                       AlignmentStatistics &statistics, float dropoff, i_dist_est &isize_est, int max_tries, size_t max_secondary) {
+inline void align_PE(
+    const alignment_params &aln_params,
+    Sam &sam,
+    std::vector<nam> &all_nams1,
+    std::vector<nam> &all_nams2,
+    const KSeq &record1, const KSeq &record2,
+    int k,
+    const References& references,
+    AlignmentStatistics &statistics,
+    float dropoff,
+    i_dist_est &isize_est,
+    int max_tries,
+    size_t max_secondary
+) {
     const auto mu = isize_est.mu;
     const auto sigma = isize_est.sigma;
     std::string read1 = record1.seq;
@@ -2537,8 +2570,8 @@ void align_PE_read(
     std::string &outstring,
     AlignmentStatistics &statistics,
     i_dist_est &isize_est,
-    alignment_params &aln_params,
-    mapping_params &map_param,
+    const alignment_params &aln_params,
+    const mapping_params &map_param,
     const IndexParameters& index_parameters,
     const References& references,
     const StrobemerIndex& index
@@ -2644,8 +2677,8 @@ void align_SE_read(
     KSeq &record,
     std::string &outstring,
     AlignmentStatistics &statistics,
-    alignment_params &aln_params,
-    mapping_params &map_param,
+    const alignment_params &aln_params,
+    const mapping_params &map_param,
     const IndexParameters& index_parameters,
     const References& references,
     const StrobemerIndex& index

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -2534,9 +2534,18 @@ inline void get_best_map_location(std::vector<std::tuple<int,nam,nam>> joint_NAM
 }
 
 
-void align_PE_read(KSeq &record1, KSeq &record2, std::string &outstring, AlignmentStatistics &statistics, i_dist_est &isize_est, alignment_params &aln_params,
-        mapping_params &map_param, const References& references, kmer_lookup &mers_index, mers_vector &flat_vector)
-{
+void align_PE_read(
+    KSeq &record1,
+    KSeq &record2,
+    std::string &outstring,
+    AlignmentStatistics &statistics,
+    i_dist_est &isize_est,
+    alignment_params &aln_params,
+    mapping_params &map_param,
+    const References& references,
+    kmer_lookup &mers_index,
+    mers_vector &flat_vector
+) {
     mers_vector_read query_mers1, query_mers2; // pos, chr_id, kmer hash value
 
     // generate mers here
@@ -2636,9 +2645,16 @@ void align_PE_read(KSeq &record1, KSeq &record2, std::string &outstring, Alignme
 }
 
 
-void align_SE_read(KSeq &record, std::string &outstring, AlignmentStatistics &statistics, alignment_params &aln_params,
-                   mapping_params &map_param, const References& references, kmer_lookup &mers_index, mers_vector &flat_vector) {
-
+void align_SE_read(
+    KSeq &record,
+    std::string &outstring,
+    AlignmentStatistics &statistics,
+    alignment_params &aln_params,
+    mapping_params &map_param,
+    const References& references,
+    kmer_lookup &mers_index,
+    mers_vector &flat_vector
+) {
         std::string seq, seq_rc;
         unsigned int q_id = 0;
         mers_vector_read query_mers; // pos, chr_id, kmer hash value

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -2549,12 +2549,12 @@ void align_PE_read(
     auto strobe_start = std::chrono::high_resolution_clock::now();
 
     std::transform(record1.seq.begin(), record1.seq.end(), record1.seq.begin(), ::toupper);
-    query_mers1 = seq_to_randstrobes2_read(index_parameters.k, map_param.w_min, map_param.w_max, record1.seq, 0, index_parameters.s, map_param.t_syncmer,
+    query_mers1 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min(), index_parameters.w_max(), record1.seq, 0, index_parameters.s, index_parameters.t_syncmer(),
                                            map_param.q,
                                            map_param.max_dist);
 
     std::transform(record2.seq.begin(), record2.seq.end(), record2.seq.begin(), ::toupper);
-    query_mers2 = seq_to_randstrobes2_read(index_parameters.k, map_param.w_min, map_param.w_max, record2.seq, 0, index_parameters.s, map_param.t_syncmer,
+    query_mers2 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min(), index_parameters.w_max(), record2.seq, 0, index_parameters.s, index_parameters.t_syncmer(),
                                            map_param.q,
                                            map_param.max_dist);
 
@@ -2658,7 +2658,7 @@ void align_SE_read(
         // generate mers here
         std::transform(record.seq.begin(), record.seq.end(), record.seq.begin(), ::toupper);
         auto strobe_start = std::chrono::high_resolution_clock::now();
-        query_mers = seq_to_randstrobes2_read(index_parameters.k, map_param.w_min, map_param.w_max, record.seq, q_id, index_parameters.s, map_param.t_syncmer, map_param.q, map_param.max_dist);
+        query_mers = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min(), index_parameters.w_max(), record.seq, q_id, index_parameters.s, index_parameters.t_syncmer(), map_param.q, map_param.max_dist);
         auto strobe_finish = std::chrono::high_resolution_clock::now();
         statistics.tot_construct_strobemers += strobe_finish - strobe_start;
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -2549,12 +2549,12 @@ void align_PE_read(
     auto strobe_start = std::chrono::high_resolution_clock::now();
 
     std::transform(record1.seq.begin(), record1.seq.end(), record1.seq.begin(), ::toupper);
-    query_mers1 = seq_to_randstrobes2_read(map_param.n, index_parameters.k, map_param.w_min, map_param.w_max, record1.seq, 0, index_parameters.s, map_param.t_syncmer,
+    query_mers1 = seq_to_randstrobes2_read(index_parameters.k, map_param.w_min, map_param.w_max, record1.seq, 0, index_parameters.s, map_param.t_syncmer,
                                            map_param.q,
                                            map_param.max_dist);
 
     std::transform(record2.seq.begin(), record2.seq.end(), record2.seq.begin(), ::toupper);
-    query_mers2 = seq_to_randstrobes2_read(map_param.n, index_parameters.k, map_param.w_min, map_param.w_max, record2.seq, 0, index_parameters.s, map_param.t_syncmer,
+    query_mers2 = seq_to_randstrobes2_read(index_parameters.k, map_param.w_min, map_param.w_max, record2.seq, 0, index_parameters.s, map_param.t_syncmer,
                                            map_param.q,
                                            map_param.max_dist);
 
@@ -2658,7 +2658,7 @@ void align_SE_read(
         // generate mers here
         std::transform(record.seq.begin(), record.seq.end(), record.seq.begin(), ::toupper);
         auto strobe_start = std::chrono::high_resolution_clock::now();
-        query_mers = seq_to_randstrobes2_read(map_param.n, index_parameters.k, map_param.w_min, map_param.w_max, record.seq, q_id, index_parameters.s, map_param.t_syncmer, map_param.q, map_param.max_dist);
+        query_mers = seq_to_randstrobes2_read(index_parameters.k, map_param.w_min, map_param.w_max, record.seq, q_id, index_parameters.s, map_param.t_syncmer, map_param.q, map_param.max_dist);
         auto strobe_finish = std::chrono::high_resolution_clock::now();
         statistics.tot_construct_strobemers += strobe_finish - strobe_start;
 

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -53,9 +53,9 @@ struct AlignmentStatistics {
 };
 
 
-void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, AlignmentStatistics& statistics, i_dist_est& isize_est, alignment_params& aln_params, mapping_params& map_param, const References& references, const StrobemerIndex& index);
+void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, AlignmentStatistics& statistics, i_dist_est& isize_est, alignment_params& aln_params, mapping_params& map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
 
-void align_SE_read(klibpp::KSeq& record, std::string& outstring, AlignmentStatistics& statistics, alignment_params& aln_params, mapping_params& map_param, const References& references, const StrobemerIndex& index);
+void align_SE_read(klibpp::KSeq& record, std::string& outstring, AlignmentStatistics& statistics, alignment_params& aln_params, mapping_params& map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
 
 
 #endif

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -53,9 +53,9 @@ struct AlignmentStatistics {
 };
 
 
-void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, AlignmentStatistics& statistics, i_dist_est& isize_est, alignment_params& aln_params, mapping_params& map_param, const References& references, kmer_lookup& mers_index, mers_vector& flat_vector);
+void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, AlignmentStatistics& statistics, i_dist_est& isize_est, alignment_params& aln_params, mapping_params& map_param, const References& references, const StrobemerIndex& index);
 
-void align_SE_read(klibpp::KSeq& record, std::string& outstring, AlignmentStatistics& statistics, alignment_params& aln_params, mapping_params& map_param, const References& references, kmer_lookup& mers_index, mers_vector& flat_vector);
+void align_SE_read(klibpp::KSeq& record, std::string& outstring, AlignmentStatistics& statistics, alignment_params& aln_params, mapping_params& map_param, const References& references, const StrobemerIndex& index);
 
 
 #endif

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -53,9 +53,9 @@ struct AlignmentStatistics {
 };
 
 
-void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, AlignmentStatistics& statistics, i_dist_est& isize_est, alignment_params& aln_params, mapping_params& map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
+void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, AlignmentStatistics& statistics, i_dist_est& isize_est, const alignment_params& aln_params, const mapping_params& map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
 
-void align_SE_read(klibpp::KSeq& record, std::string& outstring, AlignmentStatistics& statistics, alignment_params& aln_params, mapping_params& map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
+void align_SE_read(klibpp::KSeq& record, std::string& outstring, AlignmentStatistics& statistics, const alignment_params& aln_params, const mapping_params& map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
 
 
 #endif

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -78,14 +78,11 @@ std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_li
     mapping_params map_param;
     IndexParameters index_parameters;
     map_param.max_secondary = 0;
-    index_parameters.k = 20;
-    index_parameters.s = index_parameters.k - 4;
+
     map_param.f = 0.0002;
     map_param.R = 2;
     map_param.dropoff_threshold = 0.5;
     map_param.maxTries = 20;
-    index_parameters.l = 0;
-    index_parameters.u = 7;
     map_param.r = 150;
     map_param.max_dist = std::min(map_param.r - 50, 255);
     map_param.is_sam_out = true;  // true: align, false: map

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -78,7 +78,6 @@ std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_li
     mapping_params map_param;
     IndexParameters index_parameters;
     map_param.max_secondary = 0;
-    map_param.n = 2;
     index_parameters.k = 20;
     index_parameters.s = index_parameters.k - 4;
     map_param.f = 0.0002;

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -86,7 +86,6 @@ std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_li
     map_param.maxTries = 20;
     index_parameters.l = 0;
     index_parameters.u = 7;
-    map_param.c = 8;
     map_param.r = 150;
     map_param.max_dist = std::min(map_param.r - 50, 255);
     map_param.is_sam_out = true;  // true: align, false: map
@@ -108,7 +107,7 @@ std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_li
     if (l) { index_parameters.l = args::get(l); }
     if (u) { index_parameters.u = args::get(u); }
     if (s) { index_parameters.s = args::get(s); opt.s_set = true; }
-    if (c) { map_param.c = args::get(c); }
+    if (c) { opt.c = args::get(c); }
 
     // Alignment
     // if (n) { n = args::get(n); }

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -4,7 +4,7 @@
 #include "version.hpp"
 
 
-std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_line_arguments(int argc, char **argv) {
+std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int argc, char **argv) {
 
     args::ArgumentParser parser("StrobeAlign " VERSION_STRING);
     parser.helpParams.showTerminator = false;
@@ -76,7 +76,6 @@ std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_li
     CommandLineOptions opt;
 
     mapping_params map_param;
-    IndexParameters index_parameters;
     map_param.max_secondary = 0;
 
     map_param.f = 0.0002;
@@ -100,10 +99,10 @@ std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_li
     // Seeding
     if (r) { map_param.r = args::get(r); opt.r_set = true; }
     if (m) { opt.max_seed_len = args::get(m); opt.max_seed_len_set = true; }
-    if (k) { index_parameters.k = args::get(k); opt.k_set = true; }
-    if (l) { index_parameters.l = args::get(l); }
-    if (u) { index_parameters.u = args::get(u); }
-    if (s) { index_parameters.s = args::get(s); opt.s_set = true; }
+    if (k) { opt.k = args::get(k); opt.k_set = true; }
+    if (l) { opt.l = args::get(l); }
+    if (u) { opt.u = args::get(u); }
+    if (s) { opt.s = args::get(s); opt.s_set = true; }
     if (c) { opt.c = args::get(c); }
 
     // Alignment
@@ -137,5 +136,5 @@ std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_li
         // exit(1);
     }
 
-    return std::make_tuple(opt, map_param, index_parameters);
+    return std::make_pair(opt, map_param);
 }

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -4,7 +4,7 @@
 #include "version.hpp"
 
 
-std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int argc, char **argv) {
+std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_line_arguments(int argc, char **argv) {
 
     args::ArgumentParser parser("StrobeAlign " VERSION_STRING);
     parser.helpParams.showTerminator = false;
@@ -76,16 +76,17 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     CommandLineOptions opt;
 
     mapping_params map_param;
+    IndexParameters index_parameters;
     map_param.max_secondary = 0;
     map_param.n = 2;
-    map_param.k = 20;
-    map_param.s = map_param.k - 4;
+    index_parameters.k = 20;
+    index_parameters.s = index_parameters.k - 4;
     map_param.f = 0.0002;
     map_param.R = 2;
     map_param.dropoff_threshold = 0.5;
     map_param.maxTries = 20;
-    map_param.l = 0;
-    map_param.u = 7;
+    index_parameters.l = 0;
+    index_parameters.u = 7;
     map_param.c = 8;
     map_param.r = 150;
     map_param.max_dist = std::min(map_param.r - 50, 255);
@@ -104,11 +105,11 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     // Seeding
     if (r) { map_param.r = args::get(r); opt.r_set = true; }
     if (m) { opt.max_seed_len = args::get(m); opt.max_seed_len_set = true; }
-    if (k) { map_param.k = args::get(k); opt.k_set = true; }
-    if (l) { map_param.l = args::get(l); }
-    if (u) { map_param.u = args::get(u); }
+    if (k) { index_parameters.k = args::get(k); opt.k_set = true; }
+    if (l) { index_parameters.l = args::get(l); }
+    if (u) { index_parameters.u = args::get(u); }
+    if (s) { index_parameters.s = args::get(s); opt.s_set = true; }
     if (c) { map_param.c = args::get(c); }
-    if (s) { map_param.s = args::get(s); opt.s_set = true; }
 
     // Alignment
     // if (n) { n = args::get(n); }
@@ -141,5 +142,5 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
         // exit(1);
     }
 
-    return std::make_pair(opt, map_param);
+    return std::make_tuple(opt, map_param, index_parameters);
 }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -11,6 +11,7 @@ struct CommandLineOptions {
     int B { 8 };
     int O { 12 };
     int E { 1 };
+    int c = 8;
     int max_seed_len;
     std::string output_file_name;
     std::string logfile_name { "log.csv" };

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -7,6 +7,14 @@
 #include "index.hpp"
 
 struct CommandLineOptions {
+    // Index parameters
+    bool k_set { false };
+    bool s_set{ false };
+    int k { 20 };
+    int s { 16 };
+    int u { 7 };
+    int l { 0 };
+
     int A { 2 };
     int B { 8 };
     int O { 12 };
@@ -21,16 +29,14 @@ struct CommandLineOptions {
     std::string reads_filename1;
     std::string reads_filename2;
     bool is_SE { true };
-    bool k_set { false };
     bool write_to_stdout { true };
     bool index_log { false };
     bool r_set { false };
     bool max_seed_len_set { false };
-    bool s_set{ false };
     bool only_gen_index{ false };
     std::string index_out_filename;
 };
 
-std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_line_arguments(int argc, char **argv);
+std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int argc, char **argv);
 
 #endif

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -30,6 +30,6 @@ struct CommandLineOptions {
     std::string index_out_filename;
 };
 
-std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int argc, char **argv);
+std::tuple<CommandLineOptions, mapping_params, IndexParameters> parse_command_line_arguments(int argc, char **argv);
 
 #endif

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -3,9 +3,9 @@
 
 #include <stdexcept>
 
-class BadMappingParameter: public std::runtime_error {
+class BadParameter: public std::runtime_error {
 public:
-    BadMappingParameter( const char* what_arg ) : std::runtime_error(what_arg) {};
+    BadParameter( const char* what_arg ) : std::runtime_error(what_arg) {};
 };
 
 class InvalidFasta : public std::runtime_error {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -299,7 +299,7 @@ ind_mers_vector StrobemerIndex::generate_seeds(const References& references, con
     logger.debug() << "ref vector approximate size: " << approx_vec_size << std::endl;
     ind_flat_vector.reserve(approx_vec_size);
     for(size_t i = 0; i < references.size(); ++i) {
-        seq_to_randstrobes2(ind_flat_vector, map_param.n, index_parameters.k, map_param.w_min, map_param.w_max, references.sequences[i], i, index_parameters.s, map_param.t_syncmer, map_param.q, map_param.max_dist);
+        seq_to_randstrobes2(ind_flat_vector, index_parameters.k, map_param.w_min, map_param.w_max, references.sequences[i], i, index_parameters.s, map_param.t_syncmer, map_param.q, map_param.max_dist);
     }
     logger.debug() << "Ref vector actual size: " << ind_flat_vector.size() << std::endl;
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -181,7 +181,7 @@ void StrobemerIndex::write(const References& references, const std::string& file
         ofs.write(reinterpret_cast<const char*>(&p.first), sizeof(p.first));
         ofs.write(reinterpret_cast<const char*>(&p.second), sizeof(p.second));
     }
-};
+}
 
 void StrobemerIndex::read(References& references, const std::string& filename) {
     std::ifstream ifs(filename, std::ios::binary);
@@ -249,10 +249,10 @@ void StrobemerIndex::read(References& references, const std::string& filename) {
         }
         left_to_read -= to_read;
     }
-};
+}
 
 
-void StrobemerIndex::populate(const References& references, mapping_params& map_param) {
+unsigned int StrobemerIndex::populate(const References& references, const mapping_params& map_param) {
     auto start_flat_vector = high_resolution_clock::now();
     hash_vector h_vector;
     {
@@ -284,9 +284,11 @@ void StrobemerIndex::populate(const References& references, mapping_params& map_
 
     mers_index.reserve(unique_mers);
     // construct index over flat array
-    map_param.filter_cutoff = index_vector(h_vector, mers_index, map_param.f);
+    auto filter_cutoff = index_vector(h_vector, mers_index, map_param.f);
     std::chrono::duration<double> elapsed_hash_index = high_resolution_clock::now() - start_hash_index;
     logger.info() << "Total time generating hash table index: " << elapsed_hash_index.count() << " s" <<  std::endl;
+
+    return filter_cutoff;
 }
 
 ind_mers_vector StrobemerIndex::generate_seeds(const References& references, const mapping_params& map_param) const

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -299,7 +299,7 @@ ind_mers_vector StrobemerIndex::generate_seeds(const References& references, con
     logger.debug() << "ref vector approximate size: " << approx_vec_size << std::endl;
     ind_flat_vector.reserve(approx_vec_size);
     for(size_t i = 0; i < references.size(); ++i) {
-        seq_to_randstrobes2(ind_flat_vector, index_parameters.k, map_param.w_min, map_param.w_max, references.sequences[i], i, index_parameters.s, map_param.t_syncmer, map_param.q, map_param.max_dist);
+        seq_to_randstrobes2(ind_flat_vector, index_parameters.k, index_parameters.w_min(), index_parameters.w_max(), references.sequences[i], i, index_parameters.s, index_parameters.t_syncmer(), map_param.q, map_param.max_dist);
     }
     logger.debug() << "Ref vector actual size: " << ind_flat_vector.size() << std::endl;
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -252,7 +252,7 @@ void StrobemerIndex::read(References& references, const std::string& filename) {
 }
 
 
-unsigned int StrobemerIndex::populate(const References& references, const mapping_params& map_param) {
+void StrobemerIndex::populate(const References& references, const mapping_params& map_param) {
     auto start_flat_vector = high_resolution_clock::now();
     hash_vector h_vector;
     {
@@ -284,11 +284,9 @@ unsigned int StrobemerIndex::populate(const References& references, const mappin
 
     mers_index.reserve(unique_mers);
     // construct index over flat array
-    auto filter_cutoff = index_vector(h_vector, mers_index, map_param.f);
+    filter_cutoff = index_vector(h_vector, mers_index, map_param.f);
     std::chrono::duration<double> elapsed_hash_index = high_resolution_clock::now() - start_hash_index;
     logger.info() << "Total time generating hash table index: " << elapsed_hash_index.count() << " s" <<  std::endl;
-
-    return filter_cutoff;
 }
 
 ind_mers_vector StrobemerIndex::generate_seeds(const References& references, const mapping_params& map_param) const

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -252,11 +252,11 @@ void StrobemerIndex::read(References& references, const std::string& filename) {
 }
 
 
-void StrobemerIndex::populate(const References& references, const mapping_params& map_param) {
+void StrobemerIndex::populate(const References& references, const mapping_params& map_param, const IndexParameters& index_parameters) {
     auto start_flat_vector = high_resolution_clock::now();
     hash_vector h_vector;
     {
-        auto ind_flat_vector = generate_seeds(references, map_param);
+        auto ind_flat_vector = generate_seeds(references, map_param, index_parameters);
 
         //Split up the sorted vector into a vector with the hash codes and the flat vector to keep in the index.
         //The hash codes are only needed when generating the index and can be discarded afterwards.
@@ -289,17 +289,17 @@ void StrobemerIndex::populate(const References& references, const mapping_params
     logger.info() << "Total time generating hash table index: " << elapsed_hash_index.count() << " s" <<  std::endl;
 }
 
-ind_mers_vector StrobemerIndex::generate_seeds(const References& references, const mapping_params& map_param) const
+ind_mers_vector StrobemerIndex::generate_seeds(const References& references, const mapping_params& map_param, const IndexParameters& index_parameters) const
 {
     auto start_flat_vector = high_resolution_clock::now();
 
     ind_mers_vector ind_flat_vector; //includes hash - for sorting, will be discarded later
-    int expected_sampling = map_param.k - map_param.s + 1;
+    int expected_sampling = index_parameters.k - index_parameters.s + 1;
     int approx_vec_size = references.total_length() / expected_sampling;
     logger.debug() << "ref vector approximate size: " << approx_vec_size << std::endl;
     ind_flat_vector.reserve(approx_vec_size);
     for(size_t i = 0; i < references.size(); ++i) {
-        seq_to_randstrobes2(ind_flat_vector, map_param.n, map_param.k, map_param.w_min, map_param.w_max, references.sequences[i], i, map_param.s, map_param.t_syncmer, map_param.q, map_param.max_dist);
+        seq_to_randstrobes2(ind_flat_vector, map_param.n, index_parameters.k, map_param.w_min, map_param.w_max, references.sequences[i], i, index_parameters.s, map_param.t_syncmer, map_param.q, map_param.max_dist);
     }
     logger.debug() << "Ref vector actual size: " << ind_flat_vector.size() << std::endl;
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -89,11 +89,12 @@ public:
 };
 
 /* Settings that influence index creation */
-struct IndexParameters {
-    int k;
-    int s;
-    int l;
-    int u;
+class IndexParameters {
+public:
+    int k { 20 };
+    int s { 16 };
+    int u { 7 };
+    int l { 0 };
 
     void verify() const {
         if (k <= 7 || k > 32) {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -139,7 +139,7 @@ struct StrobemerIndex {
 
     void write(const References& references, const std::string& filename) const;
     void read(References& references, const std::string& filename);
-    void populate(const References& references, mapping_params& map_param);
+    unsigned int populate(const References& references, const mapping_params& map_param);
 private:
     ind_mers_vector generate_seeds(const References& references, const mapping_params& map_param) const;
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -88,20 +88,36 @@ public:
     void update(int dist);
 };
 
+/* Settings that influence index creation */
+struct IndexParameters {
+    int k;
+    int s;
+    int l;
+    int u;
+
+    void verify() const {
+        if (k <= 7 || k > 32) {
+            throw BadParameter("k not in [8,32]");
+        }
+        if (s > k) {
+            throw BadParameter("s is larger than k");
+        }
+        if ((k - s) % 2 != 0) {
+            throw BadParameter("(k - s) should be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...");
+        }
+    }
+};
+
 struct mapping_params {
     uint64_t q;
     int n;
-    int k;
-    int s;
+    int r;
     int t_syncmer;
     int w_min;
     int w_max;
     int max_secondary;
     float dropoff_threshold;
-    int r;
     int m;
-    int l;
-    int u;
     int c;
     float f;
     int S;
@@ -113,18 +129,9 @@ struct mapping_params {
     int rescue_cutoff;
     bool is_sam_out;
 
-    void verify(){
-        if (k <= 7 || k > 32) {
-            throw BadMappingParameter("k not in [8,32]");
-        }
-        if (s > k) {
-            throw BadMappingParameter("s is larger than k");
-        }
-        if ((k - s) % 2 != 0) {
-            throw BadMappingParameter("(k - s) should be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...");
-        }
+    void verify() const {
         if (max_dist > 255) {
-            throw BadMappingParameter("maximum seed length (-m <max_dist>) is larger than 255");
+            throw BadParameter("maximum seed length (-m <max_dist>) is larger than 255");
         }
     }
 };
@@ -138,11 +145,11 @@ struct StrobemerIndex {
 
     void write(const References& references, const std::string& filename) const;
     void read(References& references, const std::string& filename);
-    void populate(const References& references, const mapping_params& map_param);
+    void populate(const References& references, const mapping_params& map_param, const IndexParameters& index_parameters);
 private:
-    ind_mers_vector generate_seeds(const References& references, const mapping_params& map_param) const;
+    ind_mers_vector generate_seeds(const References& references, const mapping_params& map_param, const IndexParameters& index_parameters) const;
 
 };
 
 
-#endif /* index_hpp */
+#endif

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -119,6 +119,38 @@ public:
     int w_max() const {
         return k / (k - s + 1) + u;
     }
+
+    /* Adjust l, u, and optionally k and/or s depending on read length */
+    void adjust_depending_on_read_length(int read_length, bool overwrite_k, bool overwrite_s) {
+        struct settings {
+            int r_threshold;
+            int k;
+            int s_offset;
+            int l;
+            int u;
+        };
+        std::vector<settings> d = {
+            settings {75, 20, -4, -4, 2},
+            settings {125, 20, -4, -2, 2},
+            settings {175, 20, -4, 1, 7},
+            settings {275, 20, -4, 4, 13},
+            settings {375, 22, -4, 2, 12},
+            settings {std::numeric_limits<int>::max(), 23, -6, 2, 12},
+        };
+        for (const auto& v : d) {
+            if (read_length <= v.r_threshold) {
+                if (overwrite_k) {
+                    this->k = v.k;
+                }
+                if (overwrite_s) {
+                    this->s = this->k + v.s_offset;
+                }
+                this->l = v.l;
+                this->u = v.u;
+                break;
+            }
+        }
+    }
 };
 
 struct mapping_params {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -110,7 +110,6 @@ struct IndexParameters {
 
 struct mapping_params {
     uint64_t q;
-    int n;
     int r;
     int t_syncmer;
     int w_min;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -126,7 +126,6 @@ struct mapping_params {
     int max_secondary;
     float dropoff_threshold;
     int m;
-    int c;
     float f;
     int S;
     int M;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -111,7 +111,6 @@ struct mapping_params {
     int maxTries;
     int max_seed_len;
     int rescue_cutoff;
-    unsigned int filter_cutoff;
     bool is_sam_out;
 
     void verify(){
@@ -139,7 +138,7 @@ struct StrobemerIndex {
 
     void write(const References& references, const std::string& filename) const;
     void read(References& references, const std::string& filename);
-    unsigned int populate(const References& references, const mapping_params& map_param);
+    void populate(const References& references, const mapping_params& map_param);
 private:
     ind_mers_vector generate_seeds(const References& references, const mapping_params& map_param) const;
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -106,14 +106,23 @@ struct IndexParameters {
             throw BadParameter("(k - s) should be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...");
         }
     }
+
+    int t_syncmer() const {
+        return (k - s) / 2 + 1;
+    }
+
+    int w_min() const {
+        return std::max(1, k / (k - s + 1) + l);
+    }
+
+    int w_max() const {
+        return k / (k - s + 1) + u;
+    }
 };
 
 struct mapping_params {
     uint64_t q;
     int r;
-    int t_syncmer;
-    int w_min;
-    int w_max;
     int max_secondary;
     float dropoff_threshold;
     int m;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,38 +170,6 @@ int estimate_read_length(std::string filename1, std::string filename2) {
     }
 }
 
-/* Adjust parameters.{k,s,l,u} depending on read length */
-void adjust_index_params_depending_on_read_length(int read_length, IndexParameters &parameters, const CommandLineOptions &opt) {
-    struct settings {
-        int r_threshold;
-        int k;
-        int s_offset;
-        int l;
-        int u;
-    };
-    std::vector<settings> d = {
-        settings {75, 20, -4, -4, 2},
-        settings {125, 20, -4, -2, 2},
-        settings {175, 20, -4, 1, 7},
-        settings {275, 20, -4, 4, 13},
-        settings {375, 22, -4, 2, 12},
-        settings {std::numeric_limits<int>::max(), 23, -6, 2, 12},
-    };
-    for (const auto& v : d) {
-        if (read_length <= v.r_threshold) {
-            if (!opt.k_set) {
-                parameters.k = v.k;
-            }
-            if (!opt.s_set) {
-                parameters.s = parameters.k + v.s_offset;
-            }
-            parameters.l = v.l;
-            parameters.u = v.u;
-            break;
-        }
-    }
-}
-
 
 /*
  * Return formatted SAM header as a string
@@ -226,7 +194,7 @@ int main(int argc, char **argv)
     if (!opt.r_set) {
         map_param.r = estimate_read_length(opt.reads_filename1, opt.reads_filename2);
     }
-    adjust_index_params_depending_on_read_length(map_param.r, index_parameters, opt);
+    index_parameters.adjust_depending_on_read_length(map_param.r, !opt.k_set, !opt.s_set);
 
     if (!opt.max_seed_len_set){
         map_param.max_dist = std::max(map_param.r - 70, index_parameters.k);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,15 +187,13 @@ int main(int argc, char **argv)
 {
     CommandLineOptions opt;
     mapping_params map_param;
-    IndexParameters index_parameters;
-    std::tie(opt, map_param, index_parameters) = parse_command_line_arguments(argc, argv);
+    std::tie(opt, map_param) = parse_command_line_arguments(argc, argv);
 
     logger.set_level(opt.verbose ? LOG_DEBUG : LOG_INFO);
     if (!opt.r_set) {
         map_param.r = estimate_read_length(opt.reads_filename1, opt.reads_filename2);
     }
-    index_parameters.adjust_depending_on_read_length(map_param.r, !opt.k_set, !opt.s_set);
-
+    IndexParameters index_parameters = IndexParameters::from_read_length(map_param.r, opt.k_set ? opt.k : -1, opt.s_set ? opt.s : -1);
     if (!opt.max_seed_len_set){
         map_param.max_dist = std::max(map_param.r - 70, index_parameters.k);
         map_param.max_dist = std::min(255, map_param.max_dist);
@@ -218,14 +216,14 @@ int main(int argc, char **argv)
     logger.debug() << "Using" << std::endl
         << "k: " << index_parameters.k << std::endl
         << "s: " << index_parameters.s << std::endl
-        << "w_min: " << index_parameters.w_min() << std::endl
-        << "w_max: " << index_parameters.w_max() << std::endl
+        << "w_min: " << index_parameters.w_min << std::endl
+        << "w_max: " << index_parameters.w_max << std::endl
         << "Read length (r): " << map_param.r << std::endl
         << "Maximum seed length: " << map_param.max_dist + index_parameters.k << std::endl
         << "Threads: " << opt.n_threads << std::endl
         << "R: " << map_param.R << std::endl
-        << "Expected [w_min, w_max] in #syncmers: [" << index_parameters.w_min() << ", " << index_parameters.w_max() << "]" << std::endl
-        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_min() << ", " << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_max() << "]" << std::endl
+        << "Expected [w_min, w_max] in #syncmers: [" << index_parameters.w_min << ", " << index_parameters.w_max << "]" << std::endl
+        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_min << ", " << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_max << "]" << std::endl
         << "A: " << opt.A << std::endl
         << "B: " << opt.B << std::endl
         << "O: " << opt.O << std::endl

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,9 +300,7 @@ int main (int argc, char **argv)
             return EXIT_FAILURE;
         }
 
-        auto filter_cutoff = index.populate(references, map_param);
-        map_param.filter_cutoff = filter_cutoff;
-        index.filter_cutoff = map_param.filter_cutoff;
+        index.populate(references, map_param);
 
         // Record index creation end time
         std::chrono::duration<double> elapsed = high_resolution_clock::now() - start;
@@ -334,8 +332,6 @@ int main (int argc, char **argv)
     
     if (!(opt.only_gen_index && opt.reads_filename1.empty())) { // If the program was called with the -i flag and the fastqs are not specified, we don't run any alignment
         
-        map_param.filter_cutoff = index.filter_cutoff; //This is calculated when building the filter and needs to be filled in
-
         // Record matching time
         auto start_aln_part = high_resolution_clock::now();
 
@@ -387,7 +383,7 @@ int main (int argc, char **argv)
                 std::thread consumer(perform_task_SE, std::ref(input_buffer), std::ref(output_buffer),
                     std::ref(log_stats_vec), std::ref(aln_params),
                     std::ref(map_param), std::ref(references),
-                    std::ref(index.mers_index), std::ref(index.flat_vector));
+                    std::ref(index));
                 workers.push_back(std::move(consumer));
             }
 
@@ -417,7 +413,7 @@ int main (int argc, char **argv)
                 std::thread consumer(perform_task_PE, std::ref(input_buffer), std::ref(output_buffer),
                     std::ref(log_stats_vec), std::ref(isize_est_vec), std::ref(aln_params),
                     std::ref(map_param), std::ref(references),
-                    std::ref(index.mers_index), std::ref(index.flat_vector));
+                    std::ref(index));
                 workers.push_back(std::move(consumer));
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,10 +242,6 @@ int main (int argc, char **argv)
         map_param.q = pow(2, 8) - 1;
     }
 
-    map_param.w_min = std::max(1, index_parameters.k / (index_parameters.k - index_parameters.s + 1) + index_parameters.l);
-    map_param.w_max = index_parameters.k / (index_parameters.k - index_parameters.s+1) + index_parameters.u;
-    map_param.t_syncmer = (index_parameters.k - index_parameters.s)/2 + 1;
-
     alignment_params aln_params;
     aln_params.match = opt.A;
     aln_params.mismatch = opt.B;
@@ -255,14 +251,14 @@ int main (int argc, char **argv)
     logger.debug() << "Using" << std::endl
         << "k: " << index_parameters.k << std::endl
         << "s: " << index_parameters.s << std::endl
-        << "w_min: " << map_param.w_min << std::endl
-        << "w_max: " << map_param.w_max << std::endl
+        << "w_min: " << index_parameters.w_min() << std::endl
+        << "w_max: " << index_parameters.w_max() << std::endl
         << "Read length (r): " << map_param.r << std::endl
         << "Maximum seed length: " << map_param.max_dist + index_parameters.k << std::endl
         << "Threads: " << opt.n_threads << std::endl
         << "R: " << map_param.R << std::endl
-        << "Expected [w_min, w_max] in #syncmers: [" << map_param.w_min << ", " << map_param.w_max << "]" << std::endl
-        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.k - index_parameters.s + 1) * map_param.w_min << ", " << (index_parameters.k - index_parameters.s + 1) * map_param.w_max << "]" << std::endl
+        << "Expected [w_min, w_max] in #syncmers: [" << index_parameters.w_min() << ", " << index_parameters.w_max() << "]" << std::endl
+        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_min() << ", " << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_max() << "]" << std::endl
         << "A: " << opt.A << std::endl
         << "B: " << opt.B << std::endl
         << "O: " << opt.O << std::endl

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,6 +170,7 @@ int estimate_read_length(std::string filename1, std::string filename2) {
     }
 }
 
+/* Adjust map_param.{k,s,l,u} depending on read length */
 void adjust_mapping_params_depending_on_read_length(mapping_params &map_param, const CommandLineOptions &opt) {
     struct settings {
         int r_threshold;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ using std::chrono::high_resolution_clock;
 static Logger& logger = Logger::get();
 
 
-static void print_diagnostics(mers_vector &ref_mers, kmer_lookup &mers_index, std::string logfile_name, int k, int m) {
+static void print_diagnostics(const StrobemerIndex &index, const std::string& logfile_name, int k) {
     // Prins to csv file the statistics on the number of seeds of a particular length and what fraction of them them are unique in the index:
     // format:
     // seed_length, count, percentage_unique
@@ -54,13 +54,13 @@ static void print_diagnostics(mers_vector &ref_mers, kmer_lookup &mers_index, st
     uint64_t tot_seed_count_sq_1000_limit = 0;
 
     int seed_length;
-    for (auto &it : mers_index) {
+    for (auto &it : index.mers_index) {
         auto ref_mer = it.second;
         auto offset = ref_mer.offset;
         auto count = ref_mer.count;
 
         for (size_t j = offset; j < offset + count; ++j) {
-            auto r = ref_mers[j];
+            auto r = index.flat_vector[j];
             auto p = r.packed;
             int bit_alloc = 8;
             int mask=(1<<bit_alloc) - 1;
@@ -309,7 +309,7 @@ int main (int argc, char **argv)
         logger.info() << "Total time indexing: " << elapsed.count() << " s" << std::endl;
 
         if (opt.index_log) {
-            print_diagnostics(index.flat_vector, index.mers_index, opt.logfile_name, map_param.k, map_param.max_dist + map_param.k);
+            print_diagnostics(index, opt.logfile_name, map_param.k);
             logger.debug() << "Finished printing log stats" << std::endl;
         }
         

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,7 +215,7 @@ std::string sam_header(const References& references) {
     return out.str();
 }
 
-int main (int argc, char **argv)
+int main(int argc, char **argv)
 {
     CommandLineOptions opt;
     mapping_params map_param;
@@ -235,12 +235,11 @@ int main (int argc, char **argv)
         map_param.max_dist = opt.max_seed_len - index_parameters.k; //convert to distance in start positions
     }
 
-    if (map_param.c < 64 && map_param.c > 0) {
-        map_param.q = pow(2, map_param.c) - 1;
-    } else {
-        logger.warning() << "Parameter c must be greater than 0 and less than 64, setting c=8" << std::endl;
-        map_param.q = pow(2, 8) - 1;
+    if (opt.c >= 64 || opt.c <= 0) {
+        logger.error() << "Parameter c must be greater than 0 and less than 64" << std::endl;
+        return EXIT_FAILURE;
     }
+    map_param.q = pow(2, opt.c) - 1;
 
     alignment_params aln_params;
     aln_params.match = opt.A;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,11 +233,10 @@ int main (int argc, char **argv)
         map_param.max_dist = opt.max_seed_len - map_param.k; //convert to distance in start positions
     }
 
-
-    if ( (map_param.c < 64) && (map_param.c > 0)){
+    if (map_param.c < 64 && map_param.c > 0) {
         map_param.q = pow(2, map_param.c) - 1;
-    } else{
-        logger.warning() << "Warning wrong value for parameter c, setting c=8" << std::endl;
+    } else {
+        logger.warning() << "Parameter c must be greater than 0 and less than 64, setting c=8" << std::endl;
         map_param.q = pow(2, 8) - 1;
     }
 
@@ -301,7 +300,8 @@ int main (int argc, char **argv)
             return EXIT_FAILURE;
         }
 
-        index.populate(references, map_param);
+        auto filter_cutoff = index.populate(references, map_param);
+        map_param.filter_cutoff = filter_cutoff;
         index.filter_cutoff = map_param.filter_cutoff;
 
         // Record index creation end time
@@ -341,7 +341,7 @@ int main (int argc, char **argv)
 
         //    std::ifstream query_file(reads_filename);
 
-        map_param.rescue_cutoff = map_param.R < 100 ? map_param.R * map_param.filter_cutoff : 1000;
+        map_param.rescue_cutoff = map_param.R < 100 ? map_param.R * index.filter_cutoff : 1000;
         logger.debug() << "Using rescue cutoff: " << map_param.rescue_cutoff << std::endl;
 
         std::streambuf* buf;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,11 +82,11 @@ static void print_diagnostics(const StrobemerIndex &index, const std::string& lo
             }
         }
 
-        if ( (count == 1) & (seed_length < max_size) ) {
-            log_unique[seed_length] ++;
+        if (count == 1 && seed_length < max_size) {
+            log_unique[seed_length]++;
         }
-        if ( (count >= 10) & (seed_length < max_size) ) {
-            log_repetitive[seed_length] ++;
+        if (count >= 10 && seed_length < max_size) {
+            log_repetitive[seed_length]++;
         }
     }
 

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -77,6 +77,7 @@ inline bool align_reads_PE(
     i_dist_est &isize_est,
     alignment_params &aln_params,
     mapping_params &map_param,
+    const IndexParameters& index_parameters,
     const References& references,
     const StrobemerIndex& index
 ) {
@@ -93,7 +94,7 @@ inline bool align_reads_PE(
         auto record2 = records2[i];
 
         align_PE_read(record1, record2, sam_out, statistics, isize_est, aln_params,
-                      map_param, references, index);
+                      map_param, index_parameters, references, index);
     }
 //    std::cerr << isize_est_vec[thread_id].mu << " " << isize_est_vec[thread_id].sigma << "\n";
 //    std::cerr << log_stats_vec[thread_id].tot_all_tried << " " << log_stats_vec[thread_id].tot_ksw_aligned << "\n";
@@ -110,6 +111,7 @@ void perform_task_PE(
     std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec,
     alignment_params &aln_params,
     mapping_params &map_param,
+    const IndexParameters& index_parameters,
     const References& references,
     const StrobemerIndex& index
 ) {
@@ -125,7 +127,7 @@ void perform_task_PE(
         input_buffer.read_records_PE(records1, records2, log_stats_vec[thread_id]);
         eof = align_reads_PE(input_buffer, output_buffer, records1, records2,
                            log_stats_vec[thread_id], isize_est_vec[thread_id],
-                          aln_params, map_param, references, index);
+                          aln_params, map_param, index_parameters, references, index);
 
         if (eof) {
             break;
@@ -141,6 +143,7 @@ inline bool align_reads_SE(
     AlignmentStatistics &statistics,
     alignment_params &aln_params,
     mapping_params &map_param,
+    const IndexParameters& index_parameters,
     const References& references,
     const StrobemerIndex& index
 ) {
@@ -155,7 +158,7 @@ inline bool align_reads_SE(
         auto record1 = records[i];
 
         align_SE_read(record1, sam_out,  statistics, aln_params,
-                      map_param, references, index);
+                      map_param, index_parameters, references, index);
     }
 //    std::cerr << isize_est_vec[thread_id].mu << " " << isize_est_vec[thread_id].sigma << "\n";
 //    std::cerr << log_stats_vec[thread_id].tot_all_tried << " " << log_stats_vec[thread_id].tot_ksw_aligned << "\n";
@@ -172,6 +175,7 @@ void perform_task_SE(
     AlignmentStatistics> &log_stats_vec,
     alignment_params &aln_params,
     mapping_params &map_param,
+    const IndexParameters& index_parameters,
     const References& references,
     const StrobemerIndex& index
 ) {
@@ -186,7 +190,7 @@ void perform_task_SE(
         input_buffer.read_records_SE(records1, log_stats_vec[thread_id]);
         eof = align_reads_SE(input_buffer, output_buffer, records1,
                              log_stats_vec[thread_id],
-                             aln_params, map_param, references, index);
+                             aln_params, map_param, index_parameters, references, index);
 
         if (eof){
             break;

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -62,12 +62,12 @@ public:
 };
 
 
-
 void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                   std::unordered_map<std::thread::id, AlignmentStatistics> &log_stats_vec, std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec, alignment_params &aln_params,
-                  mapping_params &map_param, const References& references, kmer_lookup &mers_index, mers_vector &flat_vector);
+                  mapping_params &map_param, const References& references, const StrobemerIndex& index);
 
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                      std::unordered_map<std::thread::id, AlignmentStatistics> &log_stats_vec, alignment_params &aln_params,
-                     mapping_params &map_param, const References& references, kmer_lookup &mers_index, mers_vector &flat_vector);
-#endif // pc_hpp_
+                     mapping_params &map_param, const References& references, const StrobemerIndex& index);
+
+#endif

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -64,10 +64,10 @@ public:
 
 void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                   std::unordered_map<std::thread::id, AlignmentStatistics> &log_stats_vec, std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec, alignment_params &aln_params,
-                  mapping_params &map_param, const References& references, const StrobemerIndex& index);
+                  mapping_params &map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
 
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                      std::unordered_map<std::thread::id, AlignmentStatistics> &log_stats_vec, alignment_params &aln_params,
-                     mapping_params &map_param, const References& references, const StrobemerIndex& index);
+                     mapping_params &map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
 
 #endif

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -215,7 +215,7 @@ static inline void get_next_strobe_dist_constraint(const std::vector<uint64_t> &
 
 
 
-void seq_to_randstrobes2(ind_mers_vector& flat_vector, int n, int k, int w_min, int w_max, const std::string &seq, int ref_index, int s, int t, uint64_t q, int max_dist)
+void seq_to_randstrobes2(ind_mers_vector& flat_vector, int k, int w_min, int w_max, const std::string &seq, int ref_index, int s, int t, uint64_t q, int max_dist)
 {
 
     if (seq.length() < w_max) {
@@ -313,7 +313,7 @@ void seq_to_randstrobes2(ind_mers_vector& flat_vector, int n, int k, int w_min, 
 //    std::cerr << randstrobes2.size() << " randstrobes generated" << '\n';
 }
 
-mers_vector_read seq_to_randstrobes2_read(int n, int k, int w_min, int w_max, const std::string& seq, unsigned int ref_index, int s, int t, uint64_t q, int max_dist)
+mers_vector_read seq_to_randstrobes2_read(int k, int w_min, int w_max, const std::string& seq, unsigned int ref_index, int s, int t, uint64_t q, int max_dist)
 {
     // this function differs from  the function seq_to_randstrobes2 which creating randstrobes for the reference.
     // The seq_to_randstrobes2 stores randstobes only in one direction from canonical syncmers.

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -217,7 +217,6 @@ static inline void get_next_strobe_dist_constraint(const std::vector<uint64_t> &
 
 void seq_to_randstrobes2(ind_mers_vector& flat_vector, int k, int w_min, int w_max, const std::string &seq, int ref_index, int s, int t, uint64_t q, int max_dist)
 {
-
     if (seq.length() < w_max) {
         return;
     }

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -31,7 +31,7 @@ struct QueryMer {
 
 typedef std::vector<QueryMer> mers_vector_read;
 
-void seq_to_randstrobes2(ind_mers_vector& flat_vector, int n, int k, int w_min, int w_max, const std::string &seq, int ref_index,          int s, int t, uint64_t q, int max_dist);
-mers_vector_read seq_to_randstrobes2_read(             int n, int k, int w_min, int w_max, const std::string &seq, unsigned int ref_index, int s, int t, uint64_t q, int max_dist);
+void seq_to_randstrobes2(ind_mers_vector& flat_vector, int k, int w_min, int w_max, const std::string &seq, int ref_index,          int s, int t, uint64_t q, int max_dist);
+mers_vector_read seq_to_randstrobes2_read(             int k, int w_min, int w_max, const std::string &seq, unsigned int ref_index, int s, int t, uint64_t q, int max_dist);
 
 #endif


### PR DESCRIPTION
Hopefully no logic changes, only refactoring.

- Pass `StrobemerIndex` to functions instead of two separate `kmer_lookup` and `mers_vector` objects. This cleans up some functions signatures nicely.
- Added a `IndexParameters` struct for all parameters that influence index creation.
- Move some parameters from `mapping_params` into `IndexParameters` (not all, yet)
- Make more parameters `const`

Adding the `IndexParameters` struct increases again the number of parameters for some functions, but I actually want to move the indexing parameters directly into the StrobemerIndex, and then the extra parameters disappear once more. I’m not sure whether that is actually possible, but in any case, I find it helpful to have index parameters in a different place than mapping parameters because we could then more easily store them along with the index on disk (and because it’s cleaner).