### PR TITLE
Avoid running GitHub Actions job twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on: [push, pull_request]
 
 jobs:
   lint:
+    # Run for PRs only if they come from a forked repo (avoids duplicate runs)
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -11,6 +15,9 @@ jobs:
         run: "! grep -P -R '\\t' src/ tests/*.cpp"
 
   build:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     # Run for PRs only if they come from a forked repo (avoids duplicate runs)
     if: >-
       github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -17,7 +17,7 @@ jobs:
   build:
     if: >-
       github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -28,7 +28,7 @@ jobs:
         run: |
           cmake -B build
           cd build
-          make -j2
+          make -j3
           make install
       - name: Run
         run: tests/run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           cmake -B build
           cd build
-          make
+          make -j2
           make install
       - name: Run
         run: tests/run.sh


### PR DESCRIPTION
Run the job for PRs only if they come from a forked repo. From here:
https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/