### PR TITLE
Run tests on a bigger dataset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,39 @@ jobs:
           make install
       - name: Run
         run: tests/run.sh
+
+  compare:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cat tests/baseline-commit.txt >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.baseline_commit }}
+          path: baseline
+      - name: Build baseline version
+        run: |
+          cd baseline
+          cmake -B build
+          make -j3 -C build
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install samtools python3-pysam
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install samtools pysam
+      - name: Download test dataset
+        run: tests/download.sh
+      - name: Generate baseline BAM
+        run: |
+          baseline/build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view --no-PG -o baseline.bam
+      - name: Build HEAD version
+        run: |
+          cmake -B build
+          make -j3 -C build
+      - name: Generate HEAD BAM
+        run: |
+          build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view --no-PG -o head.bam

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: brew install samtools pysam
+      - name: Cache test dataset
+        uses: actions/cache@v3
+        with:
+          key: test-data-${{ hashFiles('tests/download.sh') }}
+          path: tests/drosophila/
       - name: Download test dataset
         run: tests/download.sh
       - name: Generate baseline BAM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,12 @@ jobs:
         run: tests/download.sh
       - name: Generate baseline BAM
         run: |
-          baseline/build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view --no-PG -o baseline.bam
+          baseline/build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view -o baseline.bam
       - name: Build HEAD version
         run: |
           cmake -B build
           make -j3 -C build
       - name: Generate HEAD BAM
-        run: |
-          build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view --no-PG -o head.bam
+        run: build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view -o head.bam
+      - name: Compare
+        run: python3 tests/samdiff.py baseline.bam head.bam

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,0 +1,1 @@
+baseline_commit=ef86bce15896b5cca437c54ff95dfad40da2145a

--- a/tests/download.sh
+++ b/tests/download.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Test StrobeAlign on a small, but non-toy dataset
+
+# Downlad data
+mkdir -p tests/drosophila
+cd tests/drosophila
+
+if ! [[ -e ref.fasta ]]; then
+  curl https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/215/GCF_000001215.4_Release_6_plus_ISO1_MT/GCF_000001215.4_Release_6_plus_ISO1_MT_genomic.fna.gz | gunzip > ref.fasta.tmp
+  mv ref.fasta.tmp ref.fasta
+fi
+for r in 1 2; do
+    f=reads.${r}.fastq.gz
+    if ! [[ -e ${f} ]]; then
+      set +o pipefail
+      wget -nv -O - ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR605/006/SRR6055476/SRR6055476_${r}.fastq.gz | zcat | head -n 400000 | gzip > ${f}.tmp
+      set -o pipefail
+      mv ${f}.tmp ${f}
+    fi
+done
+

--- a/tests/samdiff.py
+++ b/tests/samdiff.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Compare two SAM/BAM files and optionally determine whether the differences
+make the results better or worse compared to a third file representing the
+"truth".
+
+Queries in all input files must be in the same order (with identical QNAME).
+Record identity is based on reference name and reference start position
+(RNAME, POS) only. Differences in the other SAM fields (flags, MAPQ, CIGAR,
+RNEXT, PNEXT, TLEN) are ignored.
+"""
+import sys
+from argparse import ArgumentParser
+from contextlib import ExitStack
+from itertools import repeat
+
+from pysam import AlignmentFile, AlignedSegment
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("before")
+    parser.add_argument("after")
+    parser.add_argument("--truth")
+    parser.add_argument(
+        "--limit", metavar="N", type=int, default=10,
+        help="Report details for at most N changed records"
+    )
+    args = parser.parse_args()
+    has_truth = bool(args.truth)
+    limit = args.limit
+    with ExitStack() as stack:
+        before = stack.enter_context(AlignmentFile(args.before))
+        after = stack.enter_context(AlignmentFile(args.after))
+        if has_truth:
+            truth = stack.enter_context(AlignmentFile(args.truth))
+        else:
+            truth = repeat(None)
+        single_total = 0
+        unmapped_same = 0
+        became_unmapped = 0
+        became_mapped = 0
+        identical = 0
+        multimapper_same = 0
+        multimapper_better = 0
+        changed = 0
+
+        # The following three are only updated if truth is available
+        same = 0
+        better = 0
+        worse = 0
+
+        for b, a, t in zip(before, after, truth):
+            assert b.query_name[:-2] == a.query_name[:-2]
+            if has_truth:
+                assert a.query_name[:-2] == t.query_name
+            single_total += 1
+
+            if b.is_unmapped and a.is_unmapped:
+                unmapped_same += 1
+                continue
+
+            if a.is_unmapped:
+                became_unmapped += 1
+                continue
+
+            if b.is_unmapped:
+                became_mapped += 1
+                continue
+
+            assert not a.is_unmapped and not b.is_unmapped
+
+            b_tup = (b.reference_name, b.reference_start)
+            a_tup = (a.reference_name, a.reference_start)
+            if b_tup == a_tup:
+                identical += 1
+                continue
+
+            b_score = b.get_tag("AS")
+            a_score = a.get_tag("AS")
+            if b.mapping_quality == 0 and a.mapping_quality == 0 and b.is_proper_pair == a.is_proper_pair:
+                if b_score == a_score:
+                    multimapper_same += 1
+                    continue
+
+                if b_score < a_score:
+                    multimapper_better += 1
+                    continue
+
+            if has_truth:
+                t_tup = (t.reference_name, t.reference_start)
+                if a_tup != t_tup and b_tup != t_tup:
+                    same += 1
+                    continue
+
+                if a_tup == t_tup:
+                    better += 1
+                    continue
+                assert b_tup == t_tup
+                worse += 1
+            changed += 1
+            if changed <= limit:
+                print_comparison(b, a)
+
+    if changed > limit:
+        print(
+            f"Reporting limit reached, not showing {changed - limit} "
+            "additional changed records."
+        )
+    print()
+
+    def stat(name, value):
+        print(f"{name:>35}: {value:>9}")
+
+    stat("total", single_total)
+    stat("unmapped before and after", unmapped_same)
+    stat("became mapped", became_mapped)
+    stat("became unmapped", became_unmapped)
+    stat("identical locus", identical)
+    stat("both multimappers, same scores", multimapper_same)
+    stat("both multimappers, score got better", multimapper_better)
+    if has_truth:
+        stat("both incorrect", same)
+        stat("became correct", better)
+        stat("became incorrect", worse)
+    else:
+        stat("other changes", changed)
+
+    if unmapped_same + identical < single_total:
+        sys.exit(1)
+
+
+def print_comparison(b: AlignedSegment, a: AlignedSegment):
+    assert b.query_name[:-2] == a.query_name[:-2]
+    print(b.query_name)
+
+    def compare(name, before, after):
+        if before == after:
+            s = str(before)
+        else:
+            s = f"{before} -> {after}"
+        print("  ", name.rjust(12) + ":", s)
+
+    compare("MAPQ", b.mapping_quality, a.mapping_quality)
+    compare("score", b.get_tag("AS"), a.get_tag("AS"))
+    compare("NM", b.get_tag("NM"), a.get_tag("NM"))
+    compare("TLEN", b.template_length, a.template_length)
+    compare("proper pair", yesno(b.is_proper_pair), yesno(a.is_proper_pair))
+    compare("CIGAR", b.cigarstring, a.cigarstring)
+    compare("ref", b.reference_name, a.reference_name)
+    compare("pos", b.reference_start, a.reference_start)
+    print()
+
+
+def yesno(b: bool) -> str:
+    return "yes" if b else "no"
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds another GitHub Actions job that tests StrobeAlign on a somewhat bigger dataset. The idea is to compare the SAM/BAM output against a "baseline" commit for which we assume StrobeAlign produces correct results.

The file `tests/baseline_commit.txt` sets this baseline commit. It is currently ef86bce15896b5cca437c54ff95dfad40da2145a, which is the same as the current main. We have established that this version gives us results that are sufficienty close in accuracy to v0.7.1, so this should be a good starting point. Whenever mapping results change on purpose, we need to update the commit hash in that file. I am not super happy with this procedure and would prefer to not have this manual update, but have to think a bit how to improve upon that.

The steps of the GitHub Action are as follows:
1. A *D. melanogaster* reference and 100'000 real reads from the Sequence Read Archive are downloaded. This step takes a bit long, so I tried to enable caching for it. This means that the dataset is only re-downloaded from SRA if the `download.sh` script changes, and otherwise the cached files directly from GitHub servers are used.
2. A StrobeAlign binary is built for the baseline commit.
3. A StrobeAlign binary is built for HEAD.
4. The test data is mapped using the baseline binary.
5. The test data is mapped using the HEAD binary.
6. The BAM outputs are compared using a new `samdiff` script. This is based on the script that I wrote for the detective work in #140.

I will temporarily add a commit with a deliberate bug so you can see what the `samdiff` script produces if there are differences. Note that the script only compares reference name and position for each SAM record. It ignores changes in MAPQ, CIGAR, TLEN etc. This is on purpose because this test is about noticing when alignment accuracy decreases. Those other changes should already be caught by the existing tests.

@ksahlin Regarding the choice of dataset, I feel a bit bad that I’m not using one of the simulated datasets that you generated for this. One reason is that these files need to be put somewhere for download and I didn’t quite know where. The main reason, however, was that the real dataset was much better able to flag the bad commits. I evaluated all three datastes (your simulated dataset 1 and 2 and the real Drosophila dataset I use now), and looked at twelve different commits between v0.7.1 and main that introduced some relevant change in alignment results. Dataset 1 flagged 2/12, dataset 2 flagged 6/12 and the real Drosophila dataset flagged 11/12 commits.

The downside with using a real dataset is that we don’t have expected mapping locations. We can start using a simulated dataset when that becomes important.

Closes #128
Closes #140