### PR TITLE
Log the version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING
       "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,8 +152,11 @@ int run_strobealign(int argc, char **argv) {
     std::tie(opt, map_param) = parse_command_line_arguments(argc, argv);
 
     logger.set_level(opt.verbose ? LOG_DEBUG : LOG_INFO);
+
+    logger.info() << "This is StrobeAlign " << version_string() << '\n';
     if (!opt.r_set && !opt.reads_filename1.empty()) {
         map_param.r = estimate_read_length(opt.reads_filename1, opt.reads_filename2);
+        logger.info() << "Estimated read length: " << map_param.r << " bp\n";
     }
     if (opt.c >= 64 || opt.c <= 0) {
         throw BadParameter("c must be greater than 0 and less than 64");

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -13,6 +13,11 @@ public:
     std::chrono::duration<double> duration() const {
         return std::chrono::high_resolution_clock::now() - start_time;
     }
+
+    std::chrono::duration<double>::rep elapsed() const {
+        return duration().count();
+    }
+
 private:
     std::chrono::time_point<std::chrono::high_resolution_clock> start_time;
 };


### PR DESCRIPTION
This adds the following two lines to the logging output:
```
This is StrobeAlign v0.7.1.0-423-gc5b8545
Estimated read length: 296 bp
```
Also, I converted from direct usage of `std::chrono` to our `Timer` class while I was there.

I think logging could be made a bit nicer in a couple of other ways, but I will open a separate issue about that.