### PR TITLE
Turn -i into a flag and add --use-index option

### DIFF
--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -33,7 +33,8 @@ struct CommandLineOptions {
     bool write_to_stdout { true };
     bool r_set { false };
     bool max_seed_len_set { false };
-    bool only_gen_index{ false };
+    bool only_gen_index { false };
+    bool use_index { false };
     std::string index_out_filename;
 };
 

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -13,4 +13,9 @@ public:
     InvalidFasta(std::string message) : runtime_error(message) { }
 };
 
+class InvalidIndexFile : public std::runtime_error {
+public:
+    InvalidIndexFile(std::string message) : runtime_error(message) { }
+};
+
 #endif /* exceptions.hpp */

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -186,6 +186,8 @@ unsigned int index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, 
 void StrobemerIndex::write(const std::string& filename) const {
     std::ofstream ofs(filename, std::ios::binary);
 
+    ofs.write("STI\1", 4); // magic number
+
     //write filter_cutoff
     ofs.write(reinterpret_cast<const char*>(&filter_cutoff), sizeof(filter_cutoff));
 
@@ -205,6 +207,15 @@ void StrobemerIndex::write(const std::string& filename) const {
 
 void StrobemerIndex::read(const std::string& filename) {
     std::ifstream ifs(filename, std::ios::binary);
+
+    union {
+        char s[4];
+        uint32_t v;
+    } magic;
+    ifs.read(magic.s, 4);
+    if (magic.v != 0x01495453) { // "STI\1"
+        throw InvalidIndexFile("Index file has incorrect format (magic number mismatch)");
+    }
 
     // read filter_cutoff
     ifs.read(reinterpret_cast<char*>(&filter_cutoff), sizeof(filter_cutoff));

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -67,6 +67,36 @@ IndexParameters IndexParameters::from_read_length(int read_length, int c, int k,
     return IndexParameters(k, s, l, u, q, max_dist);
 }
 
+void write_int_to_ostream(std::ostream& os, int value) {
+    int val;
+    val = value;
+    os.write(reinterpret_cast<const char*>(&val), sizeof(val));
+}
+
+void IndexParameters::write(std::ostream& os) const {
+    write_int_to_ostream(os, k);
+    write_int_to_ostream(os, s);
+    write_int_to_ostream(os, l);
+    write_int_to_ostream(os, u);
+    write_int_to_ostream(os, q);
+    write_int_to_ostream(os, max_dist);
+}
+
+int read_int_from_istream(std::istream& is) {
+    int val;
+    is.read(reinterpret_cast<char*>(&val), sizeof(val));
+    return val;
+}
+
+IndexParameters IndexParameters::read(std::istream& is) {
+    int k = read_int_from_istream(is);
+    int s = read_int_from_istream(is);
+    int l = read_int_from_istream(is);
+    int u = read_int_from_istream(is);
+    int q = read_int_from_istream(is);
+    int max_dist = read_int_from_istream(is);
+    return IndexParameters(k, s, l, u, q, max_dist);
+}
 
 /* Add a new observation */
 void i_dist_est::update(int dist)
@@ -188,8 +218,7 @@ void StrobemerIndex::write(const std::string& filename) const {
 
     ofs.write("STI\1", 4); // magic number
 
-    //write filter_cutoff
-    ofs.write(reinterpret_cast<const char*>(&filter_cutoff), sizeof(filter_cutoff));
+    write_int_to_ostream(ofs, filter_cutoff);
 
     //write flat_vector:
     auto s1 = uint64_t(flat_vector.size());
@@ -217,8 +246,7 @@ void StrobemerIndex::read(const std::string& filename) {
         throw InvalidIndexFile("Index file has incorrect format (magic number mismatch)");
     }
 
-    // read filter_cutoff
-    ifs.read(reinterpret_cast<char*>(&filter_cutoff), sizeof(filter_cutoff));
+    filter_cutoff = read_int_from_istream(ifs);
 
     // read flat_vector:
     uint64_t sz;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -132,17 +132,18 @@ public:
 };
 
 struct StrobemerIndex {
-    StrobemerIndex() : filter_cutoff(0) {}
+    StrobemerIndex(const References& references) : filter_cutoff(0), references(references) {}
     unsigned int filter_cutoff; //This also exists in mapping_params, but is calculated during index generation,
                                 //therefore stored here since it needs to be saved with the index.
     mers_vector flat_vector;
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
 
-    void write(const References& references, const std::string& filename) const;
-    void read(References& references, const std::string& filename);
-    void populate(const References& references, const IndexParameters& index_parameters, float f);
+    void write(const std::string& filename) const;
+    void read(const std::string& filename);
+    void populate(const IndexParameters& index_parameters, float f);
 private:
-    ind_mers_vector generate_seeds(const References& references, const IndexParameters& index_parameters) const;
+    const References& references;
+    ind_mers_vector generate_seeds(const IndexParameters& index_parameters) const;
 };
 
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -114,10 +114,11 @@ public:
     }
 
     static IndexParameters from_read_length(int read_length, int c, int k = -1, int s = -1, int max_seed_len = -1);
+    static IndexParameters read(std::istream& os);
 
     void write(std::ostream& os) const;
-
-    static IndexParameters read(std::istream& os);
+    bool operator==(const IndexParameters& other) const;
+    bool operator!=(const IndexParameters& other) const { return !(*this == other); }
 
     void verify() const {
         if (k <= 7 || k > 32) {
@@ -136,7 +137,10 @@ public:
 };
 
 struct StrobemerIndex {
-    StrobemerIndex(const References& references) : filter_cutoff(0), references(references) {}
+    StrobemerIndex(const References& references, const IndexParameters& parameters)
+        : filter_cutoff(0)
+        , parameters(parameters)
+        , references(references) {}
     unsigned int filter_cutoff; //This also exists in mapping_params, but is calculated during index generation,
                                 //therefore stored here since it needs to be saved with the index.
     mers_vector flat_vector;
@@ -144,10 +148,11 @@ struct StrobemerIndex {
 
     void write(const std::string& filename) const;
     void read(const std::string& filename);
-    void populate(const IndexParameters& index_parameters, float f);
+    void populate(float f);
 private:
+    const IndexParameters& parameters;
     const References& references;
-    ind_mers_vector generate_seeds(const IndexParameters& index_parameters) const;
+    ind_mers_vector generate_seeds() const;
 };
 
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -95,7 +95,7 @@ public:
     const int s;
     const int l;
     const int u;
-    uint64_t q;
+    const uint64_t q;
     const int max_dist;
     const int t_syncmer;
     const int w_min;
@@ -114,6 +114,10 @@ public:
     }
 
     static IndexParameters from_read_length(int read_length, int c, int k = -1, int s = -1, int max_seed_len = -1);
+
+    void write(std::ostream& os) const;
+
+    static IndexParameters read(std::istream& os);
 
     void verify() const {
         if (k <= 7 || k > 32) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,18 +214,23 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    StrobemerIndex index(references);
+    StrobemerIndex index(references, index_parameters);
     if (opt.use_index) {
         // Read the index from a file
         assert(!opt.only_gen_index);
         auto start_read_index = high_resolution_clock::now();
-        index.read(opt.ref_filename + ".sti");
+        try {
+            index.read(opt.ref_filename + ".sti");
+        } catch (const InvalidIndexFile& e) {
+            logger.error() << "strobealign: " << e.what() << std::endl;
+            return EXIT_FAILURE;
+        }
         std::chrono::duration<double> elapsed_read_index = high_resolution_clock::now() - start_read_index;
         logger.info() << "Total time reading index: " << elapsed_read_index.count() << " s\n" << std::endl;
     } else {
         // Generate the index
         auto start = high_resolution_clock::now();
-        index.populate(index_parameters, opt.f);
+        index.populate(opt.f);
         std::chrono::duration<double> elapsed = high_resolution_clock::now() - start;
         logger.info() << "Total time indexing: " << elapsed.count() << " s" << std::endl;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,7 +242,7 @@ int main(int argc, char **argv)
         }
     }
 
-    // Map reads
+    // Map/align reads
         
     auto start_aln_part = high_resolution_clock::now();
     map_param.rescue_cutoff = map_param.R < 100 ? map_param.R * index.filter_cutoff : 1000;
@@ -260,11 +260,6 @@ int main(int argc, char **argv)
     }
 
     std::ostream out(buf);
-    //    std::ofstream out;
-    //    out.open(opt.output_file_name);
-
-    //    std::stringstream sam_output;
-    //    std::stringstream paf_output;
 
     if (map_param.is_sam_out) {
         out << sam_header(references);
@@ -272,17 +267,13 @@ int main(int argc, char **argv)
 
     std::unordered_map<std::thread::id, AlignmentStatistics> log_stats_vec(opt.n_threads);
 
-
     logger.info() << "Running in " << (opt.is_SE ? "single-end" : "paired-end") << " mode" << std::endl;
 
     if (opt.is_SE) {
         gzFile fp = gzopen(opt.reads_filename1.c_str(), "r");
         auto ks = klibpp::make_ikstream(fp, gzread);
 
-        ////////// ALIGNMENT START //////////
-
         int input_chunk_size = 100000;
-        // Create Buffers
         InputBuffer input_buffer(ks, ks, input_chunk_size);
         OutputBuffer output_buffer(out);
 
@@ -308,11 +299,7 @@ int main(int argc, char **argv)
         auto ks2 = klibpp::make_ikstream(fp2, gzread);
         std::unordered_map<std::thread::id, i_dist_est> isize_est_vec(opt.n_threads);
 
-        ////////// ALIGNMENT START //////////
-        /////////////////////////////////////
-
         int input_chunk_size = 100000;
-        // Create Buffers
         InputBuffer input_buffer(ks1, ks2, input_chunk_size);
         OutputBuffer output_buffer(out);
 
@@ -328,9 +315,6 @@ int main(int argc, char **argv)
         for (size_t i = 0; i < workers.size(); ++i) {
             workers[i].join();
         }
-
-        /////////////////////////////////////
-        /////////////////////////////////////
 
         gzclose(fp1);
         gzclose(fp2);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,18 +214,18 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    StrobemerIndex index;
+    StrobemerIndex index(references);
     if (opt.use_index) {
         // Read the index from a file
         assert(!opt.only_gen_index);
         auto start_read_index = high_resolution_clock::now();
-        index.read(references, opt.ref_filename + ".sti");
+        index.read(opt.ref_filename + ".sti");
         std::chrono::duration<double> elapsed_read_index = high_resolution_clock::now() - start_read_index;
         logger.info() << "Total time reading index: " << elapsed_read_index.count() << " s\n" << std::endl;
     } else {
         // Generate the index
         auto start = high_resolution_clock::now();
-        index.populate(references, index_parameters, opt.f);
+        index.populate(index_parameters, opt.f);
         std::chrono::duration<double> elapsed = high_resolution_clock::now() - start;
         logger.info() << "Total time indexing: " << elapsed.count() << " s" << std::endl;
 
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
         }
         if (opt.only_gen_index) {
             auto start_write_index = high_resolution_clock::now();
-            index.write(references, opt.ref_filename + ".sti");
+            index.write(opt.ref_filename + ".sti");
             std::chrono::duration<double> elapsed_write_index = high_resolution_clock::now() - start_write_index;
             logger.info() << "Total time writing index: " << elapsed_write_index.count() << " s\n" << std::endl;
             return EXIT_SUCCESS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
     std::tie(opt, map_param) = parse_command_line_arguments(argc, argv);
 
     logger.set_level(opt.verbose ? LOG_DEBUG : LOG_INFO);
-    if (!opt.r_set) {
+    if (!opt.r_set && !opt.reads_filename1.empty()) {
         map_param.r = estimate_read_length(opt.reads_filename1, opt.reads_filename2);
     }
     if (opt.c >= 64 || opt.c <= 0) {
@@ -198,32 +198,34 @@ int main(int argc, char **argv)
 
     //////////// CREATE INDEX OF REF SEQUENCES /////////////////
 
-    StrobemerIndex index;
     References references;
-    if (opt.ref_filename.substr(opt.ref_filename.length() - 4) != ".sti") { //assume it is a fasta file if not named ".sti"
-        //Generate index from FASTA
-    
-        // Record index creation start time
+    auto start_read_refs = high_resolution_clock::now();
+    try {
+        references = References::from_fasta(opt.ref_filename);
+    } catch (const InvalidFasta& e) {
+        logger.error() << "strobealign: " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+    std::chrono::duration<double> elapsed_read_refs = high_resolution_clock::now() - start_read_refs;
+    logger.info() << "Time reading references: " << elapsed_read_refs.count() << " s" << std::endl;
+
+    if (references.total_length() == 0) {
+        logger.error() << "No reference sequences found, aborting" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    StrobemerIndex index;
+    if (opt.use_index) {
+        // Read the index from a file
+        assert(!opt.only_gen_index);
+        auto start_read_index = high_resolution_clock::now();
+        index.read(references, opt.ref_filename + ".sti");
+        std::chrono::duration<double> elapsed_read_index = high_resolution_clock::now() - start_read_index;
+        logger.info() << "Total time reading index: " << elapsed_read_index.count() << " s\n" << std::endl;
+    } else {
+        // Generate the index
         auto start = high_resolution_clock::now();
-        auto start_read_refs = start;
-        try {
-            references = References::from_fasta(opt.ref_filename);
-        } catch (const InvalidFasta& e) {
-            logger.error() << "strobealign: " << e.what() << std::endl;
-            return EXIT_FAILURE;
-        }
-
-        std::chrono::duration<double> elapsed_read_refs = high_resolution_clock::now() - start_read_refs;
-        logger.info() << "Time reading references: " << elapsed_read_refs.count() << " s" << std::endl;
-
-        if (references.total_length() == 0) {
-            logger.error() << "No reference sequences found, aborting" << std::endl;
-            return EXIT_FAILURE;
-        }
-
         index.populate(references, index_parameters, opt.f);
-
-        // Record index creation end time
         std::chrono::duration<double> elapsed = high_resolution_clock::now() - start;
         logger.info() << "Total time indexing: " << elapsed.count() << " s" << std::endl;
 
@@ -231,148 +233,130 @@ int main(int argc, char **argv)
             print_diagnostics(index, opt.logfile_name, index_parameters.k);
             logger.debug() << "Finished printing log stats" << std::endl;
         }
-        
-        // If the program was called with the -i flag, write the index to file
-        if (opt.only_gen_index) { // If the program was called with the -i flag, we do not do the alignment
+        if (opt.only_gen_index) {
             auto start_write_index = high_resolution_clock::now();
-            index.write(references, opt.index_out_filename);
+            index.write(references, opt.ref_filename + ".sti");
             std::chrono::duration<double> elapsed_write_index = high_resolution_clock::now() - start_write_index;
             logger.info() << "Total time writing index: " << elapsed_write_index.count() << " s\n" << std::endl;
+            return EXIT_SUCCESS;
         }
+    }
+
+    // Map reads
+        
+    auto start_aln_part = high_resolution_clock::now();
+    map_param.rescue_cutoff = map_param.R < 100 ? map_param.R * index.filter_cutoff : 1000;
+    logger.debug() << "Using rescue cutoff: " << map_param.rescue_cutoff << std::endl;
+
+    std::streambuf* buf;
+    std::ofstream of;
+
+    if (!opt.write_to_stdout) {
+        of.open(opt.output_file_name);
+        buf = of.rdbuf();
     }
     else {
-        //load index from file
-        auto start_read_index = high_resolution_clock::now();
-        index.read(references, opt.ref_filename);
-        std::chrono::duration<double> elapsed_read_index = high_resolution_clock::now() - start_read_index;
-        logger.info() << "Total time reading index: " << elapsed_read_index.count() << " s\n" << std::endl;
-
+        buf = std::cout.rdbuf();
     }
 
-    ///////////////////////////// MAP ///////////////////////////////////////
-    
-    if (!(opt.only_gen_index && opt.reads_filename1.empty())) { // If the program was called with the -i flag and the fastqs are not specified, we don't run any alignment
-        
-        // Record matching time
-        auto start_aln_part = high_resolution_clock::now();
+    std::ostream out(buf);
+    //    std::ofstream out;
+    //    out.open(opt.output_file_name);
 
-        //    std::ifstream query_file(reads_filename);
+    //    std::stringstream sam_output;
+    //    std::stringstream paf_output;
 
-        map_param.rescue_cutoff = map_param.R < 100 ? map_param.R * index.filter_cutoff : 1000;
-        logger.debug() << "Using rescue cutoff: " << map_param.rescue_cutoff << std::endl;
-
-        std::streambuf* buf;
-        std::ofstream of;
-
-        if (!opt.write_to_stdout) {
-            of.open(opt.output_file_name);
-            buf = of.rdbuf();
-        }
-        else {
-            buf = std::cout.rdbuf();
-        }
-
-        std::ostream out(buf);
-        //    std::ofstream out;
-        //    out.open(opt.output_file_name);
-
-        //    std::stringstream sam_output;
-        //    std::stringstream paf_output;
-
-        if (map_param.is_sam_out) {
-            out << sam_header(references);
-        }
-
-        std::unordered_map<std::thread::id, AlignmentStatistics> log_stats_vec(opt.n_threads);
-
-
-        logger.info() << "Running in " << (opt.is_SE ? "single-end" : "paired-end") << " mode" << std::endl;
-
-        if (opt.is_SE) {
-            gzFile fp = gzopen(opt.reads_filename1.c_str(), "r");
-            auto ks = klibpp::make_ikstream(fp, gzread);
-
-            ////////// ALIGNMENT START //////////
-
-            int input_chunk_size = 100000;
-            // Create Buffers
-            InputBuffer input_buffer(ks, ks, input_chunk_size);
-            OutputBuffer output_buffer(out);
-
-            std::vector<std::thread> workers;
-            for (int i = 0; i < opt.n_threads; ++i) {
-                std::thread consumer(perform_task_SE, std::ref(input_buffer), std::ref(output_buffer),
-                    std::ref(log_stats_vec), std::ref(aln_params),
-                    std::ref(map_param), std::ref(index_parameters), std::ref(references),
-                    std::ref(index));
-                workers.push_back(std::move(consumer));
-            }
-
-            for (size_t i = 0; i < workers.size(); ++i) {
-                workers[i].join();
-            }
-
-            gzclose(fp);
-        }
-        else {
-            gzFile fp1 = gzopen(opt.reads_filename1.c_str(), "r");
-            auto ks1 = klibpp::make_ikstream(fp1, gzread);
-            gzFile fp2 = gzopen(opt.reads_filename2.c_str(), "r");
-            auto ks2 = klibpp::make_ikstream(fp2, gzread);
-            std::unordered_map<std::thread::id, i_dist_est> isize_est_vec(opt.n_threads);
-
-            ////////// ALIGNMENT START //////////
-            /////////////////////////////////////
-
-            int input_chunk_size = 100000;
-            // Create Buffers
-            InputBuffer input_buffer(ks1, ks2, input_chunk_size);
-            OutputBuffer output_buffer(out);
-
-            std::vector<std::thread> workers;
-            for (int i = 0; i < opt.n_threads; ++i) {
-                std::thread consumer(perform_task_PE, std::ref(input_buffer), std::ref(output_buffer),
-                    std::ref(log_stats_vec), std::ref(isize_est_vec), std::ref(aln_params),
-                    std::ref(map_param), std::ref(index_parameters), std::ref(references),
-                    std::ref(index));
-                workers.push_back(std::move(consumer));
-            }
-
-            for (size_t i = 0; i < workers.size(); ++i) {
-                workers[i].join();
-            }
-
-            /////////////////////////////////////
-            /////////////////////////////////////
-
-            gzclose(fp1);
-            gzclose(fp2);
-        }
-        logger.info() << "Done!\n";
-
-        AlignmentStatistics tot_statistics;
-        for (auto& it : log_stats_vec) {
-            tot_statistics += it.second;
-        }
-        // Record mapping end time
-        std::chrono::duration<double> tot_aln_part = high_resolution_clock::now() - start_aln_part;
-
-        logger.info() << "Total mapping sites tried: " << tot_statistics.tot_all_tried << std::endl
-            << "Total calls to ssw: " << tot_statistics.tot_ksw_aligned << std::endl
-            << "Calls to ksw (rescue mode): " << tot_statistics.tot_rescued << std::endl
-            << "Did not fit strobe start site: " << tot_statistics.did_not_fit << std::endl
-            << "Tried rescue: " << tot_statistics.tried_rescue << std::endl
-            << "Total time mapping: " << tot_aln_part.count() << " s." << std::endl
-            << "Total time reading read-file(s): " << tot_statistics.tot_read_file.count() / opt.n_threads << " s." << std::endl
-            << "Total time creating strobemers: " << tot_statistics.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl
-            << "Total time finding NAMs (non-rescue mode): " << tot_statistics.tot_find_nams.count() / opt.n_threads << " s." << std::endl
-            << "Total time finding NAMs (rescue mode): " << tot_statistics.tot_time_rescue.count() / opt.n_threads << " s." << std::endl;
-        //<< "Total time finding NAMs ALTERNATIVE (candidate sites): " << tot_find_nams_alt.count()/opt.n_threads  << " s." <<  std::endl;
-        logger.info() << "Total time sorting NAMs (candidate sites): " << tot_statistics.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
-            << "Total time reverse compl seq: " << tot_statistics.tot_rc.count() / opt.n_threads << " s." << std::endl
-            << "Total time base level alignment (ssw): " << tot_statistics.tot_extend.count() / opt.n_threads << " s." << std::endl
-            << "Total time writing alignment to files: " << tot_statistics.tot_write_file.count() << " s." << std::endl;
-
-        /////////////////////// FIND AND OUTPUT NAMs ///////////////////////////////
+    if (map_param.is_sam_out) {
+        out << sam_header(references);
     }
+
+    std::unordered_map<std::thread::id, AlignmentStatistics> log_stats_vec(opt.n_threads);
+
+
+    logger.info() << "Running in " << (opt.is_SE ? "single-end" : "paired-end") << " mode" << std::endl;
+
+    if (opt.is_SE) {
+        gzFile fp = gzopen(opt.reads_filename1.c_str(), "r");
+        auto ks = klibpp::make_ikstream(fp, gzread);
+
+        ////////// ALIGNMENT START //////////
+
+        int input_chunk_size = 100000;
+        // Create Buffers
+        InputBuffer input_buffer(ks, ks, input_chunk_size);
+        OutputBuffer output_buffer(out);
+
+        std::vector<std::thread> workers;
+        for (int i = 0; i < opt.n_threads; ++i) {
+            std::thread consumer(perform_task_SE, std::ref(input_buffer), std::ref(output_buffer),
+                std::ref(log_stats_vec), std::ref(aln_params),
+                std::ref(map_param), std::ref(index_parameters), std::ref(references),
+                std::ref(index));
+            workers.push_back(std::move(consumer));
+        }
+
+        for (size_t i = 0; i < workers.size(); ++i) {
+            workers[i].join();
+        }
+
+        gzclose(fp);
+    }
+    else {
+        gzFile fp1 = gzopen(opt.reads_filename1.c_str(), "r");
+        auto ks1 = klibpp::make_ikstream(fp1, gzread);
+        gzFile fp2 = gzopen(opt.reads_filename2.c_str(), "r");
+        auto ks2 = klibpp::make_ikstream(fp2, gzread);
+        std::unordered_map<std::thread::id, i_dist_est> isize_est_vec(opt.n_threads);
+
+        ////////// ALIGNMENT START //////////
+        /////////////////////////////////////
+
+        int input_chunk_size = 100000;
+        // Create Buffers
+        InputBuffer input_buffer(ks1, ks2, input_chunk_size);
+        OutputBuffer output_buffer(out);
+
+        std::vector<std::thread> workers;
+        for (int i = 0; i < opt.n_threads; ++i) {
+            std::thread consumer(perform_task_PE, std::ref(input_buffer), std::ref(output_buffer),
+                std::ref(log_stats_vec), std::ref(isize_est_vec), std::ref(aln_params),
+                std::ref(map_param), std::ref(index_parameters), std::ref(references),
+                std::ref(index));
+            workers.push_back(std::move(consumer));
+        }
+
+        for (size_t i = 0; i < workers.size(); ++i) {
+            workers[i].join();
+        }
+
+        /////////////////////////////////////
+        /////////////////////////////////////
+
+        gzclose(fp1);
+        gzclose(fp2);
+    }
+    logger.info() << "Done!\n";
+
+    AlignmentStatistics tot_statistics;
+    for (auto& it : log_stats_vec) {
+        tot_statistics += it.second;
+    }
+    // Record mapping end time
+    std::chrono::duration<double> tot_aln_part = high_resolution_clock::now() - start_aln_part;
+
+    logger.info() << "Total mapping sites tried: " << tot_statistics.tot_all_tried << std::endl
+        << "Total calls to ssw: " << tot_statistics.tot_ksw_aligned << std::endl
+        << "Calls to ksw (rescue mode): " << tot_statistics.tot_rescued << std::endl
+        << "Did not fit strobe start site: " << tot_statistics.did_not_fit << std::endl
+        << "Tried rescue: " << tot_statistics.tried_rescue << std::endl
+        << "Total time mapping: " << tot_aln_part.count() << " s." << std::endl
+        << "Total time reading read-file(s): " << tot_statistics.tot_read_file.count() / opt.n_threads << " s." << std::endl
+        << "Total time creating strobemers: " << tot_statistics.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl
+        << "Total time finding NAMs (non-rescue mode): " << tot_statistics.tot_find_nams.count() / opt.n_threads << " s." << std::endl
+        << "Total time finding NAMs (rescue mode): " << tot_statistics.tot_time_rescue.count() / opt.n_threads << " s." << std::endl;
+    //<< "Total time finding NAMs ALTERNATIVE (candidate sites): " << tot_find_nams_alt.count()/opt.n_threads  << " s." <<  std::endl;
+    logger.info() << "Total time sorting NAMs (candidate sites): " << tot_statistics.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
+        << "Total time reverse compl seq: " << tot_statistics.tot_rc.count() / opt.n_threads << " s." << std::endl
+        << "Total time base level alignment (ssw): " << tot_statistics.tot_extend.count() / opt.n_threads << " s." << std::endl
+        << "Total time writing alignment to files: " << tot_statistics.tot_write_file.count() << " s." << std::endl;
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -29,5 +29,12 @@ strobealign -x $d/phix.fasta $d/phix.1.fastq $d/phix.2.fastq | tail > phix.pe.pa
 diff -u tests/phix.pe.paf phix.pe.paf
 rm phix.pe.paf
 
+# Build a separate index
+strobealign -r 150 $d/phix.fasta $d/phix.1.fastq > without-sti.sam
+strobealign -r 150 -i $d/phix.fasta
+strobealign -r 150 --use-index $d/phix.fasta $d/phix.1.fastq > with-sti.sam
+diff -u without-sti.sam with-sti.sam
+rm without-sti.sam with-sti.sam
+
 # Unit tests
 build/test-strobealign

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -4,6 +4,7 @@
 #include "refs.hpp"
 #include "exceptions.hpp"
 #include "readlen.hpp"
+#include "index.hpp"
 
 
 TEST_CASE("References::from_fasta") {
@@ -23,4 +24,24 @@ TEST_CASE("References::from_fasta parse error") {
 TEST_CASE("estimate_read_length") {
     CHECK(estimate_read_length("tests/phix.1.fastq", "") == 296);
     CHECK(estimate_read_length("tests/phix.1.fastq", "tests/phix.2.fastq") == 296);
+}
+
+TEST_CASE("IndexParameters==") {
+    IndexParameters a = IndexParameters::from_read_length(150, 8);
+    IndexParameters b = IndexParameters::from_read_length(150, 8);
+    CHECK(a == b);
+}
+
+TEST_CASE("sti file same parameters") {
+    auto references = References::from_fasta("tests/phix.fasta");
+    auto parameters = IndexParameters::from_read_length(300, 8);
+    StrobemerIndex index(references, parameters);
+    index.populate(0.0002);
+    index.write("tmpindex.sti");
+
+    auto other_parameters = IndexParameters::from_read_length(30, 8);
+    StrobemerIndex other_index(references, other_parameters);
+
+    REQUIRE_THROWS_AS(other_index.read("tmpindex.sti"), InvalidIndexFile);
+    std::remove("tmpindex.sti");
 }


### PR DESCRIPTION
- When `-i` is specified, write the index to reference path + `.sti`
- When --use-index is specified, read the index from reference path + `.sti`
- If `-i` is used and one or two reads files are provided, estimate read length from the reads
- Do not write the reference sequences to the index (read them from the FASTA instead)
- Write a "magic number" as the first four bytes to the index file so that we can be somewhat sure that it actually is a strobemer index when reading it in again.

## To Do 

- [x] Log message "Total time creating strobemers" is printed even with `--use-index`

See #115