### PR TITLE
Log index creation times in a nicer way

### DIFF
--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -56,7 +56,6 @@ struct AlignmentStatistics {
     std::chrono::duration<double> tot_find_nams_alt;
     std::chrono::duration<double> tot_sort_nams;
     std::chrono::duration<double> tot_extend;
-    std::chrono::duration<double> tot_rc;
     std::chrono::duration<double> tot_write_file;
 
     unsigned int tot_ksw_aligned = 0;
@@ -73,7 +72,6 @@ struct AlignmentStatistics {
         this->tot_find_nams_alt += other.tot_find_nams_alt;
         this->tot_sort_nams += other.tot_sort_nams;
         this->tot_extend += other.tot_extend;
-        this->tot_rc += other.tot_rc;
         this->tot_write_file += other.tot_write_file;
         this->tot_ksw_aligned += other.tot_ksw_aligned;
         this->tot_rescued += other.tot_rescued;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -268,7 +268,6 @@ IndexCreationStatistics StrobemerIndex::populate(float f) {
     Timer flat_vector_timer;
     hash_vector h_vector;
 
-    Timer copy_timer;
     {
         auto ind_flat_vector = generate_seeds();
 
@@ -284,10 +283,7 @@ IndexCreationStatistics StrobemerIndex::populate(float f) {
         }
         // ind_flat_vector is freed here
     }
-    auto elapsed_copy_flat_vector = copy_timer.duration();
-
     uint64_t unique_mers = count_unique_elements(h_vector);
-
     std::chrono::duration<double> elapsed_flat_vector = flat_vector_timer.duration();
 
     Timer hash_index_timer;
@@ -296,7 +292,6 @@ IndexCreationStatistics StrobemerIndex::populate(float f) {
     IndexCreationStatistics index_stats = index_vector(h_vector, mers_index, f);
     filter_cutoff = index_stats.filter_cutoff;
     index_stats.elapsed_hash_index = hash_index_timer.duration();
-    index_stats.elapsed_copy_flat_vector = elapsed_copy_flat_vector;
     index_stats.unique_mers = unique_mers;
     index_stats.elapsed_flat_vector = elapsed_flat_vector;
 
@@ -321,8 +316,10 @@ ind_mers_vector StrobemerIndex::generate_seeds() const
 
     Timer sorting_timer;
     std::sort(ind_flat_vector.begin(), ind_flat_vector.end());
+
     auto elapsed_sorting_seeds = sorting_timer.duration();
     logger.info() << "Time sorting seeds: " << elapsed_sorting_seeds.count() << " s" <<  std::endl;
+
 
     return ind_flat_vector;
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -300,12 +300,10 @@ ind_mers_vector StrobemerIndex::generate_seeds() const
     ind_mers_vector ind_flat_vector; //includes hash - for sorting, will be discarded later
     int expected_sampling = parameters.k - parameters.s + 1;
     int approx_vec_size = references.total_length() / expected_sampling;
-    logger.debug() << "ref vector approximate size: " << approx_vec_size << std::endl;
     ind_flat_vector.reserve(approx_vec_size);
     for(size_t i = 0; i < references.size(); ++i) {
         randstrobes_reference(ind_flat_vector, parameters.k, parameters.w_min, parameters.w_max, references.sequences[i], i, parameters.s, parameters.t_syncmer, parameters.q, parameters.max_dist);
     }
-    logger.debug() << "Ref vector actual size: " << ind_flat_vector.size() << std::endl;
 
     std::chrono::duration<double> elapsed_generating_seeds = flat_vector_timer.duration();
     logger.info() << "Time generating seeds: " << elapsed_generating_seeds.count() << " s" <<  std::endl;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -255,25 +255,25 @@ void StrobemerIndex::read(const std::string& filename) {
 }
 
 void StrobemerIndex::populate(float f) {
-    Timer flat_vector_timer;
     hash_vector h_vector;
     {
         auto ind_flat_vector = generate_and_sort_seeds();
 
-        //Split up the sorted vector into a vector with the hash codes and the flat vector to keep in the index.
-        //The hash codes are only needed when generating the index and can be discarded afterwards.
-        //We want to do this split-up before creating the hash table to avoid a memory peak - the flat_vector is
-        //smaller - doubling that size temporarily will not cause us to go above peak memory.
+        // Split up the sorted vector into a vector with the hash codes and the flat vector to keep in the index.
+        // The hash codes are only needed when generating the index and can be discarded afterwards.
+        // We want to do this split-up before creating the hash table to avoid a memory peak - the flat_vector is
+        // smaller - doubling that size temporarily will not cause us to go above peak memory.
+        Timer flat_vector_timer;
         flat_vector.reserve(ind_flat_vector.size());
         h_vector.reserve(ind_flat_vector.size());
-        for (std::size_t i = 0; i < ind_flat_vector.size(); ++i) {
+        for (size_t i = 0; i < ind_flat_vector.size(); ++i) {
             flat_vector.push_back(ReferenceMer{ind_flat_vector[i].position, ind_flat_vector[i].packed});
             h_vector.push_back(ind_flat_vector[i].hash);
         }
+        stats.elapsed_flat_vector = flat_vector_timer.duration();
         // ind_flat_vector is freed here
     }
-    uint64_t unique_mers = count_unique_elements(h_vector);
-    std::chrono::duration<double> elapsed_flat_vector = flat_vector_timer.duration();
+    auto unique_mers = count_unique_elements(h_vector);
 
     Timer hash_index_timer;
     mers_index.reserve(unique_mers);
@@ -282,7 +282,6 @@ void StrobemerIndex::populate(float f) {
     filter_cutoff = stats.filter_cutoff;
     stats.elapsed_hash_index = hash_index_timer.duration();
     stats.unique_mers = unique_mers;
-    stats.elapsed_flat_vector = elapsed_flat_vector;
 }
 
 ind_mers_vector StrobemerIndex::generate_and_sort_seeds() const

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -12,12 +12,8 @@
 #include <algorithm>
 
 #include "timer.hpp"
-#include "logger.hpp"
 
 typedef std::vector<uint64_t> hash_vector; //only used during index generation
-
-
-static Logger& logger = Logger::get();
 
 
 /* Create an IndexParameters instance based on a given read length.
@@ -296,7 +292,7 @@ void StrobemerIndex::populate(float f) {
 
 ind_mers_vector StrobemerIndex::generate_and_sort_seeds() const
 {
-    Timer flat_vector_timer;
+    Timer randstrobes_timer;
     ind_mers_vector ind_flat_vector; //includes hash - for sorting, will be discarded later
     int expected_sampling = parameters.k - parameters.s + 1;
     int approx_vec_size = references.total_length() / expected_sampling;
@@ -304,16 +300,11 @@ ind_mers_vector StrobemerIndex::generate_and_sort_seeds() const
     for(size_t i = 0; i < references.size(); ++i) {
         randstrobes_reference(ind_flat_vector, parameters.k, parameters.w_min, parameters.w_max, references.sequences[i], i, parameters.s, parameters.t_syncmer, parameters.q, parameters.max_dist);
     }
-
-    std::chrono::duration<double> elapsed_generating_seeds = flat_vector_timer.duration();
-    logger.info() << "Time generating seeds: " << elapsed_generating_seeds.count() << " s" <<  std::endl;
+    stats.elapsed_generating_seeds = randstrobes_timer.duration();
 
     Timer sorting_timer;
     std::sort(ind_flat_vector.begin(), ind_flat_vector.end());
-
-    auto elapsed_sorting_seeds = sorting_timer.duration();
-    logger.info() << "Time sorting seeds: " << elapsed_sorting_seeds.count() << " s" <<  std::endl;
-
+    stats.elapsed_sorting_seeds = sorting_timer.duration();
 
     return ind_flat_vector;
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -267,7 +267,7 @@ void StrobemerIndex::populate(float f) {
     Timer flat_vector_timer;
     hash_vector h_vector;
     {
-        auto ind_flat_vector = generate_seeds();
+        auto ind_flat_vector = generate_and_sort_seeds();
 
         //Split up the sorted vector into a vector with the hash codes and the flat vector to keep in the index.
         //The hash codes are only needed when generating the index and can be discarded afterwards.
@@ -294,7 +294,7 @@ void StrobemerIndex::populate(float f) {
     stats.elapsed_flat_vector = elapsed_flat_vector;
 }
 
-ind_mers_vector StrobemerIndex::generate_seeds() const
+ind_mers_vector StrobemerIndex::generate_and_sort_seeds() const
 {
     Timer flat_vector_timer;
     ind_mers_vector ind_flat_vector; //includes hash - for sorting, will be discarded later

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -194,7 +194,6 @@ IndexCreationStatistics index_vector(const hash_vector &h_vector, kmer_lookup &m
     return index_stats;
 }
 
-
 void StrobemerIndex::write(const std::string& filename) const {
     std::ofstream ofs(filename, std::ios::binary);
 
@@ -264,10 +263,9 @@ void StrobemerIndex::read(const std::string& filename) {
     }
 }
 
-IndexCreationStatistics StrobemerIndex::populate(float f) {
+void StrobemerIndex::populate(float f) {
     Timer flat_vector_timer;
     hash_vector h_vector;
-
     {
         auto ind_flat_vector = generate_seeds();
 
@@ -289,13 +287,11 @@ IndexCreationStatistics StrobemerIndex::populate(float f) {
     Timer hash_index_timer;
     mers_index.reserve(unique_mers);
     // construct index over flat array
-    IndexCreationStatistics index_stats = index_vector(h_vector, mers_index, f);
-    filter_cutoff = index_stats.filter_cutoff;
-    index_stats.elapsed_hash_index = hash_index_timer.duration();
-    index_stats.unique_mers = unique_mers;
-    index_stats.elapsed_flat_vector = elapsed_flat_vector;
-
-    return index_stats;
+    stats = index_vector(h_vector, mers_index, f);
+    filter_cutoff = stats.filter_cutoff;
+    stats.elapsed_hash_index = hash_index_timer.duration();
+    stats.unique_mers = unique_mers;
+    stats.elapsed_flat_vector = elapsed_flat_vector;
 }
 
 ind_mers_vector StrobemerIndex::generate_seeds() const

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -83,7 +83,6 @@ public:
 };
 
 struct IndexCreationStatistics {
-
     unsigned int flat_vector_size = 0;
     unsigned int tot_strobemer_count = 0;
     unsigned int tot_occur_once = 0;
@@ -93,12 +92,10 @@ struct IndexCreationStatistics {
     unsigned int tot_distinct_strobemer_count = 0;
     unsigned int index_cutoff = 0;
     unsigned int filter_cutoff = 0;
-
     uint64_t unique_mers = 0;
 
     std::chrono::duration<double> elapsed_flat_vector;
     std::chrono::duration<double> elapsed_hash_index;
-
 };
 
 struct StrobemerIndex {
@@ -110,10 +107,11 @@ struct StrobemerIndex {
                                 //therefore stored here since it needs to be saved with the index.
     mers_vector flat_vector;
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
+    IndexCreationStatistics stats;
 
     void write(const std::string& filename) const;
     void read(const std::string& filename);
-    IndexCreationStatistics populate(float f);
+    void populate(float f);
 private:
     const IndexParameters& parameters;
     const References& references;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -7,7 +7,7 @@
 #ifndef index_hpp
 #define index_hpp
 
-#include <chrono>  // for high_resolution_clock
+#include <chrono>
 #include <stdio.h>
 #include <string>
 #include <vector>

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -96,6 +96,8 @@ struct IndexCreationStatistics {
 
     std::chrono::duration<double> elapsed_flat_vector;
     std::chrono::duration<double> elapsed_hash_index;
+    std::chrono::duration<double> elapsed_generating_seeds;
+    std::chrono::duration<double> elapsed_sorting_seeds;
 };
 
 struct StrobemerIndex {
@@ -107,7 +109,7 @@ struct StrobemerIndex {
                                 //therefore stored here since it needs to be saved with the index.
     mers_vector flat_vector;
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
-    IndexCreationStatistics stats;
+    mutable IndexCreationStatistics stats;
 
     void write(const std::string& filename) const;
     void read(const std::string& filename);

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -33,6 +33,7 @@ struct KmerLookupEntry {
 
 typedef robin_hood::unordered_map<uint64_t, KmerLookupEntry> kmer_lookup;
 
+typedef std::vector<uint64_t> hash_vector; //only used during index generation
 
 /* Settings that influence index creation */
 class IndexParameters {
@@ -117,6 +118,7 @@ struct StrobemerIndex {
 private:
     const IndexParameters& parameters;
     const References& references;
+    void index_vector(const hash_vector& h_vector, kmer_lookup& mers_index, float f);
     ind_mers_vector generate_and_sort_seeds() const;
 };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -96,7 +96,6 @@ struct IndexCreationStatistics {
 
     uint64_t unique_mers = 0;
 
-    std::chrono::duration<double> elapsed_copy_flat_vector;
     std::chrono::duration<double> elapsed_flat_vector;
     std::chrono::duration<double> elapsed_hash_index;
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -115,7 +115,7 @@ struct StrobemerIndex {
 private:
     const IndexParameters& parameters;
     const References& references;
-    ind_mers_vector generate_seeds() const;
+    ind_mers_vector generate_and_sort_seeds() const;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,6 +213,8 @@ int run_strobealign(int argc, char **argv) {
         index.populate(opt.f);
         
         logger.debug() << "Unique strobemers: " << index.stats.unique_mers << std::endl;
+        logger.info() << "Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;
+        logger.info() << "Time sorting seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
         logger.info() << "Total time generating flat vector: " << index.stats.elapsed_flat_vector.count() << " s" <<  std::endl;
 
         logger.debug()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -335,7 +335,6 @@ int run_strobealign(int argc, char **argv) {
         << "Total time finding NAMs (rescue mode): " << tot_statistics.tot_time_rescue.count() / opt.n_threads << " s." << std::endl;
     //<< "Total time finding NAMs ALTERNATIVE (candidate sites): " << tot_find_nams_alt.count()/opt.n_threads  << " s." <<  std::endl;
     logger.info() << "Total time sorting NAMs (candidate sites): " << tot_statistics.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
-        << "Total time reverse compl seq: " << tot_statistics.tot_rc.count() / opt.n_threads << " s." << std::endl
         << "Total time base level alignment (ssw): " << tot_statistics.tot_extend.count() / opt.n_threads << " s." << std::endl
         << "Total time writing alignment to files: " << tot_statistics.tot_write_file.count() << " s." << std::endl;
     return EXIT_SUCCESS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -212,7 +212,6 @@ int run_strobealign(int argc, char **argv) {
         Timer index_timer;
         IndexCreationStatistics index_creation_stats = index.populate(opt.f);
         
-        logger.info() << "Time copying flat vector: " << index_creation_stats.elapsed_copy_flat_vector.count() << " s" << std::endl;
         logger.debug() << "Unique strobemers: " << index_creation_stats.unique_mers << std::endl;
         logger.info() << "Total time generating flat vector: " << index_creation_stats.elapsed_flat_vector.count() << " s" <<  std::endl;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,28 +210,28 @@ int run_strobealign(int argc, char **argv) {
     } else {
         // Generate the index
         Timer index_timer;
-        IndexCreationStatistics index_creation_stats = index.populate(opt.f);
+        index.populate(opt.f);
         
-        logger.debug() << "Unique strobemers: " << index_creation_stats.unique_mers << std::endl;
-        logger.info() << "Total time generating flat vector: " << index_creation_stats.elapsed_flat_vector.count() << " s" <<  std::endl;
+        logger.debug() << "Unique strobemers: " << index.stats.unique_mers << std::endl;
+        logger.info() << "Total time generating flat vector: " << index.stats.elapsed_flat_vector.count() << " s" <<  std::endl;
 
         logger.debug()
-        << "Total strobemers count: " << index_creation_stats.tot_strobemer_count << std::endl
-        << "Total strobemers occur once: " << index_creation_stats.tot_occur_once << std::endl
-        << "Fraction Unique: " << index_creation_stats.frac_unique << std::endl
-        << "Total strobemers highly abundant > 100: " << index_creation_stats.tot_high_ab << std::endl
-        << "Total strobemers mid abundance (between 2-100): " << index_creation_stats.tot_mid_ab << std::endl
-        << "Total distinct strobemers stored: " << index_creation_stats.tot_distinct_strobemer_count << std::endl;
-        if (index_creation_stats.tot_high_ab >= 1) {
-            logger.debug() << "Ratio distinct to highly abundant: " << index_creation_stats.tot_distinct_strobemer_count / index_creation_stats.tot_high_ab << std::endl;
+        << "Total strobemers count: " << index.stats.tot_strobemer_count << std::endl
+        << "Total strobemers occur once: " << index.stats.tot_occur_once << std::endl
+        << "Fraction Unique: " << index.stats.frac_unique << std::endl
+        << "Total strobemers highly abundant > 100: " << index.stats.tot_high_ab << std::endl
+        << "Total strobemers mid abundance (between 2-100): " << index.stats.tot_mid_ab << std::endl
+        << "Total distinct strobemers stored: " << index.stats.tot_distinct_strobemer_count << std::endl;
+        if (index.stats.tot_high_ab >= 1) {
+            logger.debug() << "Ratio distinct to highly abundant: " << index.stats.tot_distinct_strobemer_count / index.stats.tot_high_ab << std::endl;
         }
-        if (index_creation_stats.tot_mid_ab >= 1) {
-            logger.debug() << "Ratio distinct to non distinct: " << index_creation_stats.tot_distinct_strobemer_count / (index_creation_stats.tot_high_ab + index_creation_stats.tot_mid_ab) << std::endl;
+        if (index.stats.tot_mid_ab >= 1) {
+            logger.debug() << "Ratio distinct to non distinct: " << index.stats.tot_distinct_strobemer_count / (index.stats.tot_high_ab + index.stats.tot_mid_ab) << std::endl;
         }
-        logger.debug() << "Filtered cutoff index: " << index_creation_stats.index_cutoff << std::endl;
-        logger.debug() << "Filtered cutoff count: " << index_creation_stats.filter_cutoff << std::endl;
+        logger.debug() << "Filtered cutoff index: " << index.stats.index_cutoff << std::endl;
+        logger.debug() << "Filtered cutoff count: " << index.stats.filter_cutoff << std::endl;
         
-        logger.info() << "Total time generating hash table index: " << index_creation_stats.elapsed_hash_index.count() << " s" <<  std::endl;
+        logger.info() << "Total time generating hash table index: " << index.stats.elapsed_hash_index.count() << " s" <<  std::endl;
 
         logger.info() << "Total time indexing: " << index_timer.elapsed() << " s\n";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,16 +208,18 @@ int run_strobealign(int argc, char **argv) {
         index.read(opt.ref_filename + ".sti");
         logger.info() << "Total time reading index: " << read_index_timer.elapsed() << " s\n";
     } else {
-        // Generate the index
+        logger.info() << "Indexing ...\n";
         Timer index_timer;
         index.populate(opt.f);
         
-        logger.debug() << "Unique strobemers: " << index.stats.unique_mers << std::endl;
-        logger.info() << "Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;
-        logger.info() << "Time sorting seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
-        logger.info() << "Total time generating flat vector: " << index.stats.elapsed_flat_vector.count() << " s" <<  std::endl;
+        logger.info() << "  Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;
+        logger.info() << "  Time sorting seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
+        logger.info() << "  Time generating flat vector: " << index.stats.elapsed_flat_vector.count() << " s" <<  std::endl;
+        logger.info() << "  Time generating hash table index: " << index.stats.elapsed_hash_index.count() << " s" <<  std::endl;
+        logger.info() << "Total time indexing: " << index_timer.elapsed() << " s\n";
 
         logger.debug()
+        << "Unique strobemers: " << index.stats.unique_mers << std::endl
         << "Total strobemers count: " << index.stats.tot_strobemer_count << std::endl
         << "Total strobemers occur once: " << index.stats.tot_occur_once << std::endl
         << "Fraction Unique: " << index.stats.frac_unique << std::endl
@@ -233,10 +235,6 @@ int run_strobealign(int argc, char **argv) {
         logger.debug() << "Filtered cutoff index: " << index.stats.index_cutoff << std::endl;
         logger.debug() << "Filtered cutoff count: " << index.stats.filter_cutoff << std::endl;
         
-        logger.info() << "Total time generating hash table index: " << index.stats.elapsed_hash_index.count() << " s" <<  std::endl;
-
-        logger.info() << "Total time indexing: " << index_timer.elapsed() << " s\n";
-
         if (!opt.logfile_name.empty()) {
             print_diagnostics(index, opt.logfile_name, index_parameters.k);
             logger.debug() << "Finished printing log stats" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <math.h>
 #include <inttypes.h>
+#include <iomanip>
 
 #include "args.hxx"
 #include "robin_hood.h"
@@ -150,8 +151,9 @@ int run_strobealign(int argc, char **argv) {
     std::tie(opt, map_param) = parse_command_line_arguments(argc, argv);
 
     logger.set_level(opt.verbose ? LOG_DEBUG : LOG_INFO);
-
+    logger.info() << std::setprecision(2) << std::fixed;
     logger.info() << "This is StrobeAlign " << version_string() << '\n';
+
     if (!opt.r_set && !opt.reads_filename1.empty()) {
         map_param.r = estimate_read_length(opt.reads_filename1, opt.reads_filename2);
         logger.info() << "Estimated read length: " << map_param.r << " bp\n";
@@ -190,7 +192,6 @@ int run_strobealign(int argc, char **argv) {
 //    assert(k <= (w/2)*w_min && "k should be smaller than (w/2)*w_min to avoid creating short strobemers");
 
     // Create index
-
     References references;
     Timer read_refs_timer;
     references = References::from_fasta(opt.ref_filename);

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <queue>
 
+#include "timer.hpp"
 #include "robin_hood.h"
 #include "index.hpp"
 #include "kseq++.hpp"
@@ -18,7 +19,7 @@ using namespace klibpp;
 
 
 void InputBuffer::read_records_PE(std::vector<KSeq> &records1, std::vector<KSeq> &records2, AlignmentStatistics &statistics) {
-     auto read_start = std::chrono::high_resolution_clock::now();
+    Timer timer;
     // Acquire a unique lock on the mutex
     std::unique_lock<std::mutex> unique_lock(mtx);
     records1 = ks1.read(chunk_size);
@@ -32,13 +33,11 @@ void InputBuffer::read_records_PE(std::vector<KSeq> &records1, std::vector<KSeq>
     unique_lock.unlock();
     // Notify a single thread that buffer isn't empty
     not_empty.notify_one();
-    auto read_finish = std::chrono::high_resolution_clock::now();
-    statistics.tot_read_file += read_finish - read_start;
-
+    statistics.tot_read_file += timer.duration();
 }
 
 void InputBuffer::read_records_SE(std::vector<KSeq> &records1, AlignmentStatistics &statistics) {
-    auto read_start = std::chrono::high_resolution_clock::now();
+    Timer timer;
     // Acquire a unique lock on the mutex
     std::unique_lock<std::mutex> unique_lock(mtx);
     records1 = ks1.read(chunk_size);
@@ -51,9 +50,7 @@ void InputBuffer::read_records_SE(std::vector<KSeq> &records1, AlignmentStatisti
     unique_lock.unlock();
     // Notify a single thread that buffer isn't empty
     not_empty.notify_one();
-    auto read_finish = std::chrono::high_resolution_clock::now();
-    statistics.tot_read_file += read_finish - read_start;
-
+    statistics.tot_read_file += timer.duration();
 }
 
 void OutputBuffer::output_records(std::string &sam_alignments) {
@@ -194,5 +191,4 @@ void perform_task_SE(
             break;
         }
     }
-
 }


### PR DESCRIPTION
This revamps the way index creation times are kept track of and logged to make them more consistent and easier to interpret.

## Before
```
This is StrobeAlign v0.7.1.0-460-ge79fa3f
Estimated read length: 151 bp
Time reading references: 0.499928 s
Time generating seeds: 2.05037 s
Time sorting seeds: 1.86406 s
Time copying flat vector: 0.125275 s
Total time generating flat vector: 4.06984 s
Total time generating hash table index: 1.30964 s
Total time indexing: 5.38767 s
Running in paired-end mode
```

## After
```
This is StrobeAlign v0.7.1.0-470-g4d250c8
Estimated read length: 151 bp
Time reading references: 0.46 s
Indexing ...
  Time generating seeds: 1.99 s
  Time sorting seeds: 1.85 s
  Time generating flat vector: 0.12 s
  Time generating hash table index: 1.31 s
Total time indexing: 5.31 s
Running in paired-end mode
```

## Details

* Ensured that index-generation runtimes are disjoint. Before, adding up the various individual times would give a duration longer than the "Total time indexing", which makes sense when you know in detail what happens under the hood, but is confusing otherwise.
* Indent all indexing times except the total by two spaces to make it clear that they represent numbers for substeps.
* Removed the "copying flat vector time" as it was included in the other numbers (counted twice)
* "Total time generating flat vector" now reports the time "copying flat vector" reported.
* Precision changed so that two figures after the decimal point are reported. The measurements aren’t more accurate than that anyway.
* Some refactoring along the way: Use Timer everywhere, keep track of statistics within `StrobemerIndex` etc.
