### PR TITLE
Fix conversion of reference to uppercase

### DIFF
--- a/src/refs.cpp
+++ b/src/refs.cpp
@@ -11,7 +11,6 @@ References References::from_fasta(const std::string& filename) {
     ref_lengths lengths;
 
     std::ifstream file(filename);
-    std::string line, seq;
 
     if (!file.good()) {
         throw InvalidFasta("Cannot read from FASTA file");
@@ -25,25 +24,25 @@ References References::from_fasta(const std::string& filename) {
         throw InvalidFasta(oss.str().c_str());
     }
 
-    while (getline(file, line)) {
-        if (line[0] == '>') {
+    std::string line, seq, name;
+    bool eof = false;
+    do {
+        eof = !bool{getline(file, line)};
+        if (eof || (!line.empty() && line[0] == '>')) {
             if (seq.length() > 0) {
                 std::transform(seq.begin(), seq.end(), seq.begin(), ::toupper);
                 sequences.push_back(seq);
                 lengths.push_back(seq.length());
+                names.push_back(name);
             }
-            names.push_back(line.substr(1, line.find(' ') - 1)); // cut at first space
+            if (!eof) {
+                name = line.substr(1, line.find(' ') - 1); // cut at first space
+            }
             seq = "";
-        }
-        else {
+        } else {
             seq += line;
         }
-    }
-    if (seq.length() > 0){
-        std::transform(seq.begin(), seq.end(), seq.begin(), ::toupper);
-        sequences.push_back(seq);
-        lengths.push_back(seq.length());
-    }
+    } while (!eof);
 
     return References(std::move(sequences), std::move(names), std::move(lengths));
 }

--- a/src/refs.cpp
+++ b/src/refs.cpp
@@ -28,6 +28,7 @@ References References::from_fasta(const std::string& filename) {
     while (getline(file, line)) {
         if (line[0] == '>') {
             if (seq.length() > 0) {
+                std::transform(seq.begin(), seq.end(), seq.begin(), ::toupper);
                 sequences.push_back(seq);
                 lengths.push_back(seq.length());
             }
@@ -40,7 +41,6 @@ References References::from_fasta(const std::string& filename) {
     }
     if (seq.length() > 0){
         std::transform(seq.begin(), seq.end(), seq.begin(), ::toupper);
-
         sequences.push_back(seq);
         lengths.push_back(seq.length());
     }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -44,6 +44,8 @@ TEST_CASE("Reference uppercase") {
     CHECK(refs.sequences[0] == "ACGT");
     CHECK(refs.sequences[1].size() == 8);
     CHECK(refs.sequences[1] == "AACCGGTT");
+    CHECK(refs.names.size() == 2);
+    CHECK(refs.lengths.size() == 2);
 }
 
 TEST_CASE("estimate_read_length") {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -26,6 +26,26 @@ TEST_CASE("Reference FASTA not found") {
     REQUIRE_THROWS_AS(References::from_fasta("does-not-exist.fasta"), InvalidFasta);
 }
 
+TEST_CASE("Reference uppercase") {
+    {
+        std::ofstream ofs("tmpref.fasta");
+        ofs
+            << ">ref1\n"
+            << "acgt\n\n"
+            << ">ref2\n"
+            << "aacc\ngg\n\ntt\n"
+            << ">empty\n"
+            << ">empty_at_end_of_file";
+    }
+    auto refs = References::from_fasta("tmpref.fasta");
+    std::remove("tmpref.fasta");
+    CHECK(refs.sequences.size() == 2);
+    CHECK(refs.sequences[0].size() == 4);
+    CHECK(refs.sequences[0] == "ACGT");
+    CHECK(refs.sequences[1].size() == 8);
+    CHECK(refs.sequences[1] == "AACCGGTT");
+}
+
 TEST_CASE("estimate_read_length") {
     CHECK(estimate_read_length("tests/phix.1.fastq", "") == 296);
     CHECK(estimate_read_length("tests/phix.1.fastq", "tests/phix.2.fastq") == 296);


### PR DESCRIPTION
I found that commit d9872741201396f2ce144e0b0ed0ce15d7ae5ac3, merged as part of PR #55, is responsible for a decrease in accuracy. The issue is that only the last reference in the FASTA file is converted to uppercase. This problem was not caught using the phiX reference because it only contains one sequence. This PR adds more extensive tests, fixes the bug and also fixes another issue where the `names` attribute could have too many entries.

I don’t know, yet, whether this restores accuracy to the level of v0.7.1. I will check that later.