### PR TITLE
Fix incorrect refactor in find_nams

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -128,7 +128,7 @@ static inline void find_nams_rescue(
         int cnt = 0;
         for (auto &q : hits) {
             auto count = q.count;
-            if ((count > filter_cutoff && cnt >= 5) || count >= 1000) {
+            if ((count > filter_cutoff && cnt >= 5) || count > 1000) {
                 break;
             }
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -281,7 +281,7 @@ static inline std::pair<float,int> find_nams(
             auto offset = mer.offset;
             auto count = mer.count;
             if (count > index.filter_cutoff) {
-                break;
+                continue;
             }
             nr_good_hits ++;
             int min_diff = 100000;


### PR DESCRIPTION
This change was introduced in https://github.com/ksahlin/StrobeAlign/commit/6973009f4779cd54aaa9ae1bc6420ba9aa80d0f3 and leads to reduced accuracy on larger references. It was intended as a refactoring and not meant to change results. The difference in results is not visible on the tiny phiX test dataset.

