### PR TITLE
Output mapped reads in the order that they had in the input file and decrease default chunk size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+* Issue #121: When more than one thread is used, changed behavior so that
+  alignments are output in the order that the reads had in the input file.
 * PR #114: Fix read-length estimate on input files with few reads.
 * PR #78: Fixed incorrect template length (TLEN) sign.
 * Issue #56: Unmapped reads did not have quality values in the SAM output.

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1664,7 +1664,7 @@ static inline void rescue_mate(
     sam_aln.ref_start =  ref_start + info.ref_offset +1; // +1 because SAM is 1-based!
     sam_aln.is_rc = a_is_rc;
     sam_aln.ref_id = n.ref_id;
-    sam_aln.is_unaligned = false;
+    sam_aln.is_unaligned = info.cigar == "*";
     sam_aln.aln_length = info.length;
     tot_ksw_aligned ++;
     tot_rescued ++;

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -17,7 +17,10 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
 
     args::HelpFlag help(parser, "help", "Print help and exit", {'h', "help"});
     args::ActionFlag version(parser, "version", "Print version and exit", {"version"}, []() { throw Version(); });
+
+    // Threading
     args::ValueFlag<int> threads(parser, "INT", "Number of threads [3]", {'t', "threads"});
+    args::ValueFlag<int> chunk_size(parser, "INT", "Number of reads processed by a worker thread at once [10000]", {"chunk-size"}, args::Options::Hidden);
 
     args::Group io(parser, "Input/output:");
     args::ValueFlag<std::string> o(parser, "PATH", "redirect output to file [stdout]", {'o'});
@@ -84,7 +87,9 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     CommandLineOptions opt;
     mapping_params map_param;
 
+    // Threading
     if (threads) { opt.n_threads = args::get(threads); }
+    if (chunk_size) { opt.chunk_size = args::get(chunk_size); }
 
     // Input/output
     if (o) { opt.output_file_name = args::get(o); opt.write_to_stdout = false; }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -8,6 +8,7 @@
 
 struct CommandLineOptions {
     int n_threads { 3 };
+    int chunk_size { 10000 };
 
     // Input/output
     std::string output_file_name;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -267,11 +267,10 @@ int run_strobealign(int argc, char **argv) {
 
     logger.info() << "Running in " << (opt.is_SE ? "single-end" : "paired-end") << " mode" << std::endl;
 
-    int input_chunk_size = 10000;
     if (opt.is_SE) {
         auto ks = open_fastq(opt.reads_filename1);
 
-        InputBuffer input_buffer(ks, ks, input_chunk_size);
+        InputBuffer input_buffer(ks, ks, opt.chunk_size);
         OutputBuffer output_buffer(out);
 
         std::vector<std::thread> workers;
@@ -292,7 +291,7 @@ int run_strobealign(int argc, char **argv) {
         auto ks2 = open_fastq(opt.reads_filename2);
         std::unordered_map<std::thread::id, i_dist_est> isize_est_vec(opt.n_threads);
 
-        InputBuffer input_buffer(ks1, ks2, input_chunk_size);
+        InputBuffer input_buffer(ks1, ks2, opt.chunk_size);
         OutputBuffer output_buffer(out);
 
         std::vector<std::thread> workers;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,7 +289,6 @@ int run_strobealign(int argc, char **argv) {
     else {
         auto ks1 = open_fastq(opt.reads_filename1);
         auto ks2 = open_fastq(opt.reads_filename2);
-        std::vector<i_dist_est> isize_est_vec(opt.n_threads);
 
         InputBuffer input_buffer(ks1, ks2, opt.chunk_size);
         OutputBuffer output_buffer(out);
@@ -297,7 +296,7 @@ int run_strobealign(int argc, char **argv) {
         std::vector<std::thread> workers;
         for (int i = 0; i < opt.n_threads; ++i) {
             std::thread consumer(perform_task_PE, std::ref(input_buffer), std::ref(output_buffer),
-                std::ref(log_stats_vec[i]), std::ref(isize_est_vec[i]), std::ref(aln_params),
+                std::ref(log_stats_vec[i]), std::ref(aln_params),
                 std::ref(map_param), std::ref(index_parameters), std::ref(references),
                 std::ref(index), std::ref(opt.read_group_id));
             workers.push_back(std::move(consumer));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -267,10 +267,10 @@ int run_strobealign(int argc, char **argv) {
 
     logger.info() << "Running in " << (opt.is_SE ? "single-end" : "paired-end") << " mode" << std::endl;
 
+    int input_chunk_size = 10000;
     if (opt.is_SE) {
         auto ks = open_fastq(opt.reads_filename1);
 
-        int input_chunk_size = 100000;
         InputBuffer input_buffer(ks, ks, input_chunk_size);
         OutputBuffer output_buffer(out);
 
@@ -292,7 +292,6 @@ int run_strobealign(int argc, char **argv) {
         auto ks2 = open_fastq(opt.reads_filename2);
         std::unordered_map<std::thread::id, i_dist_est> isize_est_vec(opt.n_threads);
 
-        int input_chunk_size = 100000;
         InputBuffer input_buffer(ks1, ks2, input_chunk_size);
         OutputBuffer output_buffer(out);
 

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -17,26 +17,32 @@
 #include "sam.hpp"
 
 
-void InputBuffer::read_records_PE(std::vector<klibpp::KSeq> &records1, std::vector<klibpp::KSeq> &records2, AlignmentStatistics &statistics) {
+size_t InputBuffer::read_records_PE(std::vector<klibpp::KSeq> &records1, std::vector<klibpp::KSeq> &records2, AlignmentStatistics &statistics) {
     Timer timer;
     // Acquire a unique lock on the mutex
     std::unique_lock<std::mutex> unique_lock(mtx);
     records1 = ks1.read(chunk_size);
     records2 = ks2.read(chunk_size);
+    size_t current_chunk_index = chunk_index;
+    chunk_index++;
 
-    if (records1.empty()){
+    if (records1.empty()) {
         finished_reading = true;
     }
 
     unique_lock.unlock();
     statistics.tot_read_file += timer.duration();
+
+    return current_chunk_index;
 }
 
-void InputBuffer::read_records_SE(std::vector<klibpp::KSeq> &records1, AlignmentStatistics &statistics) {
+size_t InputBuffer::read_records_SE(std::vector<klibpp::KSeq> &records1, AlignmentStatistics &statistics) {
     Timer timer;
     // Acquire a unique lock on the mutex
     std::unique_lock<std::mutex> unique_lock(mtx);
     records1 = ks1.read(chunk_size);
+    size_t current_chunk_index = chunk_index;
+    chunk_index++;
 
     if (records1.empty()){
         finished_reading = true;
@@ -44,6 +50,8 @@ void InputBuffer::read_records_SE(std::vector<klibpp::KSeq> &records1, Alignment
 
     unique_lock.unlock();
     statistics.tot_read_file += timer.duration();
+
+    return current_chunk_index;
 }
 
 void OutputBuffer::output_records(std::string &sam_alignments) {

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -53,7 +53,7 @@ void OutputBuffer::output_records(std::string &sam_alignments) {
 }
 
 
-inline bool align_reads_PE(
+bool align_reads_PE(
     InputBuffer &input_buffer,
     OutputBuffer &output_buffer,
     std::vector<klibpp::KSeq> &records1,
@@ -103,7 +103,7 @@ void perform_task_PE(
     const std::string& read_group_id
 ) {
     bool eof = false;
-    while (true){
+    while (!eof) {
         std::vector<klibpp::KSeq> records1;
         std::vector<klibpp::KSeq> records2;
         auto thread_id = std::this_thread::get_id();
@@ -115,15 +115,11 @@ void perform_task_PE(
         eof = align_reads_PE(input_buffer, output_buffer, records1, records2,
                            log_stats_vec[thread_id], isize_est_vec[thread_id],
                           aln_params, map_param, index_parameters, references, index, read_group_id);
-
-        if (eof) {
-            break;
-        }
     }
 }
 
 
-inline bool align_reads_SE(
+bool align_reads_SE(
     InputBuffer &input_buffer,
     OutputBuffer &output_buffer,
     std::vector<klibpp::KSeq> &records,
@@ -167,7 +163,7 @@ void perform_task_SE(
     const std::string& read_group_id
 ) {
     bool eof = false;
-    while (true){
+    while (!eof){
         std::vector<klibpp::KSeq> records1;
         auto thread_id = std::this_thread::get_id();
         if (log_stats_vec.find(thread_id) == log_stats_vec.end()) { //  Not initialized
@@ -178,9 +174,5 @@ void perform_task_SE(
         eof = align_reads_SE(input_buffer, output_buffer, records1,
                              log_stats_vec[thread_id],
                              aln_params, map_param, index_parameters, references, index, read_group_id);
-
-        if (eof){
-            break;
-        }
     }
 }

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -16,10 +16,8 @@
 #include "kseq++.hpp"
 #include "sam.hpp"
 
-using namespace klibpp;
 
-
-void InputBuffer::read_records_PE(std::vector<KSeq> &records1, std::vector<KSeq> &records2, AlignmentStatistics &statistics) {
+void InputBuffer::read_records_PE(std::vector<klibpp::KSeq> &records1, std::vector<klibpp::KSeq> &records2, AlignmentStatistics &statistics) {
     Timer timer;
     // Acquire a unique lock on the mutex
     std::unique_lock<std::mutex> unique_lock(mtx);
@@ -37,7 +35,7 @@ void InputBuffer::read_records_PE(std::vector<KSeq> &records1, std::vector<KSeq>
     statistics.tot_read_file += timer.duration();
 }
 
-void InputBuffer::read_records_SE(std::vector<KSeq> &records1, AlignmentStatistics &statistics) {
+void InputBuffer::read_records_SE(std::vector<klibpp::KSeq> &records1, AlignmentStatistics &statistics) {
     Timer timer;
     // Acquire a unique lock on the mutex
     std::unique_lock<std::mutex> unique_lock(mtx);
@@ -69,8 +67,8 @@ void OutputBuffer::output_records(std::string &sam_alignments) {
 inline bool align_reads_PE(
     InputBuffer &input_buffer,
     OutputBuffer &output_buffer,
-    std::vector<KSeq> &records1,
-    std::vector<KSeq> &records2,
+    std::vector<klibpp::KSeq> &records1,
+    std::vector<klibpp::KSeq> &records2,
     AlignmentStatistics &statistics,
     i_dist_est &isize_est,
     const alignment_params &aln_params,
@@ -117,8 +115,8 @@ void perform_task_PE(
 ) {
     bool eof = false;
     while (true){
-        std::vector<KSeq> records1;
-        std::vector<KSeq> records2;
+        std::vector<klibpp::KSeq> records1;
+        std::vector<klibpp::KSeq> records2;
         auto thread_id = std::this_thread::get_id();
         if (log_stats_vec.find(thread_id) == log_stats_vec.end()) { //  Not initialized
             AlignmentStatistics statistics;
@@ -139,7 +137,7 @@ void perform_task_PE(
 inline bool align_reads_SE(
     InputBuffer &input_buffer,
     OutputBuffer &output_buffer,
-    std::vector<KSeq> &records,
+    std::vector<klibpp::KSeq> &records,
     AlignmentStatistics &statistics,
     const alignment_params &aln_params,
     const mapping_params &map_param,
@@ -181,7 +179,7 @@ void perform_task_SE(
 ) {
     bool eof = false;
     while (true){
-        std::vector<KSeq> records1;
+        std::vector<klibpp::KSeq> records1;
         auto thread_id = std::this_thread::get_id();
         if (log_stats_vec.find(thread_id) == log_stats_vec.end()) { //  Not initialized
             AlignmentStatistics statistics;

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -75,7 +75,6 @@ void perform_task_PE(
     InputBuffer &input_buffer,
     OutputBuffer &output_buffer,
     AlignmentStatistics& statistics,
-    i_dist_est &isize_est,
     const alignment_params &aln_params,
     const mapping_params &map_param,
     const IndexParameters& index_parameters,
@@ -88,6 +87,7 @@ void perform_task_PE(
         std::vector<klibpp::KSeq> records1;
         std::vector<klibpp::KSeq> records2;
         auto chunk_index = input_buffer.read_records_PE(records1, records2, statistics);
+        i_dist_est isize_est;
         if (records1.empty() && input_buffer.finished_reading){
             break;
         }

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -28,10 +28,7 @@ void InputBuffer::read_records_PE(std::vector<klibpp::KSeq> &records1, std::vect
         finished_reading = true;
     }
 
-    // Unlock unique lock
     unique_lock.unlock();
-    // Notify a single thread that buffer isn't empty
-    not_empty.notify_one();
     statistics.tot_read_file += timer.duration();
 }
 
@@ -45,22 +42,14 @@ void InputBuffer::read_records_SE(std::vector<klibpp::KSeq> &records1, Alignment
         finished_reading = true;
     }
 
-    // Unlock unique lock
     unique_lock.unlock();
-    // Notify a single thread that buffer isn't empty
-    not_empty.notify_one();
     statistics.tot_read_file += timer.duration();
 }
 
 void OutputBuffer::output_records(std::string &sam_alignments) {
-    // Acquire a unique lock on the mutex
     std::unique_lock<std::mutex> unique_lock(mtx);
     out << sam_alignments;
-    // Update appropriate fields
-    buffer_size = 0;
-    // Unlock unique lock
     unique_lock.unlock();
-    not_full.notify_one();
 }
 
 

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -26,18 +26,12 @@ public:
     InputBuffer(input_stream_t& ks1, input_stream_t& ks2, int chunk_size)
     : ks1(ks1), ks2(ks2), chunk_size(chunk_size) { }
 
-    // Fields for concurrency input
     std::mutex mtx;
-    std::condition_variable not_empty;
-    std::condition_variable not_full;
 
-    std::queue<std::vector<klibpp::KSeq>> q1;
-    std::queue<std::vector<klibpp::KSeq>> q2;
     input_stream_t &ks1;
     input_stream_t &ks2;
-    bool finished_reading = false;
-    int buffer_size = 0;
-    int chunk_size = 100000;
+    bool finished_reading{false};
+    int chunk_size;
 
     void read_records_PE(std::vector<klibpp::KSeq> &records1, std::vector<klibpp::KSeq> &records2, AlignmentStatistics &statistics);
     void read_records_SE(std::vector<klibpp::KSeq> &records1, AlignmentStatistics &statistics);
@@ -50,10 +44,6 @@ public:
     OutputBuffer(std::ostream& out) : out(out) { }
 
     std::mutex mtx;
-    std::condition_variable not_empty;
-    std::condition_variable not_full;
-
-    int buffer_size = 0;
     std::ostream &out;
 
     void output_records(std::string &sam_alignments);

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -54,11 +54,11 @@ public:
 
 
 void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
-                  std::unordered_map<std::thread::id, AlignmentStatistics> &log_stats_vec, std::unordered_map<std::thread::id, i_dist_est> &isize_est_vec, const alignment_params &aln_params,
+                  AlignmentStatistics& statistics, i_dist_est &isize_est_vec, const alignment_params &aln_params,
                   const mapping_params &map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index, const std::string& read_group_id);
 
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
-                     std::unordered_map<std::thread::id, AlignmentStatistics> &log_stats_vec, const alignment_params &aln_params,
+                     AlignmentStatistics& statistics, const alignment_params &aln_params,
                      const mapping_params &map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index, const std::string& read_group_id);
 
 #endif

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -46,8 +46,10 @@ public:
 
     std::mutex mtx;
     std::ostream &out;
+    std::unordered_map<size_t, std::string> chunks;
+    size_t next_chunk_index{0};
 
-    void output_records(std::string &sam_alignments);
+    void output_records(std::string sam_alignments, size_t chunk_index);
 };
 
 

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -32,9 +32,10 @@ public:
     input_stream_t &ks2;
     bool finished_reading{false};
     int chunk_size;
+    size_t chunk_index{0};
 
-    void read_records_PE(std::vector<klibpp::KSeq> &records1, std::vector<klibpp::KSeq> &records2, AlignmentStatistics &statistics);
-    void read_records_SE(std::vector<klibpp::KSeq> &records1, AlignmentStatistics &statistics);
+    size_t read_records_PE(std::vector<klibpp::KSeq> &records1, std::vector<klibpp::KSeq> &records2, AlignmentStatistics &statistics);
+    size_t read_records_SE(std::vector<klibpp::KSeq> &records1, AlignmentStatistics &statistics);
 };
 
 

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -49,12 +49,12 @@ public:
     std::unordered_map<size_t, std::string> chunks;
     size_t next_chunk_index{0};
 
-    void output_records(std::string sam_alignments, size_t chunk_index);
+    void output_records(std::string chunk, size_t chunk_index);
 };
 
 
 void perform_task_PE(InputBuffer &input_buffer, OutputBuffer &output_buffer,
-                  AlignmentStatistics& statistics, i_dist_est &isize_est_vec, const alignment_params &aln_params,
+                  AlignmentStatistics& statistics, const alignment_params &aln_params,
                   const mapping_params &map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index, const std::string& read_group_id);
 
 void perform_task_SE(InputBuffer &input_buffer, OutputBuffer &output_buffer,

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=ef86bce15896b5cca437c54ff95dfad40da2145a
+baseline_commit=5d4005bb5c80c66e4cc595b16a99a869f8755724

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -13,12 +13,12 @@ strobealign -h > /dev/null
 d=tests
 
 # Single-end SAM
-strobealign -v --rg-id 1 --rg SM:sample --rg LB:library $d/phix.fasta $d/phix.1.fastq | grep -v '^@PG' > phix.se.sam
+strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library -v $d/phix.fasta $d/phix.1.fastq | grep -v '^@PG' > phix.se.sam
 diff -u tests/phix.se.sam phix.se.sam
 rm phix.se.sam
 
 # Paired-end SAM
-strobealign --rg-id 1 --rg SM:sample --rg LB:library $d/phix.fasta $d/phix.1.fastq $d/phix.2.fastq | grep -v '^@PG' > phix.pe.sam
+strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library $d/phix.fasta $d/phix.1.fastq $d/phix.2.fastq | grep -v '^@PG' > phix.pe.sam
 diff -u tests/phix.pe.sam phix.pe.sam
 rm phix.pe.sam
 


### PR DESCRIPTION
Ensuring correct order is done as discussed in #121: Read chunks are numbered consecutively, and processed chunks are buffered until it is their turn. This could theoretically affect performance a little bit because the lock that protects the output buffer is held a bit longer sometimes, but I wasn’t able to measure a significant difference (it must be less than ~1% if there is a difference).

This PR also reduces the default chunk size from 100'000 to 10'000. Together with ensuring reproducible read order, this finally allows us to run the tests on the somewhat larger dataset with multiple threads.

I also added a command-line option `--chunk-size`, which is hidden from help output. I use it in the tests to set a very low chunk size, which enables multithreading even on the tiny phiX dataset, and allows to test whether the output is indeed in the correct order.

Closes #121