### PR TITLE
De-duplicate randstrobes functions somewhat

### DIFF
--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -453,7 +453,7 @@ mers_vector_read seq_to_randstrobes2_read(
             unsigned int w_end = i+w_max;
             randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
         }
-        else if ((i + w_min + 1 < nr_hashes) && (nr_hashes <= i + w_max) ){
+        else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
             randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
         }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -253,14 +253,9 @@ public:
         return Randstrobe { hash_randstrobe2, seq_pos_strobe1, pos_to_seq_choord[strobe_pos_next] };
     }
 
-    bool has_next(int i) {
-        if (i + w_max < string_hashes.size()) {
-            return true;
-        }
-        if (i + w_min + 1 < string_hashes.size()) {
-            return true;
-        }
-        return false;
+    bool has_next(unsigned int i) {
+        return (i + w_max < string_hashes.size())
+            || (i + w_min + 1 < string_hashes.size());
     }
 
 private:

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -191,12 +191,14 @@ public:
         const std::vector<unsigned int> &pos_to_seq_choord,
         int w_min,
         int w_max,
-        uint64_t q
+        uint64_t q,
+        int max_dist
     ) : string_hashes(string_hashes)
       , pos_to_seq_choord(pos_to_seq_choord)
       , w_min(w_min)
       , w_max(w_max)
       , q(q)
+      , max_dist(max_dist)
     {
     }
 
@@ -246,12 +248,15 @@ public:
         return false;
     }
 
+
+
 private:
     const std::vector<uint64_t> &string_hashes;
     const std::vector<unsigned int> &pos_to_seq_choord;
     const int w_min;
     const int w_max;
     const uint64_t q;
+    const unsigned int max_dist;
 };
 
 
@@ -286,18 +291,19 @@ void seq_to_randstrobes2(
         return;
     }
 
-    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q };
+    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q, max_dist };
 
     // create the randstrobes
     for (unsigned int i = 0; i < nr_hashes; i++) {
+        if (!randstrobe_iter.has_next(i)) {
+            return;
+        }
+
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         unsigned int seq_end = seq_pos_strobe1 + max_dist;
 
-        if (!randstrobe_iter.has_next(i)) {
-            return;
-        }
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
@@ -359,7 +365,7 @@ mers_vector_read seq_to_randstrobes2_read(
     }
 
     // create the randstrobes FW direction!
-    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q };
+    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q, max_dist };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         if (!randstrobe_fwd_iter.has_next(i)) {
             break;
@@ -399,7 +405,7 @@ mers_vector_read seq_to_randstrobes2_read(
         pos_to_seq_choord[i] = read_length - pos_to_seq_choord[i] - k;
     }
 
-    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q };
+    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q, max_dist };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         if (!randstrobe_rc_iter.has_next(i)) {
             return randstrobes2;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -190,10 +190,12 @@ public:
         const std::vector<uint64_t> &string_hashes,
         const std::vector<unsigned int> &pos_to_seq_choord,
         int w_min,
+        int w_max,
         uint64_t q
     ) : string_hashes(string_hashes)
       , pos_to_seq_choord(pos_to_seq_choord)
       , w_min(w_min)
+      , w_max(w_max)
       , q(q)
     {
     }
@@ -238,6 +240,7 @@ private:
     const std::vector<uint64_t> &string_hashes;
     const std::vector<unsigned int> &pos_to_seq_choord;
     const int w_min;
+    const int w_max;
     const uint64_t q;
 };
 
@@ -273,7 +276,7 @@ void seq_to_randstrobes2(
         return;
     }
 
-    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord, w_min, q };
+    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q };
 
     // create the randstrobes
     for (unsigned int i = 0; i < nr_hashes; i++) {
@@ -346,7 +349,7 @@ mers_vector_read seq_to_randstrobes2_read(
     }
 
     // create the randstrobes FW direction!
-    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min, q };
+    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
@@ -385,7 +388,7 @@ mers_vector_read seq_to_randstrobes2_read(
         pos_to_seq_choord[i] = read_length - pos_to_seq_choord[i] - k;
     }
 
-    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord, w_min, q };
+    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
@@ -409,7 +412,7 @@ mers_vector_read seq_to_randstrobes2_read(
 
 
 
-        unsigned int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
+        unsigned int offset_strobe = seq_pos_strobe2 - seq_pos_strobe1;
         QueryMer s {hash_randstrobe2, seq_pos_strobe1, offset_strobe, true};
         randstrobes2.push_back(s);
     }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -200,7 +200,6 @@ public:
         unsigned int w_start,
         unsigned int w_end,
         uint64_t q,
-        unsigned int seq_start,
         unsigned int seq_end_constraint,
         unsigned int strobe1_start
     ) {
@@ -298,11 +297,11 @@ void seq_to_randstrobes2(
         unsigned int w_start = i+w_min;
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end,i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes - 1;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
         }
         else {
             return;
@@ -399,12 +398,12 @@ mers_vector_read seq_to_randstrobes2_read(
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
         }
         else {
             break;
@@ -452,12 +451,12 @@ mers_vector_read seq_to_randstrobes2_read(
         unsigned int w_start = i + w_min;
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
 
         }
         else if ((i + w_min + 1 < nr_hashes) && (nr_hashes <= i + w_max) ){
             unsigned int w_end = nr_hashes -1;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
         }
         else{
             return randstrobes2;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -263,35 +263,18 @@ void seq_to_randstrobes2(
 //    robin_hood::unordered_map< unsigned int, unsigned int>  pos_to_seq_choord;
 //    make_string_to_hashvalues_random_minimizers(seq, string_hashes, pos_to_seq_choord, k, kmask, w);
 
-//    int s = k-4;
-//    int t = 3;
     uint64_t smask=(1ULL<<2*s) - 1;
     make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_choord, kmask, k, smask, s, t);
-//    make_string_to_hashvalues_open_syncmers(seq, string_hashes, pos_to_seq_choord, kmask, k, smask, s, t);
 
     unsigned int nr_hashes = string_hashes.size();
     if (nr_hashes == 0) {
         return;
     }
 
-//        for (unsigned int i = 0; i < seq_length; i++) {
-//        std::cerr << "REF POS INDEXED: " << pos_to_seq_choord[i] << " OTHER DIRECTION: " << seq.length() - pos_to_seq_choord[i] - k <<std::endl;
-//    }
-//    int tmp_cnt = 0;
-//    for (auto a: pos_to_seq_choord){
-//        std::cerr << " OK: " << tmp_cnt << " " << a << std::endl;
-//        tmp_cnt ++;
-//    }
-//    std::cerr << seq << std::endl;
-
     RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord, w_min };
 
     // create the randstrobes
     for (unsigned int i = 0; i < nr_hashes; i++) {
-
-//        if ((i % 1000000) == 0 ){
-//            std::cerr << i << " strobemers created." << std::endl;
-//        }
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
@@ -309,36 +292,17 @@ void seq_to_randstrobes2(
             return;
         }
 
-//        uint64_t hash_randstrobe2 = (string_hashes[i] << k) ^ strobe_hashval_next;
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
 
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
-//        std::cerr <<  "Seed length: " << seq_pos_strobe2 + k - seq_pos_strobe1 << std::endl;
 
         // UNTIL HERE roughly identical
 
         int packed = (ref_index << 8);
-//        int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
         packed = packed + (seq_pos_strobe2 - seq_pos_strobe1);
         MersIndexEntry s {hash_randstrobe2, seq_pos_strobe1, packed};
         flat_vector.push_back(s);
-//        std::cerr << seq_pos_strobe1 << " " << seq_pos_strobe2 << std::endl;
-//        std::cerr << "FORWARD REF: " << seq_pos_strobe1 << " " << seq_pos_strobe2 << " " << hash_randstrobe2 << std::endl;
-//        std::cerr << "REFERENCE: " << seq_pos_strobe1 << " " << seq_pos_strobe2 << " " << hash_randstrobe2 << std::endl;
-
-
-//        auto strobe1 = seq.substr(seq_pos_strobe1, k);
-//        auto strobe2 = seq.substr(seq_pos_strobe2, k);
-//        unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
-//        if (seq_pos_strobe2 > (seq_pos_strobe1+k)) {
-////            std::cerr << seq_pos_strobe1 << " LOOOOL " << seq_pos_strobe2 << " " << seq_pos_strobe2 - (seq_pos_strobe1+k) << std::endl;
-//            std::cerr << std::string(seq_pos_strobe1, ' ') << strobe1 << std::string(seq_pos_strobe2 - (seq_pos_strobe1+k), ' ') << strobe2 << std::endl;
-//        }
-//        std::cerr << i << " " << strobe_pos_next << " " << seq_pos_strobe1 << " " << seq_pos_strobe2 << " " << seq_pos_strobe2 - (seq_pos_strobe1+k) << " " << hash_randstrobe2 << std::endl;
-//        std::cerr << i << " " << strobe_pos_next << std::endl;
-
     }
-//    std::cerr << randstrobes2.size() << " randstrobes generated" << '\n';
 }
 
 
@@ -374,20 +338,11 @@ mers_vector_read seq_to_randstrobes2_read(
 //    int t = 3;
     uint64_t smask=(1ULL<<2*s) - 1;
     make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_choord, kmask, k, smask, s, t);
-//    make_string_to_hashvalues_open_syncmers(seq, string_hashes, pos_to_seq_choord, kmask, k, smask, s, t);
 
     unsigned int nr_hashes = string_hashes.size();
-//    std::cerr << nr_hashes << " okay" << std::endl;
     if (nr_hashes == 0) {
         return randstrobes2;
     }
-
-//    int tmp_cnt = 0;
-//    for (auto a: pos_to_seq_choord){
-//        std::cerr << " OK: " << tmp_cnt << " " << a << std::endl;
-//        tmp_cnt ++;
-//    }
-//    std::cerr << seq << std::endl;
 
     // create the randstrobes FW direction!
     RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min };
@@ -410,7 +365,6 @@ mers_vector_read seq_to_randstrobes2_read(
             break;
         }
 
-//        uint64_t hash_randstrobe2 = (string_hashes[i] << k) ^ strobe_hashval_next;
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
 
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
@@ -422,17 +376,6 @@ mers_vector_read seq_to_randstrobes2_read(
         unsigned int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
         QueryMer s {hash_randstrobe2, seq_pos_strobe1, offset_strobe, false};
         randstrobes2.push_back(s);
-//        std::cerr << "FORWARD: " << seq_pos_strobe1 << " " << seq_pos_strobe2 << " " << hash_randstrobe2 << std::endl;
-
-//        auto strobe1 = seq.substr(seq_pos_strobe1, k);
-//        unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
-//        if (seq_pos_strobe2 > (seq_pos_strobe1+k)) {
-////            std::cerr << seq_pos_strobe1 << " LOOOOL " << seq_pos_strobe2 << " " << seq_pos_strobe2 - (seq_pos_strobe1+k) << std::endl;
-//            std::cerr << std::string(seq_pos_strobe1, ' ') << strobe1 << std::string(seq_pos_strobe2 - (seq_pos_strobe1+k), ' ') << std::string(k, 'X') << std::endl;
-//        }
-//        std::cerr << i << " " << strobe_pos_next << " " << seq_pos_strobe1 << " " << seq_pos_strobe2 << " " << seq_pos_strobe2 - (seq_pos_strobe1+k) << " " << hash_randstrobe2 << std::endl;
-//        std::cerr << i << " " << strobe_pos_next << std::endl;
-
     }
 
     // create the randstrobes Reverse direction!
@@ -461,23 +404,12 @@ mers_vector_read seq_to_randstrobes2_read(
             return randstrobes2;
         }
 
-//        uint64_t hash_randstrobe2 = (string_hashes[i] << k) ^ strobe_hashval_next;
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
 
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
         unsigned int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
         QueryMer s {hash_randstrobe2, seq_pos_strobe1, offset_strobe, true};
         randstrobes2.push_back(s);
-
-//        auto strobe1 = seq.substr(seq_pos_strobe1, k);
-//        unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
-//        if (seq_pos_strobe2 > (seq_pos_strobe1+k)) {
-////            std::cerr << seq_pos_strobe1 << " LOOOOL " << seq_pos_strobe2 << " " << seq_pos_strobe2 - (seq_pos_strobe1+k) << std::endl;
-//            std::cerr << std::string(seq_pos_strobe1, ' ') << strobe1 << std::string(seq_pos_strobe2 - (seq_pos_strobe1+k), ' ') << std::string(k, 'X') << std::endl;
-//        }
-//        std::cerr << i << " " << strobe_pos_next << " " << seq_pos_strobe1 << " " << seq_pos_strobe2 << " " << seq_pos_strobe2 - (seq_pos_strobe1+k) << " " << hash_randstrobe2 << std::endl;
-//        std::cerr << i << " " << strobe_pos_next << std::endl;
-
     }
     return randstrobes2;
 }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -306,9 +306,6 @@ void seq_to_randstrobes2(
             unsigned int w_end = nr_hashes - 1;
             randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
         }
-        else {
-            return;
-        }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
@@ -382,9 +379,6 @@ mers_vector_read seq_to_randstrobes2_read(
             // writes to strobe_pos_next, strobe_hashval_next
             randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
         }
-        else {
-            break;
-        }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
@@ -426,9 +420,6 @@ mers_vector_read seq_to_randstrobes2_read(
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
             randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
-        }
-        else {
-            return randstrobes2;
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -296,7 +296,6 @@ void seq_to_randstrobes2(
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end,i);
-
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes - 1;
@@ -387,7 +386,7 @@ mers_vector_read seq_to_randstrobes2_read(
 //    std::cerr << seq << std::endl;
 
     // create the randstrobes FW direction!
-    RandstrobeIterator randstrobe_iter;
+    RandstrobeIterator randstrobe_fwd_iter;
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
@@ -397,12 +396,12 @@ mers_vector_read seq_to_randstrobes2_read(
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else {
             break;
@@ -440,6 +439,7 @@ mers_vector_read seq_to_randstrobes2_read(
         pos_to_seq_choord[i] = read_length - pos_to_seq_choord[i] - k;
     }
 
+    RandstrobeIterator randstrobe_rc_iter;
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
@@ -449,12 +449,12 @@ mers_vector_read seq_to_randstrobes2_read(
         unsigned int w_start = i + w_min;
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
         else if ((i + w_min + 1 < nr_hashes) && (nr_hashes <= i + w_max) ){
             unsigned int w_end = nr_hashes -1;
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else{
             return randstrobes2;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -187,6 +187,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::
 struct Randstrobe {
     uint64_t hash;
     unsigned int strobe1_pos;
+    unsigned int strobe2_pos;
 };
 
 class RandstrobeIterator {
@@ -250,7 +251,8 @@ public:
     //    std::cerr << "Offset: " <<  strobe_pos_next - w_start << " val: " << min_val <<  ", P exact:" <<  1.0 - pow ( (float) (8-min_val)/9, strobe_pos_next - w_start) << std::endl;
 
         uint64_t hash_randstrobe2 = string_hashes[strobe1_start] + strobe_hashval_next;
-        return Randstrobe { hash_randstrobe2, seq_pos_strobe1 };
+
+        return Randstrobe { hash_randstrobe2, seq_pos_strobe1, pos_to_seq_choord[strobe_pos_next] };
     }
 
     bool has_next(int i) {
@@ -319,12 +321,10 @@ void seq_to_randstrobes2(
 
         auto randstrobe = randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
-        unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
-
         // UNTIL HERE roughly identical
 
         int packed = (ref_index << 8);
-        packed = packed + (seq_pos_strobe2 - randstrobe.strobe1_pos);
+        packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
         MersIndexEntry s {randstrobe.hash, randstrobe.strobe1_pos, packed};
         flat_vector.push_back(s);
     }
@@ -380,13 +380,11 @@ mers_vector_read seq_to_randstrobes2_read(
         uint64_t strobe_hashval_next;
         auto randstrobe = randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
-        unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
-
         // UNTIL HERE roughly identical
 
         // Output: from the above: seq_pos_strobe2, seq_pos_strobe1
 
-        unsigned int offset_strobe =  seq_pos_strobe2 - randstrobe.strobe1_pos;
+        unsigned int offset_strobe =  randstrobe.strobe2_pos - randstrobe.strobe1_pos;
         QueryMer s {randstrobe.hash, randstrobe.strobe1_pos, offset_strobe, false};
         randstrobes2.push_back(s);
     }
@@ -409,9 +407,7 @@ mers_vector_read seq_to_randstrobes2_read(
 
         auto randstrobe = randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
-        unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
-
-        unsigned int offset_strobe = seq_pos_strobe2 - randstrobe.strobe1_pos;
+        unsigned int offset_strobe = randstrobe.strobe2_pos - randstrobe.strobe1_pos;
         QueryMer s {randstrobe.hash, randstrobe.strobe1_pos, offset_strobe, true};
         randstrobes2.push_back(s);
     }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -188,21 +188,23 @@ class RandstrobeIterator {
 public:
     RandstrobeIterator(
         const std::vector<uint64_t> &string_hashes,
-        const std::vector<unsigned int> &pos_to_seq_choord
+        const std::vector<unsigned int> &pos_to_seq_choord,
+        int w_min
     ) : string_hashes(string_hashes)
       , pos_to_seq_choord(pos_to_seq_choord)
+      , w_min(w_min)
     {
     }
 
     void get_next_strobe_dist_constraint(
         unsigned int &strobe_pos_next,  // Output
         uint64_t &strobe_hashval_next,  // Output
-        unsigned int w_start,
         unsigned int w_end,
         uint64_t q,
         unsigned int seq_end_constraint,
         unsigned int strobe1_start
     ) {
+        unsigned int w_start = strobe1_start + w_min;
         uint64_t strobe_hashval = string_hashes[strobe1_start];
 
         uint64_t min_val = UINT64_MAX;
@@ -234,6 +236,7 @@ public:
 private:
     const std::vector<uint64_t> &string_hashes;
     const std::vector<unsigned int> &pos_to_seq_choord;
+    int w_min;
 };
 
 
@@ -281,7 +284,7 @@ void seq_to_randstrobes2(
 //    }
 //    std::cerr << seq << std::endl;
 
-    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord };
+    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord, w_min };
 
     // create the randstrobes
     for (unsigned int i = 0; i < nr_hashes; i++) {
@@ -294,14 +297,13 @@ void seq_to_randstrobes2(
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         unsigned int seq_end = seq_pos_strobe1 + max_dist;
 
-        unsigned int w_start = i+w_min;
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes - 1;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
         }
         else {
             return;
@@ -388,22 +390,21 @@ mers_vector_read seq_to_randstrobes2_read(
 //    std::cerr << seq << std::endl;
 
     // create the randstrobes FW direction!
-    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord };
+    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         unsigned int seq_end = seq_pos_strobe1 + max_dist;
-        unsigned int w_start = i+w_min;
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
         }
         else {
             break;
@@ -441,22 +442,20 @@ mers_vector_read seq_to_randstrobes2_read(
         pos_to_seq_choord[i] = read_length - pos_to_seq_choord[i] - k;
     }
 
-    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord };
+    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord, w_min };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         unsigned int seq_end = seq_pos_strobe1 + max_dist;
 
-        unsigned int w_start = i + w_min;
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
-
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
         }
         else if ((i + w_min + 1 < nr_hashes) && (nr_hashes <= i + w_max) ){
             unsigned int w_end = nr_hashes -1;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
         }
         else{
             return randstrobes2;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -208,11 +208,9 @@ public:
     {
     }
 
-    Randstrobe get_next_strobe_dist_constraint(
-        unsigned int &strobe_pos_next,  // Output
-        uint64_t &strobe_hashval_next,  // Output
-        unsigned int strobe1_start
-    ) {
+    Randstrobe get_next_strobe_dist_constraint(unsigned int strobe1_start) {
+        unsigned int strobe_pos_next;
+        uint64_t strobe_hashval_next;
         unsigned int w_end;
         if (strobe1_start + w_max < string_hashes.size()) {
             w_end = strobe1_start + w_max;
@@ -265,8 +263,6 @@ public:
         return false;
     }
 
-
-
 private:
     const std::vector<uint64_t> &string_hashes;
     const std::vector<unsigned int> &pos_to_seq_choord;
@@ -316,12 +312,7 @@ void seq_to_randstrobes2(
             return;
         }
 
-        unsigned int strobe_pos_next;
-        uint64_t strobe_hashval_next;
-
-        auto randstrobe = randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
-
-        // UNTIL HERE roughly identical
+        auto randstrobe = randstrobe_iter.get_next_strobe_dist_constraint(i);
 
         int packed = (ref_index << 8);
         packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
@@ -375,14 +366,7 @@ mers_vector_read seq_to_randstrobes2_read(
         if (!randstrobe_fwd_iter.has_next(i)) {
             break;
         }
-
-        unsigned int strobe_pos_next;
-        uint64_t strobe_hashval_next;
-        auto randstrobe = randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
-
-        // UNTIL HERE roughly identical
-
-        // Output: from the above: seq_pos_strobe2, seq_pos_strobe1
+        auto randstrobe = randstrobe_fwd_iter.get_next_strobe_dist_constraint(i);
 
         unsigned int offset_strobe =  randstrobe.strobe2_pos - randstrobe.strobe1_pos;
         QueryMer s {randstrobe.hash, randstrobe.strobe1_pos, offset_strobe, false};
@@ -401,11 +385,7 @@ mers_vector_read seq_to_randstrobes2_read(
         if (!randstrobe_rc_iter.has_next(i)) {
             return randstrobes2;
         }
-
-        unsigned int strobe_pos_next;
-        uint64_t strobe_hashval_next;
-
-        auto randstrobe = randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
+        auto randstrobe = randstrobe_rc_iter.get_next_strobe_dist_constraint(i);
 
         unsigned int offset_strobe = randstrobe.strobe2_pos - randstrobe.strobe1_pos;
         QueryMer s {randstrobe.hash, randstrobe.strobe1_pos, offset_strobe, true};

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -202,7 +202,7 @@ public:
     {
     }
 
-    void get_next_strobe_dist_constraint(
+    uint64_t get_next_strobe_dist_constraint(
         unsigned int &strobe_pos_next,  // Output
         uint64_t &strobe_hashval_next,  // Output
         unsigned int strobe1_start
@@ -232,7 +232,7 @@ public:
             uint64_t res = b.count();
 
             if (pos_to_seq_choord[i] > seq_end_constraint){
-                return;
+                break;
             }
 
             if (res < min_val){
@@ -244,6 +244,8 @@ public:
         }
     //    std::cerr << "Offset: " <<  strobe_pos_next - w_start << " val: " << min_val <<  ", P exact:" <<  1.0 - pow ( (float) (8-min_val)/9, strobe_pos_next - w_start) << std::endl;
 
+        uint64_t hash_randstrobe2 = string_hashes[strobe1_start] + strobe_hashval_next;
+        return hash_randstrobe2;
     }
 
     bool has_next(int i) {
@@ -311,9 +313,8 @@ void seq_to_randstrobes2(
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
 
-        randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
+        uint64_t hash_randstrobe2 = randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
-        uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
 
         // UNTIL HERE roughly identical
@@ -375,9 +376,8 @@ mers_vector_read seq_to_randstrobes2_read(
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         // writes to strobe_pos_next, strobe_hashval_next
-        randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
+        uint64_t hash_randstrobe2 = randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
-        uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
 
         // UNTIL HERE roughly identical
@@ -409,9 +409,8 @@ mers_vector_read seq_to_randstrobes2_read(
         if (!randstrobe_rc_iter.has_next(i)) {
             return randstrobes2;
         }
-        randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
+        uint64_t hash_randstrobe2 = randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
-        uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
 
         unsigned int offset_strobe = seq_pos_strobe2 - seq_pos_strobe1;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -205,9 +205,15 @@ public:
     void get_next_strobe_dist_constraint(
         unsigned int &strobe_pos_next,  // Output
         uint64_t &strobe_hashval_next,  // Output
-        unsigned int w_end,
         unsigned int strobe1_start
     ) {
+        unsigned int w_end;
+        if (strobe1_start + w_max < string_hashes.size()) {
+            w_end = strobe1_start + w_max;
+        } else if (strobe1_start + w_min + 1 < string_hashes.size()) {
+            w_end = string_hashes.size() - 1;
+        }
+
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[strobe1_start];
         unsigned int seq_end_constraint = seq_pos_strobe1 + max_dist;
 
@@ -306,12 +312,10 @@ void seq_to_randstrobes2(
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
 
         if (i + w_max < nr_hashes){
-            unsigned int w_end = i+w_max;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
-            unsigned int w_end = nr_hashes - 1;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
@@ -376,14 +380,12 @@ mers_vector_read seq_to_randstrobes2_read(
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         if (i + w_max < nr_hashes){
-            unsigned int w_end = i+w_max;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
         }
-        else if (i + w_min + 1 < nr_hashes) {
-            unsigned int w_end = nr_hashes -1;
+        else if (i + w_min + 1 < string_hashes.size()) {
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
@@ -418,19 +420,15 @@ mers_vector_read seq_to_randstrobes2_read(
         if (!randstrobe_rc_iter.has_next(i)) {
             return randstrobes2;
         }
-        if (i + w_max < nr_hashes){
-            unsigned int w_end = i+w_max;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
+        if (i + w_max < string_hashes.size()){
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
         }
-        else if (i + w_min + 1 < nr_hashes) {
-            unsigned int w_end = nr_hashes -1;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
+        else if (i + w_min + 1 < string_hashes.size()) {
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
-
-
 
         unsigned int offset_strobe = seq_pos_strobe2 - seq_pos_strobe1;
         QueryMer s {hash_randstrobe2, seq_pos_strobe1, offset_strobe, true};

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -184,39 +184,68 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::
 //    std::cerr << " " << std::endl;
 }
 
-
-static inline void get_next_strobe_dist_constraint(const std::vector<uint64_t> &string_hashes, const std::vector<unsigned int> &pos_to_seq_choord, uint64_t strobe_hashval, unsigned int &strobe_pos_next, uint64_t &strobe_hashval_next,  unsigned int w_start, unsigned int w_end, uint64_t q, unsigned int seq_start, unsigned int seq_end_constraint, unsigned int strobe1_start)
-{
-    uint64_t min_val = UINT64_MAX;
-    strobe_pos_next = strobe1_start; // Defaults if no nearby syncmer
-    strobe_hashval_next = string_hashes[strobe1_start];
-    std::bitset<64> b;
-
-    for (auto i = w_start; i <= w_end; i++) {
-
-        // Method 3' skew sample more for prob exact matching
-        b = (strobe_hashval ^ string_hashes[i])  & q;
-        uint64_t res = b.count();
-
-        if (pos_to_seq_choord[i] > seq_end_constraint){
-            return;
-        }
-
-        if (res < min_val){
-            min_val = res;
-            strobe_pos_next = i;
-//            std::cerr << strobe_pos_next << " " << min_val << std::endl;
-            strobe_hashval_next = string_hashes[i];
-        }
+class RandstrobeIterator {
+public:
+    RandstrobeIterator() {
     }
-//    std::cerr << "Offset: " <<  strobe_pos_next - w_start << " val: " << min_val <<  ", P exact:" <<  1.0 - pow ( (float) (8-min_val)/9, strobe_pos_next - w_start) << std::endl;
 
-}
+    void get_next_strobe_dist_constraint(
+        const std::vector<uint64_t> &string_hashes,
+        const std::vector<unsigned int> &pos_to_seq_choord,
+        uint64_t strobe_hashval,
+        unsigned int &strobe_pos_next,  // Output
+        uint64_t &strobe_hashval_next,  // Output
+        unsigned int w_start,
+        unsigned int w_end,
+        uint64_t q,
+        unsigned int seq_start,
+        unsigned int seq_end_constraint,
+        unsigned int strobe1_start
+    ) {
+        uint64_t min_val = UINT64_MAX;
+        strobe_pos_next = strobe1_start; // Defaults if no nearby syncmer
+        strobe_hashval_next = string_hashes[strobe1_start];
+        std::bitset<64> b;
+
+        for (auto i = w_start; i <= w_end; i++) {
+
+            // Method 3' skew sample more for prob exact matching
+            b = (strobe_hashval ^ string_hashes[i])  & q;
+            uint64_t res = b.count();
+
+            if (pos_to_seq_choord[i] > seq_end_constraint){
+                return;
+            }
+
+            if (res < min_val){
+                min_val = res;
+                strobe_pos_next = i;
+    //            std::cerr << strobe_pos_next << " " << min_val << std::endl;
+                strobe_hashval_next = string_hashes[i];
+            }
+        }
+    //    std::cerr << "Offset: " <<  strobe_pos_next - w_start << " val: " << min_val <<  ", P exact:" <<  1.0 - pow ( (float) (8-min_val)/9, strobe_pos_next - w_start) << std::endl;
+
+    }
+
+private:
 
 
+};
 
-void seq_to_randstrobes2(ind_mers_vector& flat_vector, int k, int w_min, int w_max, const std::string &seq, int ref_index, int s, int t, uint64_t q, int max_dist)
-{
+
+void seq_to_randstrobes2(
+    ind_mers_vector& flat_vector,
+    int k,
+    int w_min,
+    int w_max,
+    const std::string &seq,
+    int ref_index,
+    int s,
+    int t,
+    uint64_t q,
+    int max_dist
+) {
     if (seq.length() < w_max) {
         return;
     }
@@ -249,6 +278,8 @@ void seq_to_randstrobes2(ind_mers_vector& flat_vector, int k, int w_min, int w_m
 //    }
 //    std::cerr << seq << std::endl;
 
+    RandstrobeIterator randstrobe_iter;
+
     // create the randstrobes
     for (unsigned int i = 0; i < nr_hashes; i++) {
 
@@ -266,7 +297,7 @@ void seq_to_randstrobes2(ind_mers_vector& flat_vector, int k, int w_min, int w_m
             uint64_t strobe_hash;
             strobe_hash = string_hashes[i];
 //            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end,i);
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end,i);
 
         }
         else if (i + w_min + 1 < nr_hashes) {
@@ -275,7 +306,7 @@ void seq_to_randstrobes2(ind_mers_vector& flat_vector, int k, int w_min, int w_m
             uint64_t strobe_hash;
             strobe_hash = string_hashes[i];
 //            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
         else {
@@ -286,8 +317,12 @@ void seq_to_randstrobes2(ind_mers_vector& flat_vector, int k, int w_min, int w_m
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
 
 
+
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
 //        std::cerr <<  "Seed length: " << seq_pos_strobe2 + k - seq_pos_strobe1 << std::endl;
+
+        // UNTIL HERE roughly identical
+
         int packed = (ref_index << 8);
 //        int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
         packed = packed + (seq_pos_strobe2 - seq_pos_strobe1);
@@ -312,8 +347,17 @@ void seq_to_randstrobes2(ind_mers_vector& flat_vector, int k, int w_min, int w_m
 //    std::cerr << randstrobes2.size() << " randstrobes generated" << '\n';
 }
 
-mers_vector_read seq_to_randstrobes2_read(int k, int w_min, int w_max, const std::string& seq, int s, int t, uint64_t q, int max_dist)
-{
+
+mers_vector_read seq_to_randstrobes2_read(
+    int k,
+    int w_min,
+    int w_max,
+    const std::string& seq,
+    int s,
+    int t,
+    uint64_t q,
+    int max_dist
+) {
     // this function differs from  the function seq_to_randstrobes2 which creating randstrobes for the reference.
     // The seq_to_randstrobes2 stores randstobes only in one direction from canonical syncmers.
     // this function stores randstobes from both directions created from canonical syncmers.
@@ -352,6 +396,7 @@ mers_vector_read seq_to_randstrobes2_read(int k, int w_min, int w_max, const std
 //    std::cerr << seq << std::endl;
 
     // create the randstrobes FW direction!
+    RandstrobeIterator randstrobe_iter;
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
@@ -363,7 +408,8 @@ mers_vector_read seq_to_randstrobes2_read(int k, int w_min, int w_max, const std
             uint64_t strobe_hash;
             strobe_hash = string_hashes[i];
 //            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            // writes to strobe_pos_next, strobe_hashval_next
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
         else if (i + w_min + 1 < nr_hashes) {
@@ -372,7 +418,8 @@ mers_vector_read seq_to_randstrobes2_read(int k, int w_min, int w_max, const std
             uint64_t strobe_hash;
             strobe_hash = string_hashes[i];
 //            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            // writes to strobe_pos_next, strobe_hashval_next
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else{
 //            std::cerr << randstrobes2.size() << " randstrobes generated" << '\n';
@@ -383,6 +430,11 @@ mers_vector_read seq_to_randstrobes2_read(int k, int w_min, int w_max, const std
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
 
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
+
+        // UNTIL HERE roughly identical
+
+        // Output: from the above: seq_pos_strobe2, seq_pos_strobe1, hash_randstrobe2
+
         unsigned int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
         QueryMer s {hash_randstrobe2, seq_pos_strobe1, offset_strobe, false};
         randstrobes2.push_back(s);
@@ -418,7 +470,7 @@ mers_vector_read seq_to_randstrobes2_read(int k, int w_min, int w_max, const std
             uint64_t strobe_hash;
             strobe_hash = string_hashes[i];
 //            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
         else if ((i + w_min + 1 < nr_hashes) && (nr_hashes <= i + w_max) ){
@@ -427,7 +479,7 @@ mers_vector_read seq_to_randstrobes2_read(int k, int w_min, int w_max, const std
             uint64_t strobe_hash;
             strobe_hash = string_hashes[i];
 //            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
         else{

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -311,12 +311,7 @@ void seq_to_randstrobes2(
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
 
-        if (i + w_max < nr_hashes){
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
-        }
-        else if (i + w_min + 1 < nr_hashes) {
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
-        }
+        randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
@@ -379,14 +374,8 @@ mers_vector_read seq_to_randstrobes2_read(
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
-        if (i + w_max < nr_hashes){
-            // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
-        }
-        else if (i + w_min + 1 < string_hashes.size()) {
-            // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
-        }
+        // writes to strobe_pos_next, strobe_hashval_next
+        randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
@@ -420,12 +409,7 @@ mers_vector_read seq_to_randstrobes2_read(
         if (!randstrobe_rc_iter.has_next(i)) {
             return randstrobes2;
         }
-        if (i + w_max < string_hashes.size()){
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
-        }
-        else if (i + w_min + 1 < string_hashes.size()) {
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
-        }
+        randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -192,7 +192,6 @@ public:
     void get_next_strobe_dist_constraint(
         const std::vector<uint64_t> &string_hashes,
         const std::vector<unsigned int> &pos_to_seq_choord,
-        uint64_t strobe_hashval,
         unsigned int &strobe_pos_next,  // Output
         uint64_t &strobe_hashval_next,  // Output
         unsigned int w_start,
@@ -202,6 +201,8 @@ public:
         unsigned int seq_end_constraint,
         unsigned int strobe1_start
     ) {
+        uint64_t strobe_hashval = string_hashes[strobe1_start];
+
         uint64_t min_val = UINT64_MAX;
         strobe_pos_next = strobe1_start; // Defaults if no nearby syncmer
         strobe_hashval_next = string_hashes[strobe1_start];
@@ -294,20 +295,13 @@ void seq_to_randstrobes2(
         if (i + w_max < nr_hashes){
             unsigned int w_start = i+w_min;
             unsigned int w_end = i+w_max;
-            uint64_t strobe_hash;
-            strobe_hash = string_hashes[i];
-//            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end,i);
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end,i);
 
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_start = i+w_min;
             unsigned int w_end = nr_hashes - 1;
-            uint64_t strobe_hash;
-            strobe_hash = string_hashes[i];
-//            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
-
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else {
             return;
@@ -405,21 +399,15 @@ mers_vector_read seq_to_randstrobes2_read(
         if (i + w_max < nr_hashes){
             unsigned int w_start = i+w_min;
             unsigned int w_end = i+w_max;
-            uint64_t strobe_hash;
-            strobe_hash = string_hashes[i];
-//            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_start = i+w_min;
             unsigned int w_end = nr_hashes -1;
-            uint64_t strobe_hash;
-            strobe_hash = string_hashes[i];
-//            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else{
 //            std::cerr << randstrobes2.size() << " randstrobes generated" << '\n';
@@ -467,23 +455,15 @@ mers_vector_read seq_to_randstrobes2_read(
         if (i + w_max < nr_hashes){
             unsigned int w_start = i+w_min;
             unsigned int w_end = i+w_max;
-            uint64_t strobe_hash;
-            strobe_hash = string_hashes[i];
-//            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
         else if ((i + w_min + 1 < nr_hashes) && (nr_hashes <= i + w_max) ){
             unsigned int w_start = i+w_min;
             unsigned int w_end = nr_hashes -1;
-            uint64_t strobe_hash;
-            strobe_hash = string_hashes[i];
-//            get_next_strobe(string_hashes, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q);
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_hash, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
-
+            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else{
-//            std::cerr << randstrobes2.size() << " randstrobes generated" << '\n';
             return randstrobes2;
         }
 

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -206,9 +206,11 @@ public:
         unsigned int &strobe_pos_next,  // Output
         uint64_t &strobe_hashval_next,  // Output
         unsigned int w_end,
-        unsigned int seq_end_constraint,
         unsigned int strobe1_start
     ) {
+        unsigned int seq_pos_strobe1 = pos_to_seq_choord[strobe1_start];
+        unsigned int seq_end_constraint = seq_pos_strobe1 + max_dist;
+
         unsigned int w_start = strobe1_start + w_min;
         uint64_t strobe_hashval = string_hashes[strobe1_start];
 
@@ -302,15 +304,14 @@ void seq_to_randstrobes2(
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
-        unsigned int seq_end = seq_pos_strobe1 + max_dist;
 
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes - 1;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
@@ -374,16 +375,15 @@ mers_vector_read seq_to_randstrobes2_read(
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
-        unsigned int seq_end = seq_pos_strobe1 + max_dist;
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
@@ -414,18 +414,17 @@ mers_vector_read seq_to_randstrobes2_read(
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
-        unsigned int seq_end = seq_pos_strobe1 + max_dist;
 
         if (!randstrobe_rc_iter.has_next(i)) {
             return randstrobes2;
         }
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, i);
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -236,6 +236,16 @@ public:
 
     }
 
+    bool has_next(int i) {
+        if (i + w_max < string_hashes.size()) {
+            return true;
+        }
+        if (i + w_min + 1 < string_hashes.size()) {
+            return true;
+        }
+        return false;
+    }
+
 private:
     const std::vector<uint64_t> &string_hashes;
     const std::vector<unsigned int> &pos_to_seq_choord;
@@ -285,6 +295,9 @@ void seq_to_randstrobes2(
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         unsigned int seq_end = seq_pos_strobe1 + max_dist;
 
+        if (!randstrobe_iter.has_next(i)) {
+            return;
+        }
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
@@ -351,6 +364,10 @@ mers_vector_read seq_to_randstrobes2_read(
     // create the randstrobes FW direction!
     RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q };
     for (unsigned int i = 0; i < nr_hashes; i++) {
+        if (!randstrobe_fwd_iter.has_next(i)) {
+            break;
+        }
+
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
@@ -390,11 +407,18 @@ mers_vector_read seq_to_randstrobes2_read(
 
     RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q };
     for (unsigned int i = 0; i < nr_hashes; i++) {
+        if (!randstrobe_rc_iter.has_next(i)) {
+            return randstrobes2;
+        }
+
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         unsigned int seq_end = seq_pos_strobe1 + max_dist;
 
+        if (!randstrobe_rc_iter.has_next(i)) {
+            return randstrobes2;
+        }
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -292,14 +292,13 @@ void seq_to_randstrobes2(
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         unsigned int seq_end = seq_pos_strobe1 + max_dist;
 
+        unsigned int w_start = i+w_min;
         if (i + w_max < nr_hashes){
-            unsigned int w_start = i+w_min;
             unsigned int w_end = i+w_max;
             randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end,i);
 
         }
         else if (i + w_min + 1 < nr_hashes) {
-            unsigned int w_start = i+w_min;
             unsigned int w_end = nr_hashes - 1;
             randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
@@ -309,8 +308,6 @@ void seq_to_randstrobes2(
 
 //        uint64_t hash_randstrobe2 = (string_hashes[i] << k) ^ strobe_hashval_next;
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
-
-
 
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
 //        std::cerr <<  "Seed length: " << seq_pos_strobe2 + k - seq_pos_strobe1 << std::endl;
@@ -396,21 +393,18 @@ mers_vector_read seq_to_randstrobes2_read(
         uint64_t strobe_hashval_next;
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         unsigned int seq_end = seq_pos_strobe1 + max_dist;
+        unsigned int w_start = i+w_min;
         if (i + w_max < nr_hashes){
-            unsigned int w_start = i+w_min;
             unsigned int w_end = i+w_max;
             // writes to strobe_pos_next, strobe_hashval_next
             randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
-
         }
         else if (i + w_min + 1 < nr_hashes) {
-            unsigned int w_start = i+w_min;
             unsigned int w_end = nr_hashes -1;
             // writes to strobe_pos_next, strobe_hashval_next
             randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
-        else{
-//            std::cerr << randstrobes2.size() << " randstrobes generated" << '\n';
+        else {
             break;
         }
 
@@ -452,14 +446,13 @@ mers_vector_read seq_to_randstrobes2_read(
         unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
         unsigned int seq_end = seq_pos_strobe1 + max_dist;
 
+        unsigned int w_start = i + w_min;
         if (i + w_max < nr_hashes){
-            unsigned int w_start = i+w_min;
             unsigned int w_end = i+w_max;
             randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
         else if ((i + w_min + 1 < nr_hashes) && (nr_hashes <= i + w_max) ){
-            unsigned int w_start = i+w_min;
             unsigned int w_end = nr_hashes -1;
             randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -237,8 +237,8 @@ public:
 private:
     const std::vector<uint64_t> &string_hashes;
     const std::vector<unsigned int> &pos_to_seq_choord;
-    int w_min;
-    uint64_t q;
+    const int w_min;
+    const uint64_t q;
 };
 
 
@@ -295,7 +295,6 @@ void seq_to_randstrobes2(
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
-
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
 
         // UNTIL HERE roughly identical
@@ -368,7 +367,6 @@ mers_vector_read seq_to_randstrobes2_read(
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
-
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
 
         // UNTIL HERE roughly identical
@@ -402,13 +400,15 @@ mers_vector_read seq_to_randstrobes2_read(
             unsigned int w_end = nr_hashes -1;
             randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
         }
-        else{
+        else {
             return randstrobes2;
         }
 
         uint64_t hash_randstrobe2 = (string_hashes[i]) + (strobe_hashval_next);
-
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
+
+
+
         unsigned int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
         QueryMer s {hash_randstrobe2, seq_pos_strobe1, offset_strobe, true};
         randstrobes2.push_back(s);

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -186,6 +186,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::
 
 struct Randstrobe {
     uint64_t hash;
+    unsigned int strobe1_pos;
 };
 
 class RandstrobeIterator {
@@ -249,7 +250,7 @@ public:
     //    std::cerr << "Offset: " <<  strobe_pos_next - w_start << " val: " << min_val <<  ", P exact:" <<  1.0 - pow ( (float) (8-min_val)/9, strobe_pos_next - w_start) << std::endl;
 
         uint64_t hash_randstrobe2 = string_hashes[strobe1_start] + strobe_hashval_next;
-        return Randstrobe { hash_randstrobe2 };
+        return Randstrobe { hash_randstrobe2, seq_pos_strobe1 };
     }
 
     bool has_next(int i) {
@@ -315,7 +316,6 @@ void seq_to_randstrobes2(
 
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
-        unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
 
         auto randstrobe = randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
@@ -324,8 +324,8 @@ void seq_to_randstrobes2(
         // UNTIL HERE roughly identical
 
         int packed = (ref_index << 8);
-        packed = packed + (seq_pos_strobe2 - seq_pos_strobe1);
-        MersIndexEntry s {randstrobe.hash, seq_pos_strobe1, packed};
+        packed = packed + (seq_pos_strobe2 - randstrobe.strobe1_pos);
+        MersIndexEntry s {randstrobe.hash, randstrobe.strobe1_pos, packed};
         flat_vector.push_back(s);
     }
 }
@@ -378,8 +378,6 @@ mers_vector_read seq_to_randstrobes2_read(
 
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
-        unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
-        // writes to strobe_pos_next, strobe_hashval_next
         auto randstrobe = randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
@@ -388,8 +386,8 @@ mers_vector_read seq_to_randstrobes2_read(
 
         // Output: from the above: seq_pos_strobe2, seq_pos_strobe1
 
-        unsigned int offset_strobe =  seq_pos_strobe2 - seq_pos_strobe1;
-        QueryMer s {randstrobe.hash, seq_pos_strobe1, offset_strobe, false};
+        unsigned int offset_strobe =  seq_pos_strobe2 - randstrobe.strobe1_pos;
+        QueryMer s {randstrobe.hash, randstrobe.strobe1_pos, offset_strobe, false};
         randstrobes2.push_back(s);
     }
 
@@ -408,14 +406,13 @@ mers_vector_read seq_to_randstrobes2_read(
 
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
-        unsigned int seq_pos_strobe1 = pos_to_seq_choord[i];
 
         auto randstrobe = randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, i);
 
         unsigned int seq_pos_strobe2 = pos_to_seq_choord[strobe_pos_next];
 
-        unsigned int offset_strobe = seq_pos_strobe2 - seq_pos_strobe1;
-        QueryMer s {randstrobe.hash, seq_pos_strobe1, offset_strobe, true};
+        unsigned int offset_strobe = seq_pos_strobe2 - randstrobe.strobe1_pos;
+        QueryMer s {randstrobe.hash, randstrobe.strobe1_pos, offset_strobe, true};
         randstrobes2.push_back(s);
     }
     return randstrobes2;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -189,10 +189,12 @@ public:
     RandstrobeIterator(
         const std::vector<uint64_t> &string_hashes,
         const std::vector<unsigned int> &pos_to_seq_choord,
-        int w_min
+        int w_min,
+        uint64_t q
     ) : string_hashes(string_hashes)
       , pos_to_seq_choord(pos_to_seq_choord)
       , w_min(w_min)
+      , q(q)
     {
     }
 
@@ -200,7 +202,6 @@ public:
         unsigned int &strobe_pos_next,  // Output
         uint64_t &strobe_hashval_next,  // Output
         unsigned int w_end,
-        uint64_t q,
         unsigned int seq_end_constraint,
         unsigned int strobe1_start
     ) {
@@ -237,6 +238,7 @@ private:
     const std::vector<uint64_t> &string_hashes;
     const std::vector<unsigned int> &pos_to_seq_choord;
     int w_min;
+    uint64_t q;
 };
 
 
@@ -271,7 +273,7 @@ void seq_to_randstrobes2(
         return;
     }
 
-    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord, w_min };
+    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord, w_min, q };
 
     // create the randstrobes
     for (unsigned int i = 0; i < nr_hashes; i++) {
@@ -282,11 +284,11 @@ void seq_to_randstrobes2(
 
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes - 1;
-            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
         }
         else {
             return;
@@ -345,7 +347,7 @@ mers_vector_read seq_to_randstrobes2_read(
     }
 
     // create the randstrobes FW direction!
-    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min };
+    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min, q };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
@@ -354,12 +356,12 @@ mers_vector_read seq_to_randstrobes2_read(
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
         }
         else {
             break;
@@ -385,7 +387,7 @@ mers_vector_read seq_to_randstrobes2_read(
         pos_to_seq_choord[i] = read_length - pos_to_seq_choord[i] - k;
     }
 
-    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord, w_min };
+    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord, w_min, q };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
@@ -394,11 +396,11 @@ mers_vector_read seq_to_randstrobes2_read(
 
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, q, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_end, seq_end, i);
         }
         else{
             return randstrobes2;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -186,12 +186,15 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::
 
 class RandstrobeIterator {
 public:
-    RandstrobeIterator() {
+    RandstrobeIterator(
+        const std::vector<uint64_t> &string_hashes,
+        const std::vector<unsigned int> &pos_to_seq_choord
+    ) : string_hashes(string_hashes)
+      , pos_to_seq_choord(pos_to_seq_choord)
+    {
     }
 
     void get_next_strobe_dist_constraint(
-        const std::vector<uint64_t> &string_hashes,
-        const std::vector<unsigned int> &pos_to_seq_choord,
         unsigned int &strobe_pos_next,  // Output
         uint64_t &strobe_hashval_next,  // Output
         unsigned int w_start,
@@ -230,8 +233,8 @@ public:
     }
 
 private:
-
-
+    const std::vector<uint64_t> &string_hashes;
+    const std::vector<unsigned int> &pos_to_seq_choord;
 };
 
 
@@ -279,7 +282,7 @@ void seq_to_randstrobes2(
 //    }
 //    std::cerr << seq << std::endl;
 
-    RandstrobeIterator randstrobe_iter;
+    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord };
 
     // create the randstrobes
     for (unsigned int i = 0; i < nr_hashes; i++) {
@@ -295,11 +298,11 @@ void seq_to_randstrobes2(
         unsigned int w_start = i+w_min;
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end,i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end,i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes - 1;
-            randstrobe_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else {
             return;
@@ -386,7 +389,7 @@ mers_vector_read seq_to_randstrobes2_read(
 //    std::cerr << seq << std::endl;
 
     // create the randstrobes FW direction!
-    RandstrobeIterator randstrobe_fwd_iter;
+    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
@@ -396,12 +399,12 @@ mers_vector_read seq_to_randstrobes2_read(
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else if (i + w_min + 1 < nr_hashes) {
             unsigned int w_end = nr_hashes -1;
             // writes to strobe_pos_next, strobe_hashval_next
-            randstrobe_fwd_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_fwd_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else {
             break;
@@ -439,7 +442,7 @@ mers_vector_read seq_to_randstrobes2_read(
         pos_to_seq_choord[i] = read_length - pos_to_seq_choord[i] - k;
     }
 
-    RandstrobeIterator randstrobe_rc_iter;
+    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord };
     for (unsigned int i = 0; i < nr_hashes; i++) {
         unsigned int strobe_pos_next;
         uint64_t strobe_hashval_next;
@@ -449,12 +452,12 @@ mers_vector_read seq_to_randstrobes2_read(
         unsigned int w_start = i + w_min;
         if (i + w_max < nr_hashes){
             unsigned int w_end = i+w_max;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
 
         }
         else if ((i + w_min + 1 < nr_hashes) && (nr_hashes <= i + w_max) ){
             unsigned int w_end = nr_hashes -1;
-            randstrobe_rc_iter.get_next_strobe_dist_constraint(string_hashes, pos_to_seq_choord, strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
+            randstrobe_rc_iter.get_next_strobe_dist_constraint(strobe_pos_next, strobe_hashval_next, w_start, w_end, q, seq_pos_strobe1, seq_end, i);
         }
         else{
             return randstrobes2;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -209,9 +209,7 @@ public:
     }
 
     Randstrobe next() {
-        Randstrobe r = get(strobe1_start);
-        strobe1_start++;
-        return r;
+        return get(strobe1_start++);
     }
 
     bool has_next() {


### PR DESCRIPTION
This has a lot of commits because I went in small steps, running the tests after each.

This doesn’t actually call one function from the other as I had originally intended, but goes a different way.

The main idea is to introduce a `RandstrobeIterator` class that computes the randstrobes. The previous `get_next_strobe_dist_constraint()` function became a method of that class. All its parameters are passed just once to the `RandstrobeIterator` constructor and are stored in the instance, so they do not need to be passed again on the next iteration. Furthermore, the method returns an instance of a new `Randstrobe` struct instead of using non-const reference parameters. Also, the iterator itself now keeps track of where it is in the `string_hashes` list, so that in the end a single `.next()` (without any parameters) advances from one string hash to the next.

Since all the code dealing with the iteration was moved into this `next()` method, the loop in `seq_to_randstrobes2` and the two `for` loops in `seq_to_randstrobes2_read` are reduced to five lines. They still exist and look quite similar, so there is still some duplication, but I think it’s ok for now. There’s also still some duplication in the setup code, but I’ll also leave that as it is.

I also renamed `seq_to_randstrobes2` to `randstrobes_reference` and `seq_to_randstrobes2_read` to `randstrobes_query`, but that can easily be undone if it’s too progressive ...

Closes #81