### PR TITLE
Enable assertions during tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build
         run: |
-          cmake -B build
+          cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
           cd build
           make -j3
           make install
@@ -75,7 +75,7 @@ jobs:
 
       - name: Build HEAD version
         run: |
-          cmake -B build
+          cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
           make -j3 -C build
       - name: Generate HEAD BAM
         run: build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view -o head.bam

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash  # For -o pipefail
+
 jobs:
   lint:
     # Run for PRs only if they come from a forked repo (avoids duplicate runs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,13 @@ find_package(OpenMP)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING
-      "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+      "Choose the type of build, options are: RelWithDebInfo Debug Release" FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+    "RelWithDebInfo" "Debug" "Release")
 endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1594,10 +1594,6 @@ static inline void rescue_mate(
     ref_start = std::max(0, std::min(a,ref_len));
     ref_end = std::min(ref_len, std::max(0, b));
 
-    assert(ref_start != ref_len);
-    assert(ref_end != ref_len);
-    assert(ref_end != ref_start);
-
     if (ref_end < ref_start + k){
         sam_aln.cigar = "*";
         sam_aln.ed = read_len;

--- a/tests/samdiff.py
+++ b/tests/samdiff.py
@@ -12,7 +12,7 @@ RNEXT, PNEXT, TLEN) are ignored.
 import sys
 from argparse import ArgumentParser
 from contextlib import ExitStack
-from itertools import repeat
+from itertools import repeat, zip_longest
 
 from pysam import AlignmentFile, AlignedSegment
 
@@ -52,7 +52,11 @@ def main():
         better = 0
         worse = 0
 
-        for b, a, t in zip(before, after, truth):
+        for b, a, t in zip_longest(before, after, truth):
+            if (b is None and a is None) and not has_truth:
+                break
+            if b is None or a is None:
+                sys.exit("Input files have different lengths")
             assert b.query_name[:-2] == a.query_name[:-2]
             if has_truth:
                 assert a.query_name[:-2] == t.query_name


### PR DESCRIPTION
This is achieved by manually setting the compiler options for the "RelWithDebInfo" build type (and omitting `-DNDEBUG`).

Also, we need to ensure that we use the bash option `-o pipefail`. Without it, the exit code from `strobealign ... | samtools view ...` is 0 as long as samtools exits successfully even when strobealign crashed.

This also disables some assertions that I added in 97939f3e. I never noticed that they were triggered because I did not have assertions enabled. The assertions were a replacement for some previous debugging code that checks conditions which no longer appear to be true.
