### PR TITLE
Make indexing independent of mapping_params

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -2582,14 +2582,14 @@ void align_PE_read(
     auto strobe_start = std::chrono::high_resolution_clock::now();
 
     std::transform(record1.seq.begin(), record1.seq.end(), record1.seq.begin(), ::toupper);
-    query_mers1 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record1.seq, 0, index_parameters.s, index_parameters.t_syncmer,
-                                           map_param.q,
-                                           index_parameters.max_dist);
+    query_mers1 = seq_to_randstrobes2_read(
+        index_parameters.k, index_parameters.w_min, index_parameters.w_max, record1.seq, 0, index_parameters.s, index_parameters.t_syncmer,
+        index_parameters.q, index_parameters.max_dist);
 
     std::transform(record2.seq.begin(), record2.seq.end(), record2.seq.begin(), ::toupper);
-    query_mers2 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record2.seq, 0, index_parameters.s, index_parameters.t_syncmer,
-                                           map_param.q,
-                                           index_parameters.max_dist);
+    query_mers2 = seq_to_randstrobes2_read(
+        index_parameters.k, index_parameters.w_min, index_parameters.w_max, record2.seq, 0, index_parameters.s, index_parameters.t_syncmer,
+        index_parameters.q, index_parameters.max_dist);
 
     auto strobe_finish = std::chrono::high_resolution_clock::now();
     statistics.tot_construct_strobemers += strobe_finish - strobe_start;
@@ -2691,7 +2691,7 @@ void align_SE_read(
         // generate mers here
         std::transform(record.seq.begin(), record.seq.end(), record.seq.begin(), ::toupper);
         auto strobe_start = std::chrono::high_resolution_clock::now();
-        query_mers = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record.seq, q_id, index_parameters.s, index_parameters.t_syncmer, map_param.q, index_parameters.max_dist);
+        query_mers = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record.seq, q_id, index_parameters.s, index_parameters.t_syncmer, index_parameters.q, index_parameters.max_dist);
         auto strobe_finish = std::chrono::high_resolution_clock::now();
         statistics.tot_construct_strobemers += strobe_finish - strobe_start;
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -2584,12 +2584,12 @@ void align_PE_read(
     std::transform(record1.seq.begin(), record1.seq.end(), record1.seq.begin(), ::toupper);
     query_mers1 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record1.seq, 0, index_parameters.s, index_parameters.t_syncmer,
                                            map_param.q,
-                                           map_param.max_dist);
+                                           index_parameters.max_dist);
 
     std::transform(record2.seq.begin(), record2.seq.end(), record2.seq.begin(), ::toupper);
     query_mers2 = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record2.seq, 0, index_parameters.s, index_parameters.t_syncmer,
                                            map_param.q,
-                                           map_param.max_dist);
+                                           index_parameters.max_dist);
 
     auto strobe_finish = std::chrono::high_resolution_clock::now();
     statistics.tot_construct_strobemers += strobe_finish - strobe_start;
@@ -2691,7 +2691,7 @@ void align_SE_read(
         // generate mers here
         std::transform(record.seq.begin(), record.seq.end(), record.seq.begin(), ::toupper);
         auto strobe_start = std::chrono::high_resolution_clock::now();
-        query_mers = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record.seq, q_id, index_parameters.s, index_parameters.t_syncmer, map_param.q, map_param.max_dist);
+        query_mers = seq_to_randstrobes2_read(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record.seq, q_id, index_parameters.s, index_parameters.t_syncmer, map_param.q, index_parameters.max_dist);
         auto strobe_finish = std::chrono::high_resolution_clock::now();
         statistics.tot_construct_strobemers += strobe_finish - strobe_start;
 

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -52,6 +52,18 @@ struct AlignmentStatistics {
     }
 };
 
+struct mapping_params {
+    int r { 150 };
+    int max_secondary { 0 };
+    float dropoff_threshold { 0.5 };
+    int R { 2 };
+    int maxTries { 20 };
+    int rescue_cutoff;
+    bool is_sam_out { true };
+
+    void verify() const {
+    }
+};
 
 void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, std::string& outstring, AlignmentStatistics& statistics, i_dist_est& isize_est, const alignment_params& aln_params, const mapping_params& map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
 

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -74,17 +74,7 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     }
 
     CommandLineOptions opt;
-
     mapping_params map_param;
-    map_param.max_secondary = 0;
-
-    map_param.f = 0.0002;
-    map_param.R = 2;
-    map_param.dropoff_threshold = 0.5;
-    map_param.maxTries = 20;
-    map_param.r = 150;
-    map_param.max_dist = std::min(map_param.r - 50, 255);
-    map_param.is_sam_out = true;  // true: align, false: map
 
     if (threads) { opt.n_threads = args::get(threads); }
 

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -103,7 +103,7 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     if (E) { opt.E = args::get(E); }
 
     // Search parameters
-    if (f) { map_param.f = args::get(f); }
+    if (f) { opt.f = args::get(f); }
     if (S) { map_param.dropoff_threshold = args::get(S); }
     if (M) { map_param.maxTries = args::get(M); }
     if (R) { map_param.R = args::get(R); }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -20,6 +20,7 @@ struct CommandLineOptions {
     int O { 12 };
     int E { 1 };
     int c { 8 };
+    float f { 0.0002 };
     int max_seed_len;
     std::string output_file_name;
     std::string logfile_name { "log.csv" };

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <utility>
 
-#include "index.hpp"
+#include "aln.hpp"
 
 struct CommandLineOptions {
     // Index parameters

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -19,7 +19,7 @@ struct CommandLineOptions {
     int B { 8 };
     int O { 12 };
     int E { 1 };
-    int c = 8;
+    int c { 8 };
     int max_seed_len;
     std::string output_file_name;
     std::string logfile_name { "log.csv" };

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -299,7 +299,7 @@ void StrobemerIndex::read(References& references, const std::string& filename) {
 }
 
 
-void StrobemerIndex::populate(const References& references, const mapping_params& map_param, const IndexParameters& index_parameters) {
+void StrobemerIndex::populate(const References& references, const IndexParameters& index_parameters, float f) {
     auto start_flat_vector = high_resolution_clock::now();
     hash_vector h_vector;
     {
@@ -331,7 +331,7 @@ void StrobemerIndex::populate(const References& references, const mapping_params
 
     mers_index.reserve(unique_mers);
     // construct index over flat array
-    filter_cutoff = index_vector(h_vector, mers_index, map_param.f);
+    filter_cutoff = index_vector(h_vector, mers_index, f);
     std::chrono::duration<double> elapsed_hash_index = high_resolution_clock::now() - start_hash_index;
     logger.info() << "Total time generating hash table index: " << elapsed_hash_index.count() << " s" <<  std::endl;
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -25,7 +25,7 @@ static Logger& logger = Logger::get();
  * k and/or s can be specified explicitly by setting them to a value other than
  * -1, but otherwise reasonable defaults are used for them as well.
  */
-IndexParameters IndexParameters::from_read_length(int read_length, int k, int s, int max_seed_len) {
+IndexParameters IndexParameters::from_read_length(int read_length, int c, int k, int s, int max_seed_len) {
     int l, u;
     struct settings {
         int r_threshold;
@@ -63,8 +63,8 @@ IndexParameters IndexParameters::from_read_length(int read_length, int k, int s,
     } else {
         max_dist = max_seed_len - k; // convert to distance in start positions
     }
-
-    return IndexParameters(k, s, l, u, max_dist);
+    int q = std::pow(2, c) - 1;
+    return IndexParameters(k, s, l, u, q, max_dist);
 }
 
 
@@ -303,7 +303,7 @@ void StrobemerIndex::populate(const References& references, const mapping_params
     auto start_flat_vector = high_resolution_clock::now();
     hash_vector h_vector;
     {
-        auto ind_flat_vector = generate_seeds(references, map_param, index_parameters);
+        auto ind_flat_vector = generate_seeds(references, index_parameters);
 
         //Split up the sorted vector into a vector with the hash codes and the flat vector to keep in the index.
         //The hash codes are only needed when generating the index and can be discarded afterwards.
@@ -336,7 +336,7 @@ void StrobemerIndex::populate(const References& references, const mapping_params
     logger.info() << "Total time generating hash table index: " << elapsed_hash_index.count() << " s" <<  std::endl;
 }
 
-ind_mers_vector StrobemerIndex::generate_seeds(const References& references, const mapping_params& map_param, const IndexParameters& index_parameters) const
+ind_mers_vector StrobemerIndex::generate_seeds(const References& references, const IndexParameters& index_parameters) const
 {
     auto start_flat_vector = high_resolution_clock::now();
 
@@ -346,7 +346,7 @@ ind_mers_vector StrobemerIndex::generate_seeds(const References& references, con
     logger.debug() << "ref vector approximate size: " << approx_vec_size << std::endl;
     ind_flat_vector.reserve(approx_vec_size);
     for(size_t i = 0; i < references.size(); ++i) {
-        seq_to_randstrobes2(ind_flat_vector, index_parameters.k, index_parameters.w_min, index_parameters.w_max, references.sequences[i], i, index_parameters.s, index_parameters.t_syncmer, map_param.q, index_parameters.max_dist);
+        seq_to_randstrobes2(ind_flat_vector, index_parameters.k, index_parameters.w_min, index_parameters.w_max, references.sequences[i], i, index_parameters.s, index_parameters.t_syncmer, index_parameters.q, index_parameters.max_dist);
     }
     logger.debug() << "Ref vector actual size: " << ind_flat_vector.size() << std::endl;
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -123,22 +123,21 @@ public:
     }
 };
 
-
 struct mapping_params {
     uint64_t q;
-    int r;
-    int max_secondary;
-    float dropoff_threshold;
+    int r { 150 };
+    int max_secondary { 0 };
+    float dropoff_threshold { 0.5 };
     int m;
-    float f;
+    float f { 0.0002 };
     int S;
     int M;
-    int R;
-    int max_dist;
-    int maxTries;
+    int R { 2 };
+    int max_dist { 100 };
+    int maxTries { 20 };
     int max_seed_len;
     int rescue_cutoff;
-    bool is_sam_out;
+    bool is_sam_out { true };
 
     void verify() const {
         if (max_dist > 255) {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -135,12 +135,8 @@ struct mapping_params {
     int r { 150 };
     int max_secondary { 0 };
     float dropoff_threshold { 0.5 };
-    int m;
-    int S;
-    int M;
     int R { 2 };
     int maxTries { 20 };
-    int max_seed_len;
     int rescue_cutoff;
     bool is_sam_out { true };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -131,19 +131,6 @@ public:
     }
 };
 
-struct mapping_params {
-    int r { 150 };
-    int max_secondary { 0 };
-    float dropoff_threshold { 0.5 };
-    int R { 2 };
-    int maxTries { 20 };
-    int rescue_cutoff;
-    bool is_sam_out { true };
-
-    void verify() const {
-    }
-};
-
 struct StrobemerIndex {
     StrobemerIndex() : filter_cutoff(0) {}
     unsigned int filter_cutoff; //This also exists in mapping_params, but is calculated during index generation,

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -94,21 +94,23 @@ public:
     const int s;
     const int l;
     const int u;
+    const int max_dist;
     const int t_syncmer;
     const int w_min;
     const int w_max;
 
-    IndexParameters(int k, int s, int l, int u)
+    IndexParameters(int k, int s, int l, int u, int max_dist)
         : k(k)
         , s(s)
         , l(l)
         , u(u)
+        , max_dist(max_dist)
         , t_syncmer((k - s) / 2 + 1)
         , w_min(std::max(1, k / (k - s + 1) + l))
         , w_max(k / (k - s + 1) + u) {
     }
 
-    static IndexParameters from_read_length(int read_length, int k = -1, int s = -1);
+    static IndexParameters from_read_length(int read_length, int k = -1, int s = -1, int max_seed_len = -1);
 
     void verify() const {
         if (k <= 7 || k > 32) {
@@ -120,29 +122,28 @@ public:
         if ((k - s) % 2 != 0) {
             throw BadParameter("(k - s) should be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...");
         }
+        if (max_dist > 255) {
+            throw BadParameter("maximum seed length (-m <max_dist>) is larger than 255");
+        }
     }
 };
 
 struct mapping_params {
     uint64_t q;
+    float f { 0.0002 };
     int r { 150 };
     int max_secondary { 0 };
     float dropoff_threshold { 0.5 };
     int m;
-    float f { 0.0002 };
     int S;
     int M;
     int R { 2 };
-    int max_dist { 100 };
     int maxTries { 20 };
     int max_seed_len;
     int rescue_cutoff;
     bool is_sam_out { true };
 
     void verify() const {
-        if (max_dist > 255) {
-            throw BadParameter("maximum seed length (-m <max_dist>) is larger than 255");
-        }
     }
 };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -132,7 +132,6 @@ public:
 };
 
 struct mapping_params {
-    float f { 0.0002 };
     int r { 150 };
     int max_secondary { 0 };
     float dropoff_threshold { 0.5 };
@@ -158,7 +157,7 @@ struct StrobemerIndex {
 
     void write(const References& references, const std::string& filename) const;
     void read(References& references, const std::string& filename);
-    void populate(const References& references, const mapping_params& map_param, const IndexParameters& index_parameters);
+    void populate(const References& references, const IndexParameters& index_parameters, float f);
 private:
     ind_mers_vector generate_seeds(const References& references, const IndexParameters& index_parameters) const;
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <deque>
 #include <tuple>
+#include <cmath>
 #include "robin_hood.h"
 #include "exceptions.hpp"
 #include "refs.hpp"
@@ -94,23 +95,25 @@ public:
     const int s;
     const int l;
     const int u;
+    uint64_t q;
     const int max_dist;
     const int t_syncmer;
     const int w_min;
     const int w_max;
 
-    IndexParameters(int k, int s, int l, int u, int max_dist)
+    IndexParameters(int k, int s, int l, int u, int q, int max_dist)
         : k(k)
         , s(s)
         , l(l)
         , u(u)
+        , q(q)
         , max_dist(max_dist)
         , t_syncmer((k - s) / 2 + 1)
         , w_min(std::max(1, k / (k - s + 1) + l))
         , w_max(k / (k - s + 1) + u) {
     }
 
-    static IndexParameters from_read_length(int read_length, int k = -1, int s = -1, int max_seed_len = -1);
+    static IndexParameters from_read_length(int read_length, int c, int k = -1, int s = -1, int max_seed_len = -1);
 
     void verify() const {
         if (k <= 7 || k > 32) {
@@ -129,7 +132,6 @@ public:
 };
 
 struct mapping_params {
-    uint64_t q;
     float f { 0.0002 };
     int r { 150 };
     int max_secondary { 0 };
@@ -158,7 +160,7 @@ struct StrobemerIndex {
     void read(References& references, const std::string& filename);
     void populate(const References& references, const mapping_params& map_param, const IndexParameters& index_parameters);
 private:
-    ind_mers_vector generate_seeds(const References& references, const mapping_params& map_param, const IndexParameters& index_parameters) const;
+    ind_mers_vector generate_seeds(const References& references, const IndexParameters& index_parameters) const;
 
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,7 +200,6 @@ int main(int argc, char **argv)
     IndexParameters index_parameters = IndexParameters::from_read_length(
         map_param.r, opt.c, opt.k_set ? opt.k : -1, opt.s_set ? opt.s : -1, opt.max_seed_len_set ? opt.max_seed_len : -1);
 
-
     alignment_params aln_params;
     aln_params.match = opt.A;
     aln_params.mismatch = opt.B;
@@ -259,7 +258,7 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
 
-        index.populate(references, map_param, index_parameters);
+        index.populate(references, index_parameters, opt.f);
 
         // Record index creation end time
         std::chrono::duration<double> elapsed = high_resolution_clock::now() - start;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,14 +193,13 @@ int main(int argc, char **argv)
     if (!opt.r_set) {
         map_param.r = estimate_read_length(opt.reads_filename1, opt.reads_filename2);
     }
-    IndexParameters index_parameters = IndexParameters::from_read_length(
-        map_param.r, opt.k_set ? opt.k : -1, opt.s_set ? opt.s : -1, opt.max_seed_len_set ? opt.max_seed_len : -1);
-
     if (opt.c >= 64 || opt.c <= 0) {
         logger.error() << "Parameter c must be greater than 0 and less than 64" << std::endl;
         return EXIT_FAILURE;
     }
-    map_param.q = pow(2, opt.c) - 1;
+    IndexParameters index_parameters = IndexParameters::from_read_length(
+        map_param.r, opt.c, opt.k_set ? opt.k : -1, opt.s_set ? opt.s : -1, opt.max_seed_len_set ? opt.max_seed_len : -1);
+
 
     alignment_params aln_params;
     aln_params.match = opt.A;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,13 +193,8 @@ int main(int argc, char **argv)
     if (!opt.r_set) {
         map_param.r = estimate_read_length(opt.reads_filename1, opt.reads_filename2);
     }
-    IndexParameters index_parameters = IndexParameters::from_read_length(map_param.r, opt.k_set ? opt.k : -1, opt.s_set ? opt.s : -1);
-    if (!opt.max_seed_len_set){
-        map_param.max_dist = std::max(map_param.r - 70, index_parameters.k);
-        map_param.max_dist = std::min(255, map_param.max_dist);
-    } else {
-        map_param.max_dist = opt.max_seed_len - index_parameters.k; //convert to distance in start positions
-    }
+    IndexParameters index_parameters = IndexParameters::from_read_length(
+        map_param.r, opt.k_set ? opt.k : -1, opt.s_set ? opt.s : -1, opt.max_seed_len_set ? opt.max_seed_len : -1);
 
     if (opt.c >= 64 || opt.c <= 0) {
         logger.error() << "Parameter c must be greater than 0 and less than 64" << std::endl;
@@ -219,7 +214,7 @@ int main(int argc, char **argv)
         << "w_min: " << index_parameters.w_min << std::endl
         << "w_max: " << index_parameters.w_max << std::endl
         << "Read length (r): " << map_param.r << std::endl
-        << "Maximum seed length: " << map_param.max_dist + index_parameters.k << std::endl
+        << "Maximum seed length: " << index_parameters.max_dist + index_parameters.k << std::endl
         << "Threads: " << opt.n_threads << std::endl
         << "R: " << map_param.R << std::endl
         << "Expected [w_min, w_max] in #syncmers: [" << index_parameters.w_min << ", " << index_parameters.w_max << "]" << std::endl


### PR DESCRIPTION
- `index.cpp` no longer refers to `mapping_param` anywhere
- Move more mapping_params members into `IndexParameters`
