### PR TITLE
Slightly faster syncmer computation

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -30,7 +30,7 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
 
     args::Group seeding(parser, "Seeding:");
     //args::ValueFlag<int> n(parser, "INT", "Number of strobes [2]", {'n'});
-    args::ValueFlag<int> r(parser, "INT", "Mean read length. This parameter is estimated from first 500 records in each read file. No need to set this explicitly unless you have a reason.", {'r'});
+    args::ValueFlag<int> r(parser, "INT", "Mean read length. This parameter is estimated from the first 500 records in each read file. No need to set this explicitly unless you have a reason.", {'r'});
     args::ValueFlag<int> m(parser, "INT", "Maximum seed length. Defaults to r - 50. For reasonable values on -l and -u, the seed length distribution is usually determined by parameters l and u. Then, this parameter is only active in regions where syncmers are very sparse.", {'m'});
 
     args::ValueFlag<int> k(parser, "INT", "Strobe length, has to be below 32. [20]", {'k'});

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -7,35 +7,43 @@
 #include "aln.hpp"
 
 struct CommandLineOptions {
-    // Index parameters
-    bool k_set { false };
-    bool s_set{ false };
-    int k { 20 };
-    int s { 16 };
-    int u { 7 };
-    int l { 0 };
+    int n_threads { 3 };
 
+    // Input/output
+    std::string output_file_name;
+    bool write_to_stdout { true };
+    bool verbose { false };
+    std::string logfile_name { "" };
+    bool only_gen_index { false };
+    bool use_index { false };
+
+    // Seeding
+    bool r_set { false };
+    bool max_seed_len_set { false };
+    bool k_set { false };
+    bool s_set { false };
+    int max_seed_len;
+    int k { 20 };
+    int l { 0 };
+    int u { 7 };
+    int s { 16 };
+    int c { 8 };
+
+    // Alignment
     int A { 2 };
     int B { 8 };
     int O { 12 };
     int E { 1 };
-    int c { 8 };
+
+    // Search parameters
     float f { 0.0002 };
-    int max_seed_len;
-    std::string output_file_name;
-    std::string logfile_name { "" };
-    bool verbose { false };
-    int n_threads { 3 };
-    std::string ref_filename; //This is either a fasta file or an index file - if fasta, indexing will be run
+
+    // Reference and read files
+    std::string ref_filename; // This is either a fasta file or an index file - if fasta, indexing will be run
     std::string reads_filename1;
     std::string reads_filename2;
-    bool is_SE { true };
-    bool write_to_stdout { true };
-    bool r_set { false };
-    bool max_seed_len_set { false };
-    bool only_gen_index { false };
-    bool use_index { false };
     std::string index_out_filename;
+    bool is_SE { true };
 };
 
 std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int argc, char **argv);

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -67,7 +67,7 @@ static inline void update_window(
 static inline void make_string_to_hashvalues_open_syncmers_canonical(
     const std::string &seq,
     std::vector<uint64_t> &string_hashes,
-    std::vector<unsigned int> &pos_to_seq_choord,
+    std::vector<unsigned int> &pos_to_seq_coordinate,
     uint64_t kmask,
     int k,
     uint64_t smask,
@@ -129,7 +129,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                         uint64_t hash_k = XXH64(&yk, 8,0);
 //                        uint64_t hash_k =  sahlin_dna_hash(yk, mask);
                         string_hashes.push_back(hash_k);
-                        pos_to_seq_choord.push_back(i - k + 1);
+                        pos_to_seq_coordinate.push_back(i - k + 1);
                         hash_count++;
 //                        std::cerr << i - s + 1 << " " << i - k + 1 << " " << (xk[0] < xk[1]) << std::endl;
 //                        std::cerr <<  "Sampled gap: " << gap (k-s+1) << std::endl;
@@ -153,7 +153,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                         uint64_t hash_k = XXH64(&yk, 8, 0);
 //                        uint64_t hash_k =  sahlin_dna_hash(yk, mask);
                         string_hashes.push_back(hash_k);
-                        pos_to_seq_choord.push_back(i - k + 1);
+                        pos_to_seq_coordinate.push_back(i - k + 1);
 //                        std::cerr << i - k + 1 << std::endl;
                         hash_count++;
 //                        std::cerr << i - s + 1 << " " << i - k + 1 << " " << (xk[0] < xk[1]) << std::endl;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -76,17 +76,14 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
             uint64_t hash_s = ys;
 //          uint64_t hash_s = hash64(ys, mask);
 //          uint64_t hash_s = XXH64(&ys, 8,0);
-            // queue not initialized yet
-            if (qs_size < k - s ) {
-                qs.push_back(hash_s);
-                qs_pos.push_back(i - s + 1);
-                qs_size++;
+            qs.push_back(hash_s);
+            qs_pos.push_back(i - s + 1);
+            qs_size++;
+            // not enough hashes in the queue, yet
+            if (qs_size < k - s + 1) {
                 continue;
             }
-            if (qs_size == k - s ) { // We are seeing the last s-mer within the first k-mer, need to decide if we add it
-                qs.push_back(hash_s);
-                qs_pos.push_back(i - s + 1);
-                qs_size++;
+            if (qs_size == k - s + 1) { // We are at the last s-mer within the first k-mer, need to decide if we add it
                 for (int j = 0; j < qs_size; j++) {
                     if (qs[j] < qs_min_val) {
                         qs_min_val = qs[j];
@@ -97,14 +94,11 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
             else {
                 // update queue and current minimum and position
                 int i2 = i - s + 1;
-
                 qs.pop_front();
-
                 auto popped_index = qs_pos.front();
                 qs_pos.pop_front();
+                qs_size--;
 
-                qs.push_back(hash_s);
-                qs_pos.push_back(i2);
                 if (qs_min_pos == popped_index){ // we popped the previous minimizer, find new brute force
                     qs_min_val = UINT64_MAX;
                     qs_min_pos = i2;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -41,12 +41,13 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     const std::string &seq,
     std::vector<uint64_t> &string_hashes,
     std::vector<unsigned int> &pos_to_seq_coordinate,
-    const uint64_t kmask,
     const int k,
-    const uint64_t smask,
     const int s,
     const int t
 ) {
+    const uint64_t kmask = (1ULL << 2*k) - 1;
+    const uint64_t smask = (1ULL << 2*s) - 1;
+
     std::deque<uint64_t> qs;  // s-mer hashes
     int seq_length = seq.length();
     uint64_t qs_min_val = UINT64_MAX;
@@ -229,15 +230,13 @@ void randstrobes_reference(
         return;
     }
 
-    uint64_t kmask = (1ULL << 2*k) - 1;
     // make string of strobes into hashvalues all at once to avoid repetitive k-mer to hash value computations
     std::vector<uint64_t> string_hashes;
     std::vector<unsigned int> pos_to_seq_coordinate;
 //    robin_hood::unordered_map< unsigned int, unsigned int>  pos_to_seq_choord;
 //    make_string_to_hashvalues_random_minimizers(seq, string_hashes, pos_to_seq_choord, k, kmask, w);
 
-    uint64_t smask = (1ULL << 2*s) - 1;
-    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_coordinate, kmask, k, smask, s, t);
+    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_coordinate, k, s, t);
 
     unsigned int nr_hashes = string_hashes.size();
     if (nr_hashes == 0) {
@@ -281,13 +280,11 @@ mers_vector_read randstrobes_query(
         return randstrobes2;
     }
 
-    uint64_t kmask = (1ULL << 2*k) - 1;
     // make string of strobes into hashvalues all at once to avoid repetitive k-mer to hash value computations
     std::vector<uint64_t> string_hashes;
     std::vector<unsigned int> pos_to_seq_coordinate;
 
-    uint64_t smask = (1ULL << 2*s) - 1;
-    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_coordinate, kmask, k, smask, s, t);
+    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_coordinate, k, s, t);
 
     unsigned int nr_hashes = string_hashes.size();
     if (nr_hashes == 0) {

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -37,14 +37,14 @@ static inline uint64_t syncmer_kmer_hash(uint64_t packed) {
     return XXH64(&packed, sizeof(uint64_t), 0);
 }
 
-static inline void make_string_to_hashvalues_open_syncmers_canonical(
+static inline std::pair<std::vector<uint64_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
     const std::string &seq,
-    std::vector<uint64_t> &string_hashes,
-    std::vector<unsigned int> &pos_to_seq_coordinate,
     const size_t k,
     const size_t s,
     const size_t t
 ) {
+    std::vector<uint64_t> string_hashes;
+    std::vector<unsigned int> pos_to_seq_coordinate;
     const uint64_t kmask = (1ULL << 2*k) - 1;
     const uint64_t smask = (1ULL << 2*s) - 1;
     const uint64_t kshift = (k - 1) * 2;
@@ -116,6 +116,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
             qs.clear();
         }
     }
+    return make_pair(string_hashes, pos_to_seq_coordinate);
 }
 
 struct Randstrobe {
@@ -233,8 +234,7 @@ void randstrobes_reference(
     std::vector<unsigned int> pos_to_seq_coordinate;
 //    robin_hood::unordered_map< unsigned int, unsigned int>  pos_to_seq_choord;
 //    make_string_to_hashvalues_random_minimizers(seq, string_hashes, pos_to_seq_choord, k, kmask, w);
-
-    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_coordinate, k, s, t);
+    std::tie(string_hashes, pos_to_seq_coordinate) = make_string_to_hashvalues_open_syncmers_canonical(seq, k, s, t);
 
     unsigned int nr_hashes = string_hashes.size();
     if (nr_hashes == 0) {
@@ -282,7 +282,7 @@ mers_vector_read randstrobes_query(
     std::vector<uint64_t> string_hashes;
     std::vector<unsigned int> pos_to_seq_coordinate;
 
-    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_coordinate, k, s, t);
+    std::tie(string_hashes, pos_to_seq_coordinate) = make_string_to_hashvalues_open_syncmers_canonical(seq, k, s, t);
 
     unsigned int nr_hashes = string_hashes.size();
     if (nr_hashes == 0) {

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -74,8 +74,8 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     int s,
     int t
 ) {
-    std::deque<uint64_t> qs;
-    std::deque<unsigned int> qs_pos;
+    std::deque<uint64_t> qs;  // s-mer hashes
+    std::deque<unsigned int> qs_pos; // s-mer start positions
     int seq_length = seq.length();
     int qs_size = 0;
     uint64_t qs_min_val = UINT64_MAX;
@@ -83,7 +83,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
 
     int gap = 0;
     std::string subseq;
-    unsigned int hash_count = 0;
     int l;
     uint64_t xk[] = {0, 0};
     uint64_t xs[] = {0, 0};
@@ -112,9 +111,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                     qs.push_back(hash_s);
                     qs_pos.push_back(i - s + 1);
                     qs_size++;
-//                    std::cerr << qs_size << " "<< i - k + 1 << std::endl;
                     for (int j = 0; j < qs_size; j++) {
-//                        std::cerr << qs_pos[j] << " " << qs[j] << " " << qs_min_val << std::endl;
                         if (qs[j] < qs_min_val) {
                             qs_min_val = qs[j];
                             qs_min_pos = qs_pos[j];
@@ -130,7 +127,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
 //                        uint64_t hash_k =  sahlin_dna_hash(yk, mask);
                         string_hashes.push_back(hash_k);
                         pos_to_seq_coordinate.push_back(i - k + 1);
-                        hash_count++;
 //                        std::cerr << i - s + 1 << " " << i - k + 1 << " " << (xk[0] < xk[1]) << std::endl;
 //                        std::cerr <<  "Sampled gap: " << gap (k-s+1) << std::endl;
                         gap = 0;
@@ -155,7 +151,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                         string_hashes.push_back(hash_k);
                         pos_to_seq_coordinate.push_back(i - k + 1);
 //                        std::cerr << i - k + 1 << std::endl;
-                        hash_count++;
 //                        std::cerr << i - s + 1 << " " << i - k + 1 << " " << (xk[0] < xk[1]) << std::endl;
 //                        std::cerr <<  "Gap: " << gap << " position:" << i - k + 1 << std::endl;
                         gap = 0;
@@ -179,11 +174,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
             qs_pos.clear();
         }
     }
-//    std::cerr << hash_count << " values produced from string of length " <<   seq_length << std::endl;
-//    for(auto t: pos_to_seq_choord){
-//        std::cerr << t << " ";
-//    }
-//    std::cerr << " " << std::endl;
 }
 
 struct Randstrobe {

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -78,8 +78,9 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                     qs.push_back(hash_s);
                     qs_pos.push_back(i - s + 1);
                     qs_size++;
+                    continue;
                 }
-                else if (qs_size == k - s ) { // We are seeing the last s-mer within the first k-mer, need to decide if we add it
+                if (qs_size == k - s ) { // We are seeing the last s-mer within the first k-mer, need to decide if we add it
                     qs.push_back(hash_s);
                     qs_pos.push_back(i - s + 1);
                     qs_size++;
@@ -89,13 +90,8 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                             qs_min_pos = qs_pos[j];
                         }
                     }
-                    if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer
-                        uint64_t yk = std::min(xk[0], xk[1]);
-                        string_hashes.push_back(syncmer_kmer_hash(yk));
-                        pos_to_seq_coordinate.push_back(i - k + 1);
-                    }
                 }
-                else{
+                else {
                     // update queue and current minimum and position
                     int i2 = i - s + 1;
 
@@ -119,12 +115,11 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                         qs_min_val = hash_s;
                         qs_min_pos = i2;
                     }
-
-                    if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer
-                        uint64_t yk = std::min(xk[0], xk[1]);
-                        string_hashes.push_back(syncmer_kmer_hash(yk));
-                        pos_to_seq_coordinate.push_back(i - k + 1);
-                    }
+                }
+                if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer
+                    uint64_t yk = std::min(xk[0], xk[1]);
+                    string_hashes.push_back(syncmer_kmer_hash(yk));
+                    pos_to_seq_coordinate.push_back(i - k + 1);
                 }
             }
         } else {

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -152,51 +152,7 @@ public:
     }
 
 private:
-    Randstrobe get(unsigned int strobe1_start) const {
-        unsigned int strobe_pos_next;
-        uint64_t strobe_hashval_next;
-        unsigned int w_end;
-        if (strobe1_start + w_max < string_hashes.size()) {
-            w_end = strobe1_start + w_max;
-        } else if (strobe1_start + w_min + 1 < string_hashes.size()) {
-            w_end = string_hashes.size() - 1;
-        }
-
-        unsigned int seq_pos_strobe1 = pos_to_seq_coordinate[strobe1_start];
-        unsigned int seq_end_constraint = seq_pos_strobe1 + max_dist;
-
-        unsigned int w_start = strobe1_start + w_min;
-        uint64_t strobe_hashval = string_hashes[strobe1_start];
-
-        uint64_t min_val = UINT64_MAX;
-        strobe_pos_next = strobe1_start; // Defaults if no nearby syncmer
-        strobe_hashval_next = string_hashes[strobe1_start];
-        std::bitset<64> b;
-
-        for (auto i = w_start; i <= w_end; i++) {
-
-            // Method 3' skew sample more for prob exact matching
-            b = (strobe_hashval ^ string_hashes[i])  & q;
-            uint64_t res = b.count();
-
-            if (pos_to_seq_coordinate[i] > seq_end_constraint) {
-                break;
-            }
-
-            if (res < min_val){
-                min_val = res;
-                strobe_pos_next = i;
-    //            std::cerr << strobe_pos_next << " " << min_val << std::endl;
-                strobe_hashval_next = string_hashes[i];
-            }
-        }
-    //    std::cerr << "Offset: " <<  strobe_pos_next - w_start << " val: " << min_val <<  ", P exact:" <<  1.0 - pow ( (float) (8-min_val)/9, strobe_pos_next - w_start) << std::endl;
-
-        uint64_t hash_randstrobe2 = string_hashes[strobe1_start] + strobe_hashval_next;
-
-        return Randstrobe { hash_randstrobe2, seq_pos_strobe1, pos_to_seq_coordinate[strobe_pos_next] };
-    }
-
+    Randstrobe get(unsigned int strobe1_start) const;
     const std::vector<uint64_t> &string_hashes;
     const std::vector<unsigned int> &pos_to_seq_coordinate;
     const int w_min;
@@ -205,6 +161,51 @@ private:
     const unsigned int max_dist;
     unsigned int strobe1_start = 0;
 };
+
+Randstrobe RandstrobeIterator::get(unsigned int strobe1_start) const {
+    unsigned int strobe_pos_next;
+    uint64_t strobe_hashval_next;
+    unsigned int w_end;
+    if (strobe1_start + w_max < string_hashes.size()) {
+        w_end = strobe1_start + w_max;
+    } else if (strobe1_start + w_min + 1 < string_hashes.size()) {
+        w_end = string_hashes.size() - 1;
+    }
+
+    unsigned int seq_pos_strobe1 = pos_to_seq_coordinate[strobe1_start];
+    unsigned int seq_end_constraint = seq_pos_strobe1 + max_dist;
+
+    unsigned int w_start = strobe1_start + w_min;
+    uint64_t strobe_hashval = string_hashes[strobe1_start];
+
+    uint64_t min_val = UINT64_MAX;
+    strobe_pos_next = strobe1_start; // Defaults if no nearby syncmer
+    strobe_hashval_next = string_hashes[strobe1_start];
+    std::bitset<64> b;
+
+    for (auto i = w_start; i <= w_end; i++) {
+
+        // Method 3' skew sample more for prob exact matching
+        b = (strobe_hashval ^ string_hashes[i])  & q;
+        uint64_t res = b.count();
+
+        if (pos_to_seq_coordinate[i] > seq_end_constraint) {
+            break;
+        }
+
+        if (res < min_val){
+            min_val = res;
+            strobe_pos_next = i;
+//            std::cerr << strobe_pos_next << " " << min_val << std::endl;
+            strobe_hashval_next = string_hashes[i];
+        }
+    }
+//    std::cerr << "Offset: " <<  strobe_pos_next - w_start << " val: " << min_val <<  ", P exact:" <<  1.0 - pow ( (float) (8-min_val)/9, strobe_pos_next - w_start) << std::endl;
+
+    uint64_t hash_randstrobe2 = string_hashes[strobe1_start] + strobe_hashval_next;
+
+    return Randstrobe { hash_randstrobe2, seq_pos_strobe1, pos_to_seq_coordinate[strobe_pos_next] };
+}
 
 
 /* Generate randstrobes for a reference sequence. The randstrobes are appended

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -85,10 +85,8 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     std::string subseq;
     unsigned int hash_count = 0;
     int l;
-    uint64_t xk[2];
-    xk[0] = xk[1] = 0;
-    uint64_t xs[2];
-    xs[0] = xs[1] = 0;
+    uint64_t xk[] = {0, 0};
+    uint64_t xs[] = {0, 0};
     uint64_t kshift = (k - 1) * 2;
     uint64_t sshift = (s - 1) * 2;
     for (int i = l = 0; i < seq_length; i++) {

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -47,9 +47,9 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
 ) {
     const uint64_t kmask = (1ULL << 2*k) - 1;
     const uint64_t smask = (1ULL << 2*s) - 1;
-
+    const uint64_t kshift = (k - 1) * 2;
+    const uint64_t sshift = (s - 1) * 2;
     std::deque<uint64_t> qs;  // s-mer hashes
-    int seq_length = seq.length();
     uint64_t qs_min_val = UINT64_MAX;
     int qs_min_pos = -1;
 
@@ -57,9 +57,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     int l = 0;
     uint64_t xk[] = {0, 0};
     uint64_t xs[] = {0, 0};
-    uint64_t kshift = (k - 1) * 2;
-    uint64_t sshift = (s - 1) * 2;
-    for (int i = 0; i < seq_length; i++) {
+    for (size_t i = 0; i < seq.length(); i++) {
         int c = seq_nt4_table[(uint8_t) seq[i]];
         if (c < 4) { // not an "N" base
             xk[0] = (xk[0] << 2 | c) & kmask;                  // forward strand

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -81,7 +81,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     uint64_t qs_min_val = UINT64_MAX;
     int qs_min_pos = -1;
 
-    int gap = 0;
     std::string subseq;
     int l;
     uint64_t xk[] = {0, 0};
@@ -107,7 +106,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                     qs_pos.push_back(i - s + 1);
                     qs_size++;
                 }
-                else if (qs_size == k - s ) { // We are here adding the last s-mer and have filled queue up, need to decide for this k-mer (the first encountered) if we are adding it/
+                else if (qs_size == k - s ) { // We are seeing the last s-mer within the first k-mer, need to decide if we add it
                     qs.push_back(hash_s);
                     qs_pos.push_back(i - s + 1);
                     qs_size++;
@@ -118,7 +117,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                         }
                     }
                     if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer
-//                    if ( (qs_min_pos == qs_pos[t-1]) || ((gap > 10) && ((qs_min_pos == qs_pos[k - s]) || (qs_min_pos == qs_pos[0]))) ) { // occurs at first or last position in k-mer
                         uint64_t yk = std::min(xk[0], xk[1]);
 //                        uint64_t hash_k = robin_hash(yk);
 //                        uint64_t hash_k = yk;
@@ -127,21 +125,12 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
 //                        uint64_t hash_k =  sahlin_dna_hash(yk, mask);
                         string_hashes.push_back(hash_k);
                         pos_to_seq_coordinate.push_back(i - k + 1);
-//                        std::cerr << i - s + 1 << " " << i - k + 1 << " " << (xk[0] < xk[1]) << std::endl;
-//                        std::cerr <<  "Sampled gap: " << gap (k-s+1) << std::endl;
-                        gap = 0;
                     }
                 }
                 else{
                     bool new_minimizer = false;
                     update_window(qs, qs_pos, qs_min_val, qs_min_pos, hash_s, i - s + 1, new_minimizer );
                     if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer
-//                    if ( (qs_min_pos == qs_pos[t-1]) || ((gap > 10) && ((qs_min_pos == qs_pos[k - s]) || (qs_min_pos == qs_pos[0]))) ) { // occurs at first or last position in k-mer
-//                        if ( (gap > k) && (gap < 200) ) { // open syncmers no window guarantee, fill in subsequence with closed syncmers
-//                            subseq = seq.substr(i - k + 1 - gap + 1, gap +k);
-//                            make_string_to_hashvalues_closed_syncmers_canonical(subseq, string_hashes, pos_to_seq_choord, kmask, k, smask, s, t, i - k + 1 - gap + 1);
-//                        }
-
                         uint64_t yk = std::min(xk[0], xk[1]);
 //                        uint64_t hash_k = robin_hash(yk);
 //                        uint64_t hash_k = yk;
@@ -150,19 +139,8 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
 //                        uint64_t hash_k =  sahlin_dna_hash(yk, mask);
                         string_hashes.push_back(hash_k);
                         pos_to_seq_coordinate.push_back(i - k + 1);
-//                        std::cerr << i - k + 1 << std::endl;
-//                        std::cerr << i - s + 1 << " " << i - k + 1 << " " << (xk[0] < xk[1]) << std::endl;
-//                        std::cerr <<  "Gap: " << gap << " position:" << i - k + 1 << std::endl;
-                        gap = 0;
                     }
-                    gap ++;
                 }
-//                if (gap > 25){
-//                    std::cerr <<  "Gap: " << gap << " position:" << i - k + 1 << std::endl;
-//                    if (gap < 500 ) {
-//                        std::cerr << seq.substr(i - k + 1 - gap + 1, gap +k) << std::endl;
-//                    }
-//                }
             }
         } else {
             // if there is an "N", restart

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -49,7 +49,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
 ) {
     std::deque<uint64_t> qs;  // s-mer hashes
     int seq_length = seq.length();
-    int qs_size = 0;
     uint64_t qs_min_val = UINT64_MAX;
     int qs_min_pos = -1;
 
@@ -76,13 +75,12 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
 //          uint64_t hash_s = hash64(ys, mask);
 //          uint64_t hash_s = XXH64(&ys, 8,0);
             qs.push_back(hash_s);
-            qs_size++;
             // not enough hashes in the queue, yet
-            if (qs_size < k - s + 1) {
+            if (qs.size() < k - s + 1) {
                 continue;
             }
-            if (qs_size == k - s + 1) { // We are at the last s-mer within the first k-mer, need to decide if we add it
-                for (int j = 0; j < qs_size; j++) {
+            if (qs.size() == k - s + 1) { // We are at the last s-mer within the first k-mer, need to decide if we add it
+                for (int j = 0; j < qs.size(); j++) {
                     if (qs[j] < qs_min_val) {
                         qs_min_val = qs[j];
                         qs_min_pos = i - k + j + 1;
@@ -92,7 +90,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
             else {
                 // update queue and current minimum and position
                 qs.pop_front();
-                qs_size--;
 
                 if (qs_min_pos == i - k) { // we popped the previous minimizer, find new brute force
                     qs_min_val = UINT64_MAX;
@@ -118,7 +115,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
             qs_min_val = UINT64_MAX;
             qs_min_pos = -1;
             l = xs[0] = xs[1] = xk[0] = xk[1] = 0;
-            qs_size = 0;
             qs.clear();
         }
     }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -128,13 +128,13 @@ class RandstrobeIterator {
 public:
     RandstrobeIterator(
         const std::vector<uint64_t> &string_hashes,
-        const std::vector<unsigned int> &pos_to_seq_choord,
+        const std::vector<unsigned int> &pos_to_seq_coordinate,
         int w_min,
         int w_max,
         uint64_t q,
         int max_dist
     ) : string_hashes(string_hashes)
-      , pos_to_seq_choord(pos_to_seq_choord)
+      , pos_to_seq_coordinate(pos_to_seq_coordinate)
       , w_min(w_min)
       , w_max(w_max)
       , q(q)
@@ -162,7 +162,7 @@ private:
             w_end = string_hashes.size() - 1;
         }
 
-        unsigned int seq_pos_strobe1 = pos_to_seq_choord[strobe1_start];
+        unsigned int seq_pos_strobe1 = pos_to_seq_coordinate[strobe1_start];
         unsigned int seq_end_constraint = seq_pos_strobe1 + max_dist;
 
         unsigned int w_start = strobe1_start + w_min;
@@ -179,7 +179,7 @@ private:
             b = (strobe_hashval ^ string_hashes[i])  & q;
             uint64_t res = b.count();
 
-            if (pos_to_seq_choord[i] > seq_end_constraint){
+            if (pos_to_seq_coordinate[i] > seq_end_constraint) {
                 break;
             }
 
@@ -194,11 +194,11 @@ private:
 
         uint64_t hash_randstrobe2 = string_hashes[strobe1_start] + strobe_hashval_next;
 
-        return Randstrobe { hash_randstrobe2, seq_pos_strobe1, pos_to_seq_choord[strobe_pos_next] };
+        return Randstrobe { hash_randstrobe2, seq_pos_strobe1, pos_to_seq_coordinate[strobe_pos_next] };
     }
 
     const std::vector<uint64_t> &string_hashes;
-    const std::vector<unsigned int> &pos_to_seq_choord;
+    const std::vector<unsigned int> &pos_to_seq_coordinate;
     const int w_min;
     const int w_max;
     const uint64_t q;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -39,8 +39,6 @@ static inline void update_window(
     int i,
     bool &new_minimizer
 ) {
-//    uint64_t popped_val;
-//    popped_val = q.front();
     q.pop_front();
 
     auto popped_index = q_pos.front();
@@ -49,11 +47,9 @@ static inline void update_window(
     q.push_back(new_strobe_hashval);
     q_pos.push_back(i);
     if (q_min_pos == popped_index){ // we popped the previous minimizer, find new brute force
-//    if (popped_val == q_min_val){ // we popped the minimum value, find new brute force
         q_min_val = UINT64_MAX;
         q_min_pos = i;
         for (int j = q.size() - 1; j >= 0; j--) { //Iterate in reverse to choose the rightmost minimizer in a window
-//        for (int j = 0; j <= q.size()-1; j++) {
             if (q[j] < q_min_val) {
                 q_min_val = q[j];
                 q_min_pos = q_pos[j];
@@ -85,11 +81,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     uint64_t qs_min_val = UINT64_MAX;
     int qs_min_pos = -1;
 
-//    robin_hood::hash<uint64_t> robin_hash;
-    uint64_t mask = (1ULL<<2*k) - 1;
-//    std::cerr << mask << std::endl;
-
-//    std::vector<std::tuple<uint64_t, unsigned int, unsigned int> > kmers;
     int gap = 0;
     std::string subseq;
     unsigned int hash_count = 0;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -55,12 +55,12 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     int qs_min_pos = -1;
 
     std::string subseq;
-    int l;
+    int l = 0;
     uint64_t xk[] = {0, 0};
     uint64_t xs[] = {0, 0};
     uint64_t kshift = (k - 1) * 2;
     uint64_t sshift = (s - 1) * 2;
-    for (int i = l = 0; i < seq_length; i++) {
+    for (int i = 0; i < seq_length; i++) {
         int c = seq_nt4_table[(uint8_t) seq[i]];
         if (c < 4) { // not an "N" base
             xk[0] = (xk[0] << 2 | c) & kmask;                  // forward strand
@@ -93,7 +93,6 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
             }
             else {
                 // update queue and current minimum and position
-                int i2 = i - s + 1;
                 qs.pop_front();
                 auto popped_index = qs_pos.front();
                 qs_pos.pop_front();
@@ -101,7 +100,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
 
                 if (qs_min_pos == popped_index){ // we popped the previous minimizer, find new brute force
                     qs_min_val = UINT64_MAX;
-                    qs_min_pos = i2;
+                    qs_min_pos = i - s + 1;
                     for (int j = qs.size() - 1; j >= 0; j--) { //Iterate in reverse to choose the rightmost minimizer in a window
                         if (qs[j] < qs_min_val) {
                             qs_min_val = qs[j];
@@ -110,7 +109,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                     }
                 } else if (hash_s < qs_min_val) { // the new value added to queue is the new minimum
                     qs_min_val = hash_s;
-                    qs_min_pos = i2;
+                    qs_min_pos = i - s + 1;
                 }
             }
             if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -35,8 +35,7 @@ static inline void update_window(std::deque <uint64_t> &q, std::deque <unsigned 
 //    popped_val = q.front();
     q.pop_front();
 
-    unsigned int popped_index;
-    popped_index=q_pos.front();
+    auto popped_index = q_pos.front();
     q_pos.pop_front();
 
     q.push_back(new_strobe_hashval);
@@ -340,7 +339,7 @@ mers_vector_read randstrobes_query(
     // this function stores randstobes from both directions created from canonical syncmers.
     // Since creating canonical syncmers is the most time consuming step, we avoid perfomring it twice for the read and its RC here
     mers_vector_read randstrobes2;
-    unsigned int read_length = seq.length();
+    auto read_length = seq.length();
     if (read_length < w_max) {
         return randstrobes2;
     }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -300,19 +300,19 @@ void randstrobes_reference(
     uint64_t kmask = (1ULL << 2*k) - 1;
     // make string of strobes into hashvalues all at once to avoid repetitive k-mer to hash value computations
     std::vector<uint64_t> string_hashes;
-    std::vector<unsigned int> pos_to_seq_choord;
+    std::vector<unsigned int> pos_to_seq_coordinate;
 //    robin_hood::unordered_map< unsigned int, unsigned int>  pos_to_seq_choord;
 //    make_string_to_hashvalues_random_minimizers(seq, string_hashes, pos_to_seq_choord, k, kmask, w);
 
     uint64_t smask = (1ULL << 2*s) - 1;
-    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_choord, kmask, k, smask, s, t);
+    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_coordinate, kmask, k, smask, s, t);
 
     unsigned int nr_hashes = string_hashes.size();
     if (nr_hashes == 0) {
         return;
     }
 
-    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q, max_dist };
+    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
     while (randstrobe_iter.has_next()) {
         auto randstrobe = randstrobe_iter.next();
         int packed = (ref_index << 8);
@@ -352,17 +352,17 @@ mers_vector_read randstrobes_query(
     uint64_t kmask = (1ULL << 2*k) - 1;
     // make string of strobes into hashvalues all at once to avoid repetitive k-mer to hash value computations
     std::vector<uint64_t> string_hashes;
-    std::vector<unsigned int> pos_to_seq_choord;
+    std::vector<unsigned int> pos_to_seq_coordinate;
 
     uint64_t smask = (1ULL << 2*s) - 1;
-    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_choord, kmask, k, smask, s, t);
+    make_string_to_hashvalues_open_syncmers_canonical(seq, string_hashes, pos_to_seq_coordinate, kmask, k, smask, s, t);
 
     unsigned int nr_hashes = string_hashes.size();
     if (nr_hashes == 0) {
         return randstrobes2;
     }
 
-    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q, max_dist };
+    RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
     while (randstrobe_fwd_iter.has_next()) {
         auto randstrobe = randstrobe_fwd_iter.next();
         unsigned int offset_strobe = randstrobe.strobe2_pos - randstrobe.strobe1_pos;
@@ -371,12 +371,12 @@ mers_vector_read randstrobes_query(
     }
 
     std::reverse(string_hashes.begin(), string_hashes.end());
-    std::reverse(pos_to_seq_choord.begin(), pos_to_seq_choord.end());
+    std::reverse(pos_to_seq_coordinate.begin(), pos_to_seq_coordinate.end());
     for (unsigned int i = 0; i < nr_hashes; i++) {
-        pos_to_seq_choord[i] = read_length - pos_to_seq_choord[i] - k;
+        pos_to_seq_coordinate[i] = read_length - pos_to_seq_coordinate[i] - k;
     }
 
-    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_choord, w_min, w_max, q, max_dist };
+    RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
     while (randstrobe_rc_iter.has_next()) {
         auto randstrobe = randstrobe_rc_iter.next();
         unsigned int offset_strobe = randstrobe.strobe2_pos - randstrobe.strobe1_pos;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -96,10 +96,8 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                     }
                 }
                 else{
-                    int i2 = i - s + 1;
-                    bool new_minimizer = false;
-
                     // update queue and current minimum and position
+                    int i2 = i - s + 1;
 
                     qs.pop_front();
 
@@ -115,13 +113,11 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                             if (qs[j] < qs_min_val) {
                                 qs_min_val = qs[j];
                                 qs_min_pos = qs_pos[j];
-                                new_minimizer = true;
                             }
                         }
                     } else if (hash_s < qs_min_val) { // the new value added to queue is the new minimum
                         qs_min_val = hash_s;
                         qs_min_pos = i2;
-                        new_minimizer = true;
                     }
 
                     if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -41,9 +41,9 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     const std::string &seq,
     std::vector<uint64_t> &string_hashes,
     std::vector<unsigned int> &pos_to_seq_coordinate,
-    const int k,
-    const int s,
-    const int t
+    const size_t k,
+    const size_t s,
+    const size_t t
 ) {
     const uint64_t kmask = (1ULL << 2*k) - 1;
     const uint64_t smask = (1ULL << 2*s) - 1;
@@ -51,10 +51,9 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     const uint64_t sshift = (s - 1) * 2;
     std::deque<uint64_t> qs;  // s-mer hashes
     uint64_t qs_min_val = UINT64_MAX;
-    int qs_min_pos = -1;
+    size_t qs_min_pos = -1;
 
-    std::string subseq;
-    int l = 0;
+    size_t l = 0;
     uint64_t xk[] = {0, 0};
     uint64_t xs[] = {0, 0};
     for (size_t i = 0; i < seq.length(); i++) {
@@ -79,7 +78,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                 continue;
             }
             if (qs.size() == k - s + 1) { // We are at the last s-mer within the first k-mer, need to decide if we add it
-                for (int j = 0; j < qs.size(); j++) {
+                for (size_t j = 0; j < qs.size(); j++) {
                     if (qs[j] < qs_min_val) {
                         qs_min_val = qs[j];
                         qs_min_pos = i - k + j + 1;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -63,6 +63,13 @@ static inline void update_window(
     }
 }
 
+static inline uint64_t syncmer_kmer_hash(uint64_t packed) {
+    // return robin_hash(yk);
+    // return yk;
+    // return hash64(yk, mask);
+    // return sahlin_dna_hash(yk, mask);
+    return XXH64(&packed, sizeof(uint64_t), 0);
+}
 
 static inline void make_string_to_hashvalues_open_syncmers_canonical(
     const std::string &seq,
@@ -118,12 +125,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                     }
                     if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer
                         uint64_t yk = std::min(xk[0], xk[1]);
-//                        uint64_t hash_k = robin_hash(yk);
-//                        uint64_t hash_k = yk;
-//                        uint64_t hash_k =  hash64(yk, mask);
-                        uint64_t hash_k = XXH64(&yk, 8,0);
-//                        uint64_t hash_k =  sahlin_dna_hash(yk, mask);
-                        string_hashes.push_back(hash_k);
+                        string_hashes.push_back(syncmer_kmer_hash(yk));
                         pos_to_seq_coordinate.push_back(i - k + 1);
                     }
                 }
@@ -132,12 +134,7 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
                     update_window(qs, qs_pos, qs_min_val, qs_min_pos, hash_s, i - s + 1, new_minimizer );
                     if (qs_min_pos == qs_pos[t-1]) { // occurs at t:th position in k-mer
                         uint64_t yk = std::min(xk[0], xk[1]);
-//                        uint64_t hash_k = robin_hash(yk);
-//                        uint64_t hash_k = yk;
-//                        uint64_t hash_k = hash64(yk, mask);
-                        uint64_t hash_k = XXH64(&yk, 8, 0);
-//                        uint64_t hash_k =  sahlin_dna_hash(yk, mask);
-                        string_hashes.push_back(hash_k);
+                        string_hashes.push_back(syncmer_kmer_hash(yk));
                         pos_to_seq_coordinate.push_back(i - k + 1);
                     }
                 }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -41,11 +41,11 @@ static inline void make_string_to_hashvalues_open_syncmers_canonical(
     const std::string &seq,
     std::vector<uint64_t> &string_hashes,
     std::vector<unsigned int> &pos_to_seq_coordinate,
-    uint64_t kmask,
-    int k,
-    uint64_t smask,
-    int s,
-    int t
+    const uint64_t kmask,
+    const int k,
+    const uint64_t smask,
+    const int s,
+    const int t
 ) {
     std::deque<uint64_t> qs;  // s-mer hashes
     std::deque<unsigned int> qs_pos; // s-mer start positions

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -30,7 +30,15 @@ static unsigned char seq_nt4_table[256] = {
 };
 
 // update queue and current minimum and position
-static inline void update_window(std::deque <uint64_t> &q, std::deque <unsigned int> &q_pos, uint64_t &q_min_val, int &q_min_pos, uint64_t new_strobe_hashval, int i, bool &new_minimizer){
+static inline void update_window(
+    std::deque<uint64_t> &q,
+    std::deque<unsigned int> &q_pos,
+    uint64_t &q_min_val,
+    int &q_min_pos,
+    uint64_t new_strobe_hashval,
+    int i,
+    bool &new_minimizer
+) {
 //    uint64_t popped_val;
 //    popped_val = q.front();
     q.pop_front();
@@ -52,8 +60,7 @@ static inline void update_window(std::deque <uint64_t> &q, std::deque <unsigned 
                 new_minimizer = true;
             }
         }
-    }
-    else if ( new_strobe_hashval < q_min_val ) { // the new value added to queue is the new minimum
+    } else if (new_strobe_hashval < q_min_val) { // the new value added to queue is the new minimum
         q_min_val = new_strobe_hashval;
         q_min_pos = i;
         new_minimizer = true;
@@ -61,15 +68,22 @@ static inline void update_window(std::deque <uint64_t> &q, std::deque <unsigned 
 }
 
 
-static inline void make_string_to_hashvalues_open_syncmers_canonical(const std::string &seq, std::vector<uint64_t> &string_hashes, std::vector<unsigned int> &pos_to_seq_choord, uint64_t kmask, int k, uint64_t smask, int s, int t)
-{
+static inline void make_string_to_hashvalues_open_syncmers_canonical(
+    const std::string &seq,
+    std::vector<uint64_t> &string_hashes,
+    std::vector<unsigned int> &pos_to_seq_choord,
+    uint64_t kmask,
+    int k,
+    uint64_t smask,
+    int s,
+    int t
+) {
     std::deque<uint64_t> qs;
     std::deque<unsigned int> qs_pos;
     int seq_length = seq.length();
     int qs_size = 0;
     uint64_t qs_min_val = UINT64_MAX;
     int qs_min_pos = -1;
-
 
 //    robin_hood::hash<uint64_t> robin_hash;
     uint64_t mask = (1ULL<<2*k) - 1;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -xeuo pipefail
 
+# Unit tests
+build/test-strobealign
+
 # should fail when unknown command-line option used
 if strobealign -G > /dev/null 2> /dev/null; then false; fi
 
@@ -36,5 +39,3 @@ strobealign -r 150 --use-index $d/phix.fasta $d/phix.1.fastq | grep -v '^@PG' > 
 diff -u without-sti.sam with-sti.sam
 rm without-sti.sam with-sti.sam
 
-# Unit tests
-build/test-strobealign


### PR DESCRIPTION
This PR contains mostly refactoring commits, but the last one 33964c1c9de157a3fd7338712efd4ff117d031b9 is more interesting because it speeds up computation of snycmers a little bit.

I noticed that `make_string_to_hashvalues_open_syncmers_canonical()` keeps track of the s-mer hashes in `qs` and their start positions in `qs_pos`, but the positions can actually be computed when needed. This is possible because `qs_pos` only ever contains consecutive indices (5, 6, 7, etc.).

For mapping 1 million reads from the real Drosophila dataset, overall runtime decreases from ~304 to ~301 seconds (when run with `-t 1`). It appears that the compiler is already quite good at reducing the overhead from using the second `std::deque`, so the benefit isn’t huge. In any case, 1% is better than nothing an readability also improves IMO.