### PR TITLE
Properly exit if an input FASTQ file is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_compile_options(-Wall -Wextra)
 
 add_library(salib STATIC ${SOURCES}
   src/refs.cpp
+  src/fastq.cpp
   src/cmdline.cpp
   src/index.cpp
   src/sam.cpp

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -2,6 +2,7 @@
 #define exceptions_hpp
 
 #include <stdexcept>
+#include <string>
 
 class BadParameter: public std::runtime_error {
 public:
@@ -18,4 +19,9 @@ public:
     InvalidIndexFile(std::string message) : runtime_error(message) { }
 };
 
-#endif /* exceptions.hpp */
+class InvalidFile : public std::runtime_error {
+public:
+    InvalidFile(std::string message) : runtime_error(message) { }
+};
+
+#endif

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -1,0 +1,10 @@
+#include "fastq.hpp"
+
+input_stream_t open_fastq(std::string& filename) {
+    gzFile fp = gzopen(filename.c_str(), "r");
+    if (fp == nullptr) {
+        throw InvalidFile("Could not open FASTQ file");
+    }
+    // 16384 is the default buffer size. We need to pass it to be able to pass gzclose.
+    return klibpp::make_ikstream(fp, gzread, 16384, gzclose);
+}

--- a/src/fastq.hpp
+++ b/src/fastq.hpp
@@ -1,0 +1,14 @@
+#ifndef FASTQ_HPP
+#define FASTQ_HPP
+
+#include <zlib.h>
+#include <string>
+
+#include "exceptions.hpp"
+#include "kseq++.hpp"
+
+typedef klibpp::KStream<gzFile_s*, int (*)(gzFile_s*, void*, unsigned int), klibpp::mode::In_> input_stream_t;
+
+input_stream_t open_fastq(std::string& filename);
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,8 +146,7 @@ std::string sam_header(const References& references) {
     return out.str();
 }
 
-int main(int argc, char **argv)
-{
+int run_strobealign(int argc, char **argv) {
     CommandLineOptions opt;
     mapping_params map_param;
     std::tie(opt, map_param) = parse_command_line_arguments(argc, argv);
@@ -348,4 +347,8 @@ int main(int argc, char **argv)
         << "Total time reverse compl seq: " << tot_statistics.tot_rc.count() / opt.n_threads << " s." << std::endl
         << "Total time base level alignment (ssw): " << tot_statistics.tot_extend.count() / opt.n_threads << " s." << std::endl
         << "Total time writing alignment to files: " << tot_statistics.tot_write_file.count() << " s." << std::endl;
+}
+
+int main(int argc, char **argv) {
+    return run_strobealign(argc, argv);
 }

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -11,19 +11,17 @@
 #include <vector>
 #include <sstream>
 #include <unordered_map>
-#include <zlib.h>
 
 #include "robin_hood.h"
-#include "kseq++.hpp"
 #include "ssw_cpp.h"
 #include "index.hpp"
 #include "aln.hpp"
 #include "refs.hpp"
+#include "fastq.hpp"
 
 class InputBuffer {
 
 public:
-    typedef klibpp::KStream<gzFile_s*, int (*)(gzFile_s*, void*, unsigned int), klibpp::mode::In_> input_stream_t;
 
     InputBuffer(input_stream_t& ks1, input_stream_t& ks2, int chunk_size)
     : ks1(ks1), ks2(ks2), chunk_size(chunk_size) { }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -21,6 +21,10 @@ TEST_CASE("References::from_fasta parse error") {
     REQUIRE_THROWS_AS(References::from_fasta("tests/phix.1.fastq"), InvalidFasta);
 }
 
+TEST_CASE("Reference FASTA not found") {
+    REQUIRE_THROWS_AS(References::from_fasta("does-not-exist.fasta"), InvalidFasta);
+}
+
 TEST_CASE("estimate_read_length") {
     CHECK(estimate_read_length("tests/phix.1.fastq", "") == 296);
     CHECK(estimate_read_length("tests/phix.1.fastq", "tests/phix.2.fastq") == 296);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -5,6 +5,7 @@
 #include "exceptions.hpp"
 #include "readlen.hpp"
 #include "index.hpp"
+#include "fastq.hpp"
 
 
 TEST_CASE("References::from_fasta") {
@@ -48,4 +49,9 @@ TEST_CASE("sti file same parameters") {
 
     REQUIRE_THROWS_AS(other_index.read("tmpindex.sti"), InvalidIndexFile);
     std::remove("tmpindex.sti");
+}
+
+TEST_CASE("Reads file missing") {
+    std::string filename("does-not-exist.fastq");
+    REQUIRE_THROWS_AS(open_fastq(filename), InvalidFile);
 }


### PR DESCRIPTION
- Factor out an open_fastq function
- Check whether gzopen() returns nullptr
- Pass "gzclose" to make_ikstream to make it automatically close
  the underlying file

This also splits out a `run_strobealign` function from `main()` that does most of the work. `run_strobalign()` only throws exceptions and never exits if there is an error. This makes it easier to use the function in a library.