### PR TITLE
Fix ReferenceMer memory usage

### DIFF
--- a/src/index.hpp
+++ b/src/index.hpp
@@ -35,8 +35,8 @@ public:
     }
 
 private:
-    const int bit_alloc = 8;
-    const int mask = (1 << bit_alloc) - 1;
+    static const int bit_alloc = 8;
+    static const int mask = (1 << bit_alloc) - 1;
     int32_t packed;
 };
 


### PR DESCRIPTION
I added "bit_alloc" and "mask" as attributes in a previous commit, but did not realize that a "const" attribute is stored in the instance. It needs to be static to avoid this.

I verified that the compiled code is the same as if one had hardcoded the constants.

Memory usage for indexing CHM13 went up from 30 GiB to 34 GiB. With this change, it is back to 30 GiB.