### PR TITLE
Fix: Reference sequences copied unnecessarily, speed up uppercasing

### DIFF
--- a/src/refs.cpp
+++ b/src/refs.cpp
@@ -29,7 +29,11 @@ References References::from_fasta(const std::string& filename) {
         eof = !bool{getline(file, line)};
         if (eof || (!line.empty() && line[0] == '>')) {
             if (seq.length() > 0) {
-                std::transform(seq.begin(), seq.end(), seq.begin(), ::toupper);
+                std::transform(seq.begin(), seq.end(), seq.begin(),
+                    [](unsigned char c) {
+                        return c & ~32;  // convert to uppercase
+                    }
+                );
                 sequences.push_back(seq);
                 names.push_back(name);
             }

--- a/src/refs.hpp
+++ b/src/refs.hpp
@@ -15,9 +15,9 @@ class References {
 public:
     References() { }
     References(
-        std::vector<std::string>&& sequences,
-        ref_names&& names
-    ) : sequences(sequences), names(names) {
+        std::vector<std::string> sequences_,
+        ref_names names_
+    ) : sequences(std::move(sequences_)), names(std::move(names_)) {
 
         if (sequences.size() != names.size()) {
             throw std::invalid_argument("lengths do not match");


### PR DESCRIPTION
* Fix an unnecessary copy of the reference sequences. This was introduced when References::from_fasta was factored out. This increased peak memory usage just before creating the index, so it does not matter overall because the memory is immediately freed and then used for the index.

* Speed up uppercasing the reference. Reading a 3 GB reference takes about 1.8 seconds, but converting it to
uppercase with std::toupper takes another 6 seconds because toupper takes the current locale into account. Since we assume ASCII for the FASTA input file anyway, we can use a custom function that manipulates the bits of the
char. This takes only ~0.2 seconds.
