### PR TITLE
Require a path for -i/--use-index

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -22,8 +22,8 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     args::Flag x(parser, "x", "Only map reads, no base level alignment (produces PAF file)", {'x'});
     args::ValueFlag<int> N(parser, "INT", "Retain at most INT secondary alignments (is upper bounded by -M and depends on -S) [0]", {'N'});
     args::ValueFlag<std::string> L(parser, "PATH", "Print statistics of indexing to PATH", {'L'});
-    args::Flag i(parser, "index", "Write the generated index to a file. Do not map reads. If read files are provided, they are used to estimate read length", { 'i' });
-    args::Flag use_index(parser, "use_index", "Use a pre-generated index", { "use-index" });
+    args::ValueFlag<std::string> i(parser, "index", "Write the generated index to a file. Do not map reads. If read files are provided, they are used to estimate read length", { 'i' });
+    args::ValueFlag<std::string> use_index(parser, "use_index", "Use a pre-generated index", { "use-index" });
 
     args::Group seeding(parser, "Seeding:");
     //args::ValueFlag<int> n(parser, "INT", "Number of strobes [2]", {'n'});
@@ -82,8 +82,8 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     if (x) { map_param.is_sam_out = false; }
     if (N) { map_param.max_secondary = args::get(N); }
     if (L) { opt.logfile_name = args::get(L); }
-    if (i) { opt.only_gen_index = true; opt.index_out_filename = args::get(i); }
-    if (use_index) { opt.use_index = true; }
+    if (i) { opt.only_gen_index = true; opt.index_filename = args::get(i); }
+    if (use_index) { opt.use_index = true; opt.index_filename = args::get(use_index); }
 
     // Seeding
     if (r) { map_param.r = args::get(r); opt.r_set = true; }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -35,7 +35,7 @@ struct CommandLineOptions {
     bool max_seed_len_set { false };
     bool only_gen_index { false };
     bool use_index { false };
-    std::string index_out_filename;
+    std::string index_filename;
 };
 
 std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int argc, char **argv);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,7 +205,7 @@ int run_strobealign(int argc, char **argv) {
         // Read the index from a file
         assert(!opt.only_gen_index);
         auto start_read_index = high_resolution_clock::now();
-        index.read(opt.ref_filename + ".sti");
+        index.read(opt.index_filename);
         std::chrono::duration<double> elapsed_read_index = high_resolution_clock::now() - start_read_index;
         logger.info() << "Total time reading index: " << elapsed_read_index.count() << " s\n" << std::endl;
     } else {
@@ -244,7 +244,7 @@ int run_strobealign(int argc, char **argv) {
         }
         if (opt.only_gen_index) {
             auto start_write_index = high_resolution_clock::now();
-            index.write(opt.ref_filename + ".sti");
+            index.write(opt.index_filename);
             std::chrono::duration<double> elapsed_write_index = high_resolution_clock::now() - start_write_index;
             logger.info() << "Total time writing index: " << elapsed_write_index.count() << " s\n" << std::endl;
             return EXIT_SUCCESS;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -31,8 +31,9 @@ rm phix.pe.paf
 
 # Build a separate index
 strobealign -r 150 $d/phix.fasta $d/phix.1.fastq > without-sti.sam
-strobealign -r 150 -i $d/phix.fasta
-strobealign -r 150 --use-index $d/phix.fasta $d/phix.1.fastq > with-sti.sam
+strobealign -r 150 -i $d/phix.150.sti $d/phix.fasta
+test -f $d/phix.150.sti
+strobealign -r 150 --use-index $d/phix.150.sti $d/phix.fasta $d/phix.1.fastq > with-sti.sam
 diff -u without-sti.sam with-sti.sam
 rm without-sti.sam with-sti.sam
 


### PR DESCRIPTION
Temporary fix for #133. With this, options `-i` and `--use-index` require the path to the index file. Is this good enough? You do need to adjust the benchmark script, though.
```
strobealign -r 200 -i ref.200.sti ref.fasta
strobealign -r 200 --use-index ref.200.sti ref.fasta reads.1.fastq reads.2.fastq
```
This isn’t as nice as I would like it, but would at least allow you to run the benchmarks. We can then discuss how to improve this later.