### PR TITLE
Refactor StrobemerIndex

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -160,7 +160,7 @@ static inline void find_nams_rescue(
 
     for (auto &it : hits_per_ref) {
         auto ref_id = it.first;
-        std::vector<hit> hits = it.second;
+        std::vector<hit>& hits = it.second;
         std::sort(hits.begin(), hits.end(), [](const hit& a, const hit& b) -> bool {
                 // first sort on query starts, then on reference starts
                 return (a.query_s < b.query_s) || ( (a.query_s == b.query_s) && (a.ref_s < b.ref_s) );
@@ -286,7 +286,7 @@ static inline std::pair<float,int> find_nams(
 
     for (auto &it : hits_per_ref) {
         auto ref_id = it.first;
-        std::vector<hit> hits = it.second;
+        const std::vector<hit>& hits = it.second;
         open_nams = std::vector<nam> (); // Initialize vector
         unsigned int prev_q_start = 0;
         for (auto &h : hits){

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -132,8 +132,7 @@ static inline void find_nams_rescue(
     for (auto &q : query_mers) {
         auto ref_hit = index.find(q.hash);
         if (ref_hit != index.end()) {
-            auto query_e = q.position + q.strobe_offset + k;
-            Hit s{ref_hit->second.count, ref_hit->second.offset, q.position, query_e, q.is_reverse};
+            Hit s{ref_hit->second.count, ref_hit->second.offset, q.start, q.end, q.is_reverse};
             if (q.is_reverse){
                 hits_rc.push_back(s);
             } else {
@@ -275,8 +274,7 @@ static inline std::pair<float,int> find_nams(
                 continue;
             }
             nr_good_hits++;
-            int query_e = q.position + q.strobe_offset + k; // h.query_s + read_length/2;
-            add_to_hits_per_ref(hits_per_ref, q.position, query_e, q.is_reverse, index, k, ref_hit->second.offset, count, 100000);
+            add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, k, ref_hit->second.offset, count, 100000);
         }
     }
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -18,8 +18,8 @@ struct Hit {
     bool is_rc;
 
     bool operator< (const Hit& rhs) const {
-        return std::tie(count, offset, query_s, query_e, is_rc)
-            < std::tie(rhs.count, rhs.offset, rhs.query_s, rhs.query_e, rhs.is_rc);
+        return std::tie(count, query_s, query_e, is_rc)
+            < std::tie(rhs.count, rhs.query_s, rhs.query_e, rhs.is_rc);
     }
 };
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -103,16 +103,11 @@ void add_to_hits_per_ref(
     for (int j = offset; j < offset + count; ++j) {
         auto r = index.flat_vector[j];
         h.ref_s = r.position;
-        auto p = r.packed;
-        int bit_alloc = 8;
-        int r_id = (p >> bit_alloc);
-        int mask = (1 << bit_alloc) - 1;
-        int offset = (p & mask);
-        h.ref_e = h.ref_s + offset + k;
+        h.ref_e = h.ref_s + r.strobe2_offset() + k;
 
         int diff = std::abs((h.query_e - h.query_s) - (h.ref_e - h.ref_s));
         if (diff <= min_diff) {
-            hits_per_ref[r_id].push_back(h);
+            hits_per_ref[r.reference_index()].push_back(h);
             min_diff = diff;
         }
     }

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -108,8 +108,8 @@ static inline void find_nams_rescue(
 
     for (auto &q : query_mers) {
         auto mer_hashv = q.hash;
-        auto ref_hit = index.mers_index.find(mer_hashv);
-        if (ref_hit != index.mers_index.end()) {
+        auto ref_hit = index.find(mer_hashv);
+        if (ref_hit != index.end()) {
             auto query_e = q.position + q.offset_strobe + k;
             Hit s{ref_hit->second.count, ref_hit->second.offset, q.position, query_e, q.is_reverse};
             if (q.is_reverse){
@@ -271,8 +271,8 @@ static inline std::pair<float,int> find_nams(
     hit h;
     for (auto &q : query_mers) {
         auto mer_hashv = q.hash;
-        auto ref_hit = index.mers_index.find(mer_hashv);
-        if (ref_hit != index.mers_index.end()) {
+        auto ref_hit = index.find(mer_hashv);
+        if (ref_hit != index.end()) {
             total_hits++;
             h.query_s = q.position;
             h.query_e = h.query_s + q.offset_strobe + k; // h.query_s + read_length/2;

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -132,7 +132,7 @@ static inline void find_nams_rescue(
     for (auto &q : query_mers) {
         auto ref_hit = index.find(q.hash);
         if (ref_hit != index.end()) {
-            Hit s{ref_hit->second.count(), ref_hit->second.offset, q.start, q.end, q.is_reverse};
+            Hit s{ref_hit->second.count(), ref_hit->second.offset(), q.start, q.end, q.is_reverse};
             if (q.is_reverse){
                 hits_rc.push_back(s);
             } else {
@@ -274,7 +274,7 @@ static inline std::pair<float,int> find_nams(
                 continue;
             }
             nr_good_hits++;
-            add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, k, ref_hit->second.offset, count, 100000);
+            add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, k, ref_hit->second.offset(), count, 100000);
         }
     }
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -132,7 +132,7 @@ static inline void find_nams_rescue(
     for (auto &q : query_mers) {
         auto ref_hit = index.find(q.hash);
         if (ref_hit != index.end()) {
-            Hit s{ref_hit->second.count, ref_hit->second.offset, q.start, q.end, q.is_reverse};
+            Hit s{ref_hit->second.count(), ref_hit->second.offset, q.start, q.end, q.is_reverse};
             if (q.is_reverse){
                 hits_rc.push_back(s);
             } else {
@@ -269,7 +269,7 @@ static inline std::pair<float,int> find_nams(
         auto ref_hit = index.find(q.hash);
         if (ref_hit != index.end()) {
             total_hits++;
-            auto count = ref_hit->second.count;
+            auto count = ref_hit->second.count();
             if (count > index.filter_cutoff) {
                 continue;
             }

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -108,10 +108,10 @@ static inline void find_nams_rescue(
 
     for (auto &q : query_mers) {
         auto mer_hashv = q.hash;
-        if (index.mers_index.find(mer_hashv) != index.mers_index.end()) {
-            auto ref_hit = index.mers_index.at(mer_hashv);
+        auto ref_hit = index.mers_index.find(mer_hashv);
+        if (ref_hit != index.mers_index.end()) {
             auto query_e = q.position + q.offset_strobe + k;
-            Hit s{ref_hit.count, ref_hit.offset, q.position, query_e, q.is_reverse};
+            Hit s{ref_hit->second.count, ref_hit->second.offset, q.position, query_e, q.is_reverse};
             if (q.is_reverse){
                 hits_rc.push_back(s);
             } else {
@@ -271,14 +271,14 @@ static inline std::pair<float,int> find_nams(
     hit h;
     for (auto &q : query_mers) {
         auto mer_hashv = q.hash;
-        if (index.mers_index.find(mer_hashv) != index.mers_index.end()) {
+        auto ref_hit = index.mers_index.find(mer_hashv);
+        if (ref_hit != index.mers_index.end()) {
             total_hits++;
             h.query_s = q.position;
             h.query_e = h.query_s + q.offset_strobe + k; // h.query_s + read_length/2;
             h.is_rc = q.is_reverse;
-            auto mer = index.mers_index.at(mer_hashv);
-            auto offset = mer.offset;
-            auto count = mer.count;
+            auto offset = ref_hit->second.offset;
+            auto count = ref_hit->second.count;
             if (count > index.filter_cutoff) {
                 continue;
             }

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -131,7 +131,7 @@ static inline void find_nams_rescue(
         auto mer_hashv = q.hash;
         auto ref_hit = index.find(mer_hashv);
         if (ref_hit != index.end()) {
-            auto query_e = q.position + q.offset_strobe + k;
+            auto query_e = q.position + q.strobe_offset + k;
             Hit s{ref_hit->second.count, ref_hit->second.offset, q.position, query_e, q.is_reverse};
             if (q.is_reverse){
                 hits_rc.push_back(s);
@@ -280,7 +280,7 @@ static inline std::pair<float,int> find_nams(
         if (ref_hit != index.end()) {
             total_hits++;
             h.query_s = q.position;
-            h.query_e = h.query_s + q.offset_strobe + k; // h.query_s + read_length/2;
+            h.query_e = h.query_s + q.strobe_offset + k; // h.query_s + read_length/2;
             h.is_rc = q.is_reverse;
             auto offset = ref_hit->second.offset;
             auto count = ref_hit->second.count;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -116,7 +116,7 @@ uint64_t count_unique_elements(const hash_vector& h_vector){
     return unique_elements;
 }
 
-void StrobemerIndex::index_vector(const hash_vector &h_vector, kmer_lookup &mers_index, float f) {
+void StrobemerIndex::index_vector(const hash_vector &h_vector, float f) {
     stats.flat_vector_size = h_vector.size();
 
     unsigned int offset = 0;
@@ -278,7 +278,7 @@ void StrobemerIndex::populate(float f) {
     Timer hash_index_timer;
     mers_index.reserve(unique_mers);
     // construct index over flat array
-    index_vector(h_vector, mers_index, f);
+    index_vector(h_vector, f);
     filter_cutoff = stats.filter_cutoff;
     stats.elapsed_hash_index = hash_index_timer.duration();
     stats.unique_mers = unique_mers;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -148,9 +148,7 @@ void StrobemerIndex::index_vector(const hash_vector &h_vector, float f) {
                 tot_mid_ab ++;
                 strobemer_counts.push_back(count);
             }
-
-            KmerLookupEntry s{prev_offset, count};
-            mers_index[prev_k] = s;
+            add_entry(prev_k, prev_offset, count);
             count = 1;
             prev_k = curr_k;
             prev_offset = offset;
@@ -159,10 +157,9 @@ void StrobemerIndex::index_vector(const hash_vector &h_vector, float f) {
     }
 
     // last k-mer
-    KmerLookupEntry s{prev_offset, count};
-    mers_index[curr_k] = s;
-    float frac_unique = ((float) tot_occur_once )/ mers_index.size();
+    add_entry(curr_k, prev_offset, count);
 
+    float frac_unique = ((float) tot_occur_once )/ mers_index.size();
     stats.tot_strobemer_count = offset;
     stats.tot_occur_once = tot_occur_once;
     stats.frac_unique = frac_unique;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -302,3 +302,93 @@ ind_mers_vector StrobemerIndex::generate_and_sort_seeds() const
 
     return ind_flat_vector;
 }
+
+
+void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) const {
+    // Prins to csv file the statistics on the number of seeds of a particular length and what fraction of them them are unique in the index:
+    // format:
+    // seed_length, count, percentage_unique
+
+    size_t max_size = 100000;
+    std::vector<int> log_count(max_size, 0);  // stores count and each index represents the length
+    std::vector<int> log_unique(max_size, 0);  // stores count unique and each index represents the length
+    std::vector<int> log_repetitive(max_size, 0);  // stores count unique and each index represents the length
+
+
+    std::vector<uint64_t> log_count_squared(max_size,0);
+    uint64_t tot_seed_count = 0;
+    uint64_t tot_seed_count_sq = 0;
+
+    std::vector<uint64_t> log_count_1000_limit(max_size, 0);  // stores count and each index represents the length
+    uint64_t tot_seed_count_1000_limit = 0;
+
+    size_t seed_length;
+    for (auto &it : mers_index) {
+        auto ref_mer = it.second;
+        auto offset = ref_mer.offset;
+        auto count = ref_mer.count;
+
+        for (size_t j = offset; j < offset + count; ++j) {
+            auto r = flat_vector[j];
+            auto p = r.packed;
+            const uint8_t bit_alloc = 8;
+            const int mask = (1 << bit_alloc) - 1;
+            const int offset = p & mask;
+            seed_length =  offset + k;
+            if (seed_length < max_size){
+                log_count[seed_length] ++;
+                log_count_squared[seed_length] += count;
+                tot_seed_count ++;
+                tot_seed_count_sq += count;
+                if (count <= 1000){
+                    log_count_1000_limit[seed_length] ++;
+                    tot_seed_count_1000_limit ++;
+                }
+            } else {
+               // TODO This function should not log anything
+               // logger.info() << "Detected seed size over " << max_size << " bp (can happen, e.g., over centromere): " << seed_length << std::endl;
+            }
+        }
+
+        if (count == 1 && seed_length < max_size) {
+            log_unique[seed_length]++;
+        }
+        if (count >= 10 && seed_length < max_size) {
+            log_repetitive[seed_length]++;
+        }
+    }
+
+    // printing
+    std::ofstream log_file;
+    log_file.open(logfile_name);
+
+    for (size_t i = 0; i < log_count.size(); ++i) {
+        if (log_count[i] > 0) {
+            double e_count = log_count_squared[i] / log_count[i];
+            log_file << i << ',' << log_count[i] << ',' << e_count << std::endl;
+        }
+    }
+
+    // Get median
+    size_t n = 0;
+    int median = 0;
+    for (size_t i = 0; i < log_count.size(); ++i) {
+        n += log_count[i];
+        if (n >= tot_seed_count/2) {
+            break;
+        }
+    }
+    // Get median 1000 limit
+    size_t n_lim = 0;
+    for (size_t i = 0; i < log_count_1000_limit.size(); ++i) {
+        n_lim += log_count_1000_limit[i];
+        if (n_lim >= tot_seed_count_1000_limit/2) {
+            break;
+        }
+    }
+
+    log_file << "E_size for total seeding wih max seed size m below (m, tot_seeds, E_hits)" << std::endl;
+    double e_hits = (double) tot_seed_count_sq/ (double) tot_seed_count;
+    double fraction_masked = 1.0 - (double) tot_seed_count_1000_limit/ (double) tot_seed_count;
+    log_file << median << ',' << tot_seed_count << ',' << e_hits << ',' << 100*fraction_masked << std::endl;
+}

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -327,11 +327,7 @@ void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) c
 
         for (size_t j = offset; j < offset + count; ++j) {
             auto r = flat_vector[j];
-            auto p = r.packed;
-            const uint8_t bit_alloc = 8;
-            const int mask = (1 << bit_alloc) - 1;
-            const int offset = p & mask;
-            seed_length =  offset + k;
+            seed_length = r.strobe2_offset() + k;
             if (seed_length < max_size){
                 log_count[seed_length] ++;
                 log_count_squared[seed_length] += count;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -322,7 +322,7 @@ void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) c
     size_t seed_length;
     for (auto &it : mers_index) {
         auto ref_mer = it.second;
-        auto offset = ref_mer.offset;
+        auto offset = ref_mer.offset();
         auto count = ref_mer.count();
 
         for (size_t j = offset; j < offset + count; ++j) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -323,7 +323,7 @@ void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) c
     for (auto &it : mers_index) {
         auto ref_mer = it.second;
         auto offset = ref_mer.offset;
-        auto count = ref_mer.count;
+        auto count = ref_mer.count();
 
         for (size_t j = offset; j < offset + count; ++j) {
             auto r = flat_vector[j];

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -19,8 +19,24 @@
 #include "refs.hpp"
 #include "randstrobes.hpp"
 
-struct ReferenceMer {
+class ReferenceMer {
+public:
+    ReferenceMer() { }  // TODO should not be needed
+    ReferenceMer(uint32_t position, int32_t packed) : position(position), packed(packed) {
+    }
     uint32_t position;
+
+    int reference_index() const {
+        return packed >> bit_alloc;
+    }
+
+    int strobe2_offset() const {
+        return packed & mask;
+    }
+
+private:
+    const int bit_alloc = 8;
+    const int mask = (1 << bit_alloc) - 1;
     int32_t packed;
 };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -109,7 +109,6 @@ struct StrobemerIndex {
     unsigned int filter_cutoff; //This also exists in mapping_params, but is calculated during index generation,
                                 //therefore stored here since it needs to be saved with the index.
     mers_vector flat_vector;
-    kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
     mutable IndexCreationStatistics stats;
 
     void write(const std::string& filename) const;
@@ -117,9 +116,19 @@ struct StrobemerIndex {
     void populate(float f);
     void print_diagnostics(const std::string& logfile_name, int k) const;
 
+    kmer_lookup::const_iterator find(uint64_t key) const {
+        return mers_index.find(key);
+    }
+
+    kmer_lookup::const_iterator end() const {
+        return mers_index.cend();
+    }
+
 private:
     const IndexParameters& parameters;
     const References& references;
+    kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
+
     void index_vector(const hash_vector& h_vector, kmer_lookup& mers_index, float f);
     ind_mers_vector generate_and_sort_seeds() const;
 };

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -45,13 +45,18 @@ typedef std::vector<ReferenceMer> mers_vector;
 class KmerLookupEntry {
 public:
     KmerLookupEntry() { }
-    KmerLookupEntry(unsigned int offset, unsigned int count) : offset(offset), m_count(count) { }
-    unsigned int offset;
+    KmerLookupEntry(unsigned int offset, unsigned int count) : m_offset(offset), m_count(count) { }
 
     unsigned int count() const {
         return m_count;
     }
+
+    unsigned int offset() const{
+        return m_offset;
+    }
+
 private:
+    unsigned int m_offset;
     unsigned int m_count;
 };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -42,9 +42,17 @@ private:
 
 typedef std::vector<ReferenceMer> mers_vector;
 
-struct KmerLookupEntry {
+class KmerLookupEntry {
+public:
+    KmerLookupEntry() { }
+    KmerLookupEntry(unsigned int offset, unsigned int count) : offset(offset), m_count(count) { }
     unsigned int offset;
-    unsigned int count;
+
+    unsigned int count() const {
+        return m_count;
+    }
+private:
+    unsigned int m_count;
 };
 
 typedef robin_hood::unordered_map<uint64_t, KmerLookupEntry> kmer_lookup;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -115,6 +115,8 @@ struct StrobemerIndex {
     void write(const std::string& filename) const;
     void read(const std::string& filename);
     void populate(float f);
+    void print_diagnostics(const std::string& logfile_name, int k) const;
+
 private:
     const IndexParameters& parameters;
     const References& references;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -129,7 +129,7 @@ private:
     const References& references;
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
 
-    void index_vector(const hash_vector& h_vector, kmer_lookup& mers_index, float f);
+    void index_vector(const hash_vector& h_vector, float f);
     ind_mers_vector generate_and_sort_seeds() const;
 };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -124,6 +124,11 @@ struct StrobemerIndex {
         return mers_index.cend();
     }
 
+    void add_entry(uint64_t key, unsigned int offset, unsigned int count) {
+        KmerLookupEntry s{offset, count};
+        mers_index[key] = s;
+    }
+
 private:
     const IndexParameters& parameters;
     const References& references;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,94 +30,6 @@
 static Logger& logger = Logger::get();
 
 
-static void print_diagnostics(const StrobemerIndex &index, const std::string& logfile_name, int k) {
-    // Prins to csv file the statistics on the number of seeds of a particular length and what fraction of them them are unique in the index:
-    // format:
-    // seed_length, count, percentage_unique
-
-    size_t max_size = 100000;
-    std::vector<int> log_count(max_size, 0);  // stores count and each index represents the length
-    std::vector<int> log_unique(max_size, 0);  // stores count unique and each index represents the length
-    std::vector<int> log_repetitive(max_size, 0);  // stores count unique and each index represents the length
-
-
-    std::vector<uint64_t> log_count_squared(max_size,0);
-    uint64_t tot_seed_count = 0;
-    uint64_t tot_seed_count_sq = 0;
-
-    std::vector<uint64_t> log_count_1000_limit(max_size, 0);  // stores count and each index represents the length
-    uint64_t tot_seed_count_1000_limit = 0;
-
-    size_t seed_length;
-    for (auto &it : index.mers_index) {
-        auto ref_mer = it.second;
-        auto offset = ref_mer.offset;
-        auto count = ref_mer.count;
-
-        for (size_t j = offset; j < offset + count; ++j) {
-            auto r = index.flat_vector[j];
-            auto p = r.packed;
-            const uint8_t bit_alloc = 8;
-            const int mask = (1 << bit_alloc) - 1;
-            const int offset = p & mask;
-            seed_length =  offset + k;
-            if (seed_length < max_size){
-                log_count[seed_length] ++;
-                log_count_squared[seed_length] += count;
-                tot_seed_count ++;
-                tot_seed_count_sq += count;
-                if (count <= 1000){
-                    log_count_1000_limit[seed_length] ++;
-                    tot_seed_count_1000_limit ++;
-                }
-            } else {
-               logger.info() << "Detected seed size over " << max_size << " bp (can happen, e.g., over centromere): " << seed_length << std::endl;
-            }
-        }
-
-        if (count == 1 && seed_length < max_size) {
-            log_unique[seed_length]++;
-        }
-        if (count >= 10 && seed_length < max_size) {
-            log_repetitive[seed_length]++;
-        }
-    }
-
-    // printing
-    std::ofstream log_file;
-    log_file.open(logfile_name);
-
-    for (size_t i = 0; i < log_count.size(); ++i) {
-        if (log_count[i] > 0) {
-            double e_count = log_count_squared[i] / log_count[i];
-            log_file << i << ',' << log_count[i] << ',' << e_count << std::endl;
-        }
-    }
-
-    // Get median
-    size_t n = 0;
-    int median = 0;
-    for (size_t i = 0; i < log_count.size(); ++i) {
-        n += log_count[i];
-        if (n >= tot_seed_count/2) {
-            break;
-        }
-    }
-    // Get median 1000 limit
-    size_t n_lim = 0;
-    for (size_t i = 0; i < log_count_1000_limit.size(); ++i) {
-        n_lim += log_count_1000_limit[i];
-        if (n_lim >= tot_seed_count_1000_limit/2) {
-            break;
-        }
-    }
-
-    log_file << "E_size for total seeding wih max seed size m below (m, tot_seeds, E_hits)" << std::endl;
-    double e_hits = (double) tot_seed_count_sq/ (double) tot_seed_count;
-    double fraction_masked = 1.0 - (double) tot_seed_count_1000_limit/ (double) tot_seed_count;
-    log_file << median << ',' << tot_seed_count << ',' << e_hits << ',' << 100*fraction_masked << std::endl;
-}
-
 /*
  * Return formatted SAM header as a string
  */
@@ -229,7 +141,7 @@ int run_strobealign(int argc, char **argv) {
         logger.debug() << "Filtered cutoff count: " << index.stats.filter_cutoff << std::endl;
         
         if (!opt.logfile_name.empty()) {
-            print_diagnostics(index, opt.logfile_name, index_parameters.k);
+            index.print_diagnostics(opt.logfile_name, index_parameters.k);
             logger.debug() << "Finished printing log stats" << std::endl;
         }
         if (opt.only_gen_index) {

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -292,9 +292,8 @@ mers_vector_read randstrobes_query(
     RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
     while (randstrobe_fwd_iter.has_next()) {
         auto randstrobe = randstrobe_fwd_iter.next();
-        unsigned int offset_strobe = randstrobe.strobe2_pos - randstrobe.strobe1_pos;
-        QueryMer s {randstrobe.hash, randstrobe.strobe1_pos, offset_strobe, false};
-        randstrobes2.push_back(s);
+        QueryMer query_mer{randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + k, false};
+        randstrobes2.push_back(query_mer);
     }
 
     std::reverse(string_hashes.begin(), string_hashes.end());
@@ -306,9 +305,8 @@ mers_vector_read randstrobes_query(
     RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
     while (randstrobe_rc_iter.has_next()) {
         auto randstrobe = randstrobe_rc_iter.next();
-        unsigned int offset_strobe = randstrobe.strobe2_pos - randstrobe.strobe1_pos;
-        QueryMer s {randstrobe.hash, randstrobe.strobe1_pos, offset_strobe, true};
-        randstrobes2.push_back(s);
+        QueryMer query_mer{randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + k, true};
+        randstrobes2.push_back(query_mer);
     }
     return randstrobes2;
 }

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -22,8 +22,8 @@ typedef std::vector<MersIndexEntry> ind_mers_vector;
 
 struct QueryMer {
     uint64_t hash;
-    unsigned int position;
-    unsigned int strobe_offset;
+    unsigned int start;
+    unsigned int end;
     bool is_reverse;
 };
 

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -23,7 +23,7 @@ typedef std::vector<MersIndexEntry> ind_mers_vector;
 struct QueryMer {
     uint64_t hash;
     unsigned int position;
-    unsigned int offset_strobe;
+    unsigned int strobe_offset;
     bool is_reverse;
 };
 

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1205,7 +1205,7 @@ static inline void find_nams_rescue(
             total_hits ++;
             auto ref_hit = mers_index[mer_hashv];
             auto offset = ref_hit.offset;
-            auto count = ref_hit.count;
+            auto count = ref_hit.count();
             auto query_s = q.start;
             auto query_e = q.end;
             is_rc = q.is_reverse;
@@ -1500,7 +1500,7 @@ static inline std::pair<float,int> find_nams(
             h.is_rc = q.is_reverse;
             auto mer = mers_index[mer_hashv];
             auto offset = mer.offset;
-            auto count = mer.count;
+            auto count = mer.count();
 //            if (count == 1){
 //                auto r = ref_mers[offset];
 //                unsigned int ref_id = std::get<0>(r); //The indexes in this code are not fixed after removal of the 64-bit hash

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1206,8 +1206,8 @@ static inline void find_nams_rescue(
             auto ref_hit = mers_index[mer_hashv];
             auto offset = ref_hit.offset;
             auto count = ref_hit.count;
-            auto query_s = q.position;
-            auto query_e = query_s + q.strobe_offset + k;
+            auto query_s = q.start;
+            auto query_e = q.end;
             is_rc = q.is_reverse;
             if (is_rc){
                 Hit s{count, offset, query_s, query_e, is_rc};
@@ -1495,8 +1495,8 @@ static inline std::pair<float,int> find_nams(
         auto mer_hashv = q.hash;
         if (mers_index.find(mer_hashv) != mers_index.end()) { //  In  index
             total_hits ++;
-            h.query_s = q.position;
-            h.query_e = h.query_s + q.strobe_offset + k; // h.query_s + read_length/2;
+            h.query_s = q.start;
+            h.query_e = q.end; // h.query_s + read_length/2;
             h.is_rc = q.is_reverse;
             auto mer = mers_index[mer_hashv];
             auto offset = mer.offset;

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1207,7 +1207,7 @@ static inline void find_nams_rescue(
             auto offset = ref_hit.offset;
             auto count = ref_hit.count;
             auto query_s = q.position;
-            auto query_e = query_s + q.offset_strobe + k;
+            auto query_e = query_s + q.strobe_offset + k;
             is_rc = q.is_reverse;
             if (is_rc){
                 Hit s{count, offset, query_s, query_e, is_rc};
@@ -1496,7 +1496,7 @@ static inline std::pair<float,int> find_nams(
         if (mers_index.find(mer_hashv) != mers_index.end()) { //  In  index
             total_hits ++;
             h.query_s = q.position;
-            h.query_e = h.query_s + q.offset_strobe + k; // h.query_s + read_length/2;
+            h.query_e = h.query_s + q.strobe_offset + k; // h.query_s + read_length/2;
             h.is_rc = q.is_reverse;
             auto mer = mers_index[mer_hashv];
             auto offset = mer.offset;

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1204,7 +1204,7 @@ static inline void find_nams_rescue(
         if (mers_index.find(mer_hashv) != mers_index.end()){ //  In  index
             total_hits ++;
             auto ref_hit = mers_index[mer_hashv];
-            auto offset = ref_hit.offset;
+            auto offset = ref_hit.offset();
             auto count = ref_hit.count();
             auto query_s = q.start;
             auto query_e = q.end;
@@ -1499,7 +1499,7 @@ static inline std::pair<float,int> find_nams(
             h.query_e = q.end; // h.query_s + read_length/2;
             h.is_rc = q.is_reverse;
             auto mer = mers_index[mer_hashv];
-            auto offset = mer.offset;
+            auto offset = mer.offset();
             auto count = mer.count();
 //            if (count == 1){
 //                auto r = ref_mers[offset];

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1294,18 +1294,13 @@ static inline void find_nams_rescue(
             {
                 auto r = ref_mers[j];
                 h.ref_s = r.position;
-                auto p = r.packed;
-                int bit_alloc = 8;
-                int r_id = (p >> bit_alloc);
-                int mask=(1<<bit_alloc) - 1;
-                int offset = (p & mask);
-                h.ref_e = h.ref_s + offset + k;
+                h.ref_e = h.ref_s + r.strobe2_offset() + k;
 //                h.count = count;
 //                hits_per_ref[std::get<0>(r)].push_back(h);
 
                 int diff = std::abs((h.query_e - h.query_s) - (h.ref_e - h.ref_s));
                 if (diff <= min_diff ){
-                    hits_per_ref[r_id].push_back(h);
+                    hits_per_ref[r.reference_index()].push_back(h);
                     min_diff = diff;
                 }
             }
@@ -1343,17 +1338,12 @@ static inline void find_nams_rescue(
             {
                 auto r = ref_mers[j];
                 h.ref_s = r.position;
-                auto p = r.packed;
-                int bit_alloc = 8;
-                int r_id = (p >> bit_alloc);
-                int mask=(1<<bit_alloc) - 1;
-                int offset = (p & mask);
-                h.ref_e = h.ref_s + offset + k;
+                h.ref_e = h.ref_s + r.strobe2_offset() + k;
 //                h.count = count;
 //                hits_per_ref[std::get<1>(r)].push_back(h);
                 int diff = std::abs((h.query_e - h.query_s) - (h.ref_e - h.ref_s));
                 if (diff <= min_diff ){
-                    hits_per_ref[r_id].push_back(h);
+                    hits_per_ref[r.reference_index()].push_back(h);
                     min_diff = diff;
                 }
             }
@@ -1547,12 +1537,7 @@ static inline std::pair<float,int> find_nams(
 //                    unsigned int ref_s = std::get<1>(r);
 //                    unsigned int ref_e = std::get<2>(r) + k; //ref_s + read_length/2;
                     h.ref_s = r.position;
-                    auto p = r.packed;
-                    int bit_alloc = 8;
-                    int r_id = (p >> bit_alloc);
-                    int mask=(1<<bit_alloc) - 1;
-                    int offset = (p & mask);
-                    h.ref_e = h.ref_s + offset + k;
+                    h.ref_e = h.ref_s + r.strobe2_offset() + k;
 //                    h.count = count;
 //                    hits_per_ref[std::get<1>(r)].push_back(h);
 //                    hits_per_ref[std::get<0>(r)].push_back(h);
@@ -1567,7 +1552,7 @@ static inline std::pair<float,int> find_nams(
 //                        start_log = true;
 //                    }
                     if (diff <= min_diff ){
-                        hits_per_ref[r_id].push_back(h);
+                        hits_per_ref[r.reference_index()].push_back(h);
                         min_diff = diff;
 //                        std::cerr << "Found: query: " <<  h.query_s << " " << h.query_e << " ref: " <<  h.ref_s << " " << h.ref_e << " " << h.is_rc << " diff " << diff << std::endl;
 //                        tries ++;

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=5d4005bb5c80c66e4cc595b16a99a869f8755724
+baseline_commit=bb4613176a46114832b785e4f935bfc1fc9b0a9f


### PR DESCRIPTION
I’m working on reducing memory usage and need to make some refactorings along the way in order to encapsulate the index and some of the other data structures better, which will then make it easer to change the way the index is structured.

For example, I made `mers_index` private to ensure that it is accessed only through methods provided by the `StrobemerIndex` class. `KmerLookupEntry::count` also becomes a method. These "getter" methods are inlined by the compiler, so there’s no cost for this.

Lastly, commit bb4613176a46114832b785e4f935bfc1fc9b0a9f changes results: When sorting multiple `Hit`s, the current behavior is to sort them by count first and then by offset. I want to change this in a later commit so that a Hit doesn’t know where in the flat vector a strobemer is stored (that is, there’s no offset anymore), so I’ve removed the offset from the comparison. Since this changes some alignments, I will push another commit to change the baseline commit. (I have not pushed it yet so that the test failure is visible.)