### PR TITLE
Fix: TLEN should be zero when reads map to different contigs 

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1763,9 +1763,9 @@ void rescue_read(
 //            get_MAPQ(all_nams1, n_max1, mapq1);
 //            mapq2 = 0;
         if (swap_r1r2) {
-            sam.add_pair(sam_aln2, sam_aln1, record2, record1, read2.rc(), read1.rc(), mapq2, mapq1, mu, sigma, true);
+            sam.add_pair(sam_aln2, sam_aln1, record2, record1, read2.rc(), read1.rc(), mapq2, mapq1, is_proper_pair(sam_aln2, sam_aln1, mu, sigma), true);
         } else {
-            sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(), mapq1, mapq2, mu, sigma, true);
+            sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(), mapq1, mapq2, is_proper_pair(sam_aln1, sam_aln2, mu, sigma), true);
         }
     } else {
         int max_out = std::min(high_scores.size(), max_secondary);
@@ -1785,9 +1785,11 @@ void rescue_read(
             alignment sam_aln2 = std::get<2>(aln_pair);
             if (s_max - s_score < secondary_dropoff) {
                 if (swap_r1r2) {
-                    sam.add_pair(sam_aln2, sam_aln1, record2, record1, read2.rc(), read1.rc(), mapq2, mapq1, mu, sigma, is_primary);
+                    bool is_proper = is_proper_pair(sam_aln2, sam_aln1, mu, sigma);
+                    sam.add_pair(sam_aln2, sam_aln1, record2, record1, read2.rc(), read1.rc(), mapq2, mapq1, is_proper, is_primary);
                 } else {
-                    sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(), mapq1, mapq2, mu, sigma, is_primary);
+                    bool is_proper = is_proper_pair(sam_aln1, sam_aln2, mu, sigma);
+                    sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(), mapq1, mapq2, is_proper, is_primary);
                 }
             } else {
                 break;
@@ -1937,9 +1939,10 @@ inline void align_PE(
         statistics.tot_all_tried ++;
         int mapq1 = get_MAPQ(all_nams1, n_max1);
         int mapq2 = get_MAPQ(all_nams2, n_max2);
-        sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(), mapq1, mapq2, mu, sigma, true);
+        bool is_proper = is_proper_pair(sam_aln1, sam_aln2, mu, sigma);
+        sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(), mapq1, mapq2, is_proper, true);
 
-        if ((isize_est.sample_size < 400) && ((sam_aln1.ed + sam_aln2.ed) < 3) && sam_aln1.is_proper && sam_aln2.is_proper ){
+        if ((isize_est.sample_size < 400) && ((sam_aln1.ed + sam_aln2.ed) < 3) && is_proper) {
             isize_est.update(std::abs(sam_aln1.ref_start - sam_aln2.ref_start));
         }
         return;
@@ -2102,8 +2105,9 @@ inline void align_PE(
     sam_aln2 = std::get<2>(best_aln_pair);
     if (max_secondary == 0) {
 //            get_MAPQ_aln(sam_aln1, sam_aln2);
+        bool is_proper = is_proper_pair(sam_aln1, sam_aln2, mu, sigma);
         sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(),
-                        mapq1, mapq2, mu, sigma, true);
+                        mapq1, mapq2, is_proper, true);
     } else {
         int max_out = std::min(high_scores.size(), max_secondary);
         // remove eventual duplicates - comes from, e.g., adding individual best alignments above (if identical to joint best alignment)
@@ -2130,8 +2134,9 @@ inline void align_PE(
             }
 
             if (s_max - s_score < secondary_dropoff) {
+                bool is_proper = is_proper_pair(sam_aln1, sam_aln2, mu, sigma);
                 sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(),
-                                mapq1, mapq2, mu, sigma, is_primary);
+                                mapq1, mapq2, is_proper, is_primary);
             } else {
                 break;
             }

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -208,16 +208,9 @@ void Sam::add_pair(
     }
 
     std::string output_read1 = record1.seq;
-    std::string output_read2 = record2.seq;
-
     std::string mate_name1;
-    std::string mate_name2;
-
     std::string ref1;
-    std::string ref2;
     int ed1 = sam_aln1.ed;
-    int ed2 = sam_aln2.ed;
-
     if (sam_aln1.is_unaligned) {
         f1 |= UNMAP;
         f2 |= MUNMAP;
@@ -236,6 +229,11 @@ void Sam::add_pair(
         mate_name1 = references.names[sam_aln1.ref_id];
         ref1 = references.names[sam_aln1.ref_id];
     }
+
+    std::string output_read2 = record2.seq;
+    std::string mate_name2;
+    std::string ref2;
+    int ed2 = sam_aln2.ed;
     if (sam_aln2.is_unaligned) {
         f2 |= UNMAP;
         f1 |= MUNMAP;

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -174,6 +174,13 @@ void Sam::add_pair(
     float sigma,
     bool is_primary
 ) {
+    int f1 = PAIRED | READ1;
+    int f2 = PAIRED | READ2;
+    if (!is_primary) {
+        f1 |= SECONDARY;
+        f2 |= SECONDARY;
+    }
+
     const int dist = sam_aln2.ref_start - sam_aln1.ref_start;
     int template_len1;
     if (dist > 0) {
@@ -196,12 +203,6 @@ void Sam::add_pair(
         sam_aln2.is_proper = false;
     }
 
-    int f1 = PAIRED | READ1;
-    int f2 = PAIRED | READ2;
-    if (!is_primary) {
-        f1 |= SECONDARY;
-        f2 |= SECONDARY;
-    }
     if (sam_aln1.is_proper && sam_aln2.is_proper) {
         f1 |= PROPER_PAIR;
         f2 |= PROPER_PAIR;
@@ -215,7 +216,6 @@ void Sam::add_pair(
         f1 |= UNMAP;
         f2 |= MUNMAP;
         mapq1 = SAM_UNMAPPED_MAPQ;
-        ed1 = 0;
         template_len1 = 0;
         sam_aln1.ref_start = 0;
         ref1 = "*";
@@ -238,7 +238,6 @@ void Sam::add_pair(
         f2 |= UNMAP;
         f1 |= MUNMAP;
         mapq2 = SAM_UNMAPPED_MAPQ;
-        ed2 = 0;
         template_len1 = 0;
         sam_aln2.ref_start = 0;
         ref2 = "*";

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -191,11 +191,12 @@ void Sam::add_pair(
     }
 
     bool both_aligned = !sam_aln1.is_unaligned && !sam_aln2.is_unaligned;
+    bool same_reference = both_aligned && sam_aln1.ref_id == sam_aln2.ref_id;
     bool r1_r2 = !sam_aln1.is_rc && sam_aln2.is_rc && dist >= 0; // r1 ---> <---- r2
     bool r2_r1 = !sam_aln2.is_rc && sam_aln1.is_rc && dist <= 0; // r2 ---> <---- r1
     bool rel_orientation_good = r1_r2 || r2_r1;
     bool insert_good = std::abs(dist) <= mu + 6 * sigma;
-    if (both_aligned && insert_good && rel_orientation_good) {
+    if (same_reference && both_aligned && insert_good && rel_orientation_good) {
         sam_aln1.is_proper = true;
         sam_aln2.is_proper = true;
     } else {

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -180,15 +180,17 @@ void Sam::add_pair(
         f2 |= SECONDARY;
     }
 
-    const int dist = sam_aln2.ref_start - sam_aln1.ref_start;
-    int template_len1;
-    if (dist > 0) {
-        template_len1 = dist + sam_aln2.aln_length;
+    int template_len1 = 0;
+    bool both_aligned = !sam_aln1.is_unaligned && !sam_aln2.is_unaligned;
+    if (both_aligned && sam_aln1.ref_id == sam_aln2.ref_id) {
+        const int dist = sam_aln2.ref_start - sam_aln1.ref_start;
+        if (dist > 0) {
+            template_len1 = dist + sam_aln2.aln_length;
+        }
+        else {
+            template_len1 = dist - sam_aln1.aln_length;
+        }
     }
-    else {
-        template_len1 = dist - sam_aln1.aln_length;
-    }
-
     if (is_proper) {
         f1 |= PROPER_PAIR;
         f2 |= PROPER_PAIR;
@@ -202,8 +204,6 @@ void Sam::add_pair(
     if (sam_aln1.is_unaligned) {
         f1 |= UNMAP;
         f2 |= MUNMAP;
-        mapq1 = SAM_UNMAPPED_MAPQ;
-        template_len1 = 0;
         ref1 = "*";
         ref_start1 = 0;
         mate_name1 = "*";
@@ -225,8 +225,6 @@ void Sam::add_pair(
     if (sam_aln2.is_unaligned) {
         f2 |= UNMAP;
         f1 |= MUNMAP;
-        mapq2 = SAM_UNMAPPED_MAPQ;
-        template_len1 = 0;
         ref_start2 = 0;
         ref2 = "*";
         mate_name2 = "*";

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -162,16 +162,15 @@ void Sam::add_one(
 }
 
 void Sam::add_pair(
-    alignment &sam_aln1,
-    alignment &sam_aln2,
+    const alignment &sam_aln1,
+    const alignment &sam_aln2,
     const KSeq& record1,
     const KSeq& record2,
     const std::string &read1_rc,
     const std::string &read2_rc,
     int mapq1,
     int mapq2,
-    float mu,
-    float sigma,
+    bool is_proper,
     bool is_primary
 ) {
     int f1 = PAIRED | READ1;
@@ -190,21 +189,7 @@ void Sam::add_pair(
         template_len1 = dist - sam_aln1.aln_length;
     }
 
-    bool both_aligned = !sam_aln1.is_unaligned && !sam_aln2.is_unaligned;
-    bool same_reference = both_aligned && sam_aln1.ref_id == sam_aln2.ref_id;
-    bool r1_r2 = !sam_aln1.is_rc && sam_aln2.is_rc && dist >= 0; // r1 ---> <---- r2
-    bool r2_r1 = !sam_aln2.is_rc && sam_aln1.is_rc && dist <= 0; // r2 ---> <---- r1
-    bool rel_orientation_good = r1_r2 || r2_r1;
-    bool insert_good = std::abs(dist) <= mu + 6 * sigma;
-    if (same_reference && both_aligned && insert_good && rel_orientation_good) {
-        sam_aln1.is_proper = true;
-        sam_aln2.is_proper = true;
-    } else {
-        sam_aln1.is_proper = false;
-        sam_aln2.is_proper = false;
-    }
-
-    if (sam_aln1.is_proper && sam_aln2.is_proper) {
+    if (is_proper) {
         f1 |= PROPER_PAIR;
         f2 |= PROPER_PAIR;
     }
@@ -212,14 +197,15 @@ void Sam::add_pair(
     std::string output_read1 = record1.seq;
     std::string mate_name1;
     std::string ref1;
+    int ref_start1 = sam_aln1.ref_start;
     int ed1 = sam_aln1.ed;
     if (sam_aln1.is_unaligned) {
         f1 |= UNMAP;
         f2 |= MUNMAP;
         mapq1 = SAM_UNMAPPED_MAPQ;
         template_len1 = 0;
-        sam_aln1.ref_start = 0;
         ref1 = "*";
+        ref_start1 = 0;
         mate_name1 = "*";
     } else {
         if (sam_aln1.is_rc) {
@@ -234,13 +220,14 @@ void Sam::add_pair(
     std::string output_read2 = record2.seq;
     std::string mate_name2;
     std::string ref2;
+    int ref_start2 = sam_aln2.ref_start;
     int ed2 = sam_aln2.ed;
     if (sam_aln2.is_unaligned) {
         f2 |= UNMAP;
         f1 |= MUNMAP;
         mapq2 = SAM_UNMAPPED_MAPQ;
         template_len1 = 0;
-        sam_aln2.ref_start = 0;
+        ref_start2 = 0;
         ref2 = "*";
         mate_name2 = "*";
     } else {
@@ -252,19 +239,31 @@ void Sam::add_pair(
         mate_name2 = references.names[sam_aln2.ref_id];
         ref2 = references.names[sam_aln2.ref_id];
     }
-    if (both_aligned && sam_aln1.ref_id == sam_aln2.ref_id) {
+    if (!sam_aln1.is_unaligned && !sam_aln2.is_unaligned && sam_aln1.ref_id == sam_aln2.ref_id) {
         mate_name1 = "=";
         mate_name2 = "=";
     }
 
     if (sam_aln1.is_unaligned) {
-        add_unmapped_mate(record1, f1, mate_name2, sam_aln2.ref_start);
+        add_unmapped_mate(record1, f1, mate_name2, ref_start2);
     } else {
-        add_one(record1, f1, ref1, sam_aln1, mapq1, mate_name2, sam_aln2.ref_start, template_len1, output_read1, ed1);
+        add_one(record1, f1, ref1, sam_aln1, mapq1, mate_name2, ref_start2, template_len1, output_read1, ed1);
     }
     if (sam_aln2.is_unaligned) {
-        add_unmapped_mate(record2, f2, mate_name1, sam_aln1.ref_start);
+        add_unmapped_mate(record2, f2, mate_name1, ref_start1);
     } else {
-        add_one(record2, f2, ref2, sam_aln2, mapq2, mate_name1, sam_aln1.ref_start, -template_len1, output_read2, ed2);
+        add_one(record2, f2, ref2, sam_aln2, mapq2, mate_name1, ref_start1, -template_len1, output_read2, ed2);
     }
+}
+
+bool is_proper_pair(const alignment& sam_aln1, const alignment& sam_aln2, float mu, float sigma) {
+    const int dist = sam_aln2.ref_start - sam_aln1.ref_start;
+    const bool same_reference = sam_aln1.ref_id == sam_aln2.ref_id;
+    const bool both_aligned = same_reference && !sam_aln1.is_unaligned && !sam_aln2.is_unaligned;
+    const bool r1_r2 = !sam_aln1.is_rc && sam_aln2.is_rc && dist >= 0; // r1 ---> <---- r2
+    const bool r2_r1 = !sam_aln2.is_rc && sam_aln1.is_rc && dist <= 0; // r2 ---> <---- r1
+    const bool rel_orientation_good = r1_r2 || r2_r1;
+    const bool insert_good = std::abs(dist) <= mu + 6 * sigma;
+
+    return both_aligned && insert_good && rel_orientation_good;
 }

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -45,7 +45,7 @@ public:
 
     /* Add an alignment */
     void add(const alignment& sam_aln, const klibpp::KSeq& record, const std::string& sequence_rc, bool is_secondary = false);
-    void add_pair(alignment& sam_aln1, alignment& sam_aln2, const klibpp::KSeq& record1, const klibpp::KSeq& record2, const std::string& read1_rc, const std::string& read2_rc, int mapq1, int mapq2, float mu, float sigma, bool is_primary);
+    void add_pair(const alignment& sam_aln1, const alignment& sam_aln2, const klibpp::KSeq& record1, const klibpp::KSeq& record2, const std::string& read1_rc, const std::string& read2_rc, int mapq1, int mapq2, bool is_proper, bool is_primary);
     void add_unmapped(const klibpp::KSeq& record, int flags = UNMAP);
     void add_unmapped_pair(const klibpp::KSeq& r1, const klibpp::KSeq& r2);
     void add_unmapped_mate(const klibpp::KSeq& record, int flags, const std::string& mate_rname, int mate_pos);
@@ -57,5 +57,6 @@ private:
     const References& references;
 };
 
+bool is_proper_pair(const alignment& sam_aln1, const alignment& sam_aln2, float mu, float sigma);
 
 #endif

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -134,8 +134,7 @@ TEST_CASE("pair with one unmapped SAM record") {
 
     int mapq1 = 55;
     int mapq2 = 57;
-    float mu = 100;
-    float sigma = 50;
+    bool is_proper = false;
     bool is_primary = true;
 
     sam.add_pair(
@@ -147,8 +146,7 @@ TEST_CASE("pair with one unmapped SAM record") {
         read2_rc,
         mapq1,
         mapq2,
-        mu,
-        sigma,
+        is_proper,
         is_primary
     );
     // 89: PAIRED,MUNMAP,REVERSE,READ1
@@ -197,8 +195,7 @@ TEST_CASE("TLEN zero when reads map to different contigs") {
 
     int mapq1 = 55;
     int mapq2 = 57;
-    float mu = 100;
-    float sigma = 50;
+    bool is_proper = false;
     bool is_primary = true;
 
     sam.add_pair(
@@ -210,8 +207,7 @@ TEST_CASE("TLEN zero when reads map to different contigs") {
         read2_rc,
         mapq1,
         mapq2,
-        mu,
-        sigma,
+        is_proper,
         is_primary
     );
     // 65: PAIRED,READ1

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -158,3 +158,66 @@ TEST_CASE("pair with one unmapped SAM record") {
       "readname\t165\t*\t0\t0\t*\tcontig1\t2\t0\tGGTT\tIHB#\n"
     );
 }
+
+TEST_CASE("TLEN zero when reads map to different contigs") {
+    References references;
+    references.add("contig1", "ACGT");
+    references.add("contig2", "GGAA");
+    std::string sam_string;
+    Sam sam(sam_string, references);
+
+    alignment aln1;
+    aln1.ref_id = 0;
+    aln1.is_unaligned = false;
+    aln1.ref_start = 2;
+    aln1.is_rc = false;
+    aln1.ed = 17;
+    aln1.aln_score = 9;
+    aln1.cigar = "2M";
+
+    alignment aln2;
+    aln2.is_unaligned = false;
+    aln2.ref_id = 1;
+    aln2.ref_start = 3;
+    aln2.is_rc = false;
+    aln2.ed = 2;
+    aln2.aln_score = 4;
+    aln2.cigar = "3M";
+
+    klibpp::KSeq record1;
+    klibpp::KSeq record2;
+    record1.name = "readname";
+    record1.seq = "AACC";
+    record1.qual = "#!B<";
+    record2.name = "readname";
+    record2.seq = "GGTT";
+    record2.qual = "IHB#";
+    std::string read1_rc = reverse_complement(record1.seq);
+    std::string read2_rc = reverse_complement(record2.seq);
+
+    int mapq1 = 55;
+    int mapq2 = 57;
+    float mu = 100;
+    float sigma = 50;
+    bool is_primary = true;
+
+    sam.add_pair(
+        aln1,
+        aln2,
+        record1,
+        record2,
+        read1_rc,
+        read2_rc,
+        mapq1,
+        mapq2,
+        mu,
+        sigma,
+        is_primary
+    );
+    // 65: PAIRED,READ1
+    // 129: PAIRED,READ2
+    CHECK(sam_string ==
+      "readname\t65\tcontig1\t2\t55\t2M\tcontig2\t3\t0\tAACC\t#!B<\tNM:i:17\tAS:i:9\n"
+      "readname\t129\tcontig2\t3\t57\t3M\tcontig1\t2\t0\tGGTT\tIHB#\tNM:i:2\tAS:i:4\n"
+    );
+}


### PR DESCRIPTION
I attempted to fix this in #151, which led to different mapping results. With my previous change, `Sam::add_pair` would no longer change the `is_proper` attribute for the two alignments that are passed in. At one of the sites where `add_pair()` was called, this was actually relied upon. I have now extracted a function `is_proper_pair()`, which needs to be called to compute whether an alignment pair is a proper pair. This allows us to make the two `alignment` parameters to `Sam::add_pair` const, which was on my to-do list anyway.

Closes #142