### PR TITLE
Deliberate bug

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -217,7 +217,7 @@ IndexCreationStatistics index_vector(const hash_vector &h_vector, kmer_lookup &m
     } else {
         filter_cutoff = 30;
     }
-    index_stats.filter_cutoff = filter_cutoff;
+    index_stats.filter_cutoff = filter_cutoff / 2;
     return index_stats;
 }
 


### PR DESCRIPTION
This is a temporary PR related to #145. It shows how the baseline comparison test fails when a bug is introduced that changes mapping results.

Note how the normal tests on phiX do not catch this.