### PR TITLE
Reduced memory usage with a pre-generated index

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -127,6 +127,7 @@ void StrobemerIndex::index_vector(const ind_mers_vector &mers, float f) {
     unsigned int tot_mid_ab = 0;
     std::vector<unsigned int> strobemer_counts;
 
+    auto prev_mer = mers[0];
     uint64_t prev_hash = mers[0].hash;
     uint64_t curr_hash;
 
@@ -149,10 +150,17 @@ void StrobemerIndex::index_vector(const ind_mers_vector &mers, float f) {
                 tot_mid_ab++;
                 strobemer_counts.push_back(count);
             }
-            add_entry(prev_hash, prev_offset, count);
+
+            if (count == 1) {
+                add_entry(prev_hash, prev_mer.position, prev_mer.packed | 0x8000'0000);
+                flat_vector[flat_vector.size() - 2] = ReferenceMer{0, 0};  // should never be used
+            } else {
+                add_entry(prev_hash, prev_offset, count);
+            }
             count = 1;
             prev_hash = curr_hash;
             prev_offset = offset;
+            prev_mer = mer;
         }
         offset++;
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -128,36 +128,36 @@ void StrobemerIndex::index_vector(const hash_vector &h_vector, float f) {
     unsigned int tot_mid_ab = 0;
     std::vector<unsigned int> strobemer_counts;
 
-    uint64_t prev_k = h_vector[0];
-    uint64_t curr_k;
+    uint64_t prev_hash = h_vector[0];
+    uint64_t curr_hash;
 
-    for ( auto &t : h_vector) {
-        curr_k = t;
-        if (curr_k == prev_k){
-            count ++;
+    for (auto &hash : h_vector) {
+        curr_hash = hash;
+        if (curr_hash == prev_hash){
+            count++;
         }
         else {
-            if (count == 1){
-                tot_occur_once ++;
+            if (count == 1) {
+                tot_occur_once++;
             }
             else if (count > 100){
-                tot_high_ab ++;
+                tot_high_ab++;
                 strobemer_counts.push_back(count);
             }
             else{
-                tot_mid_ab ++;
+                tot_mid_ab++;
                 strobemer_counts.push_back(count);
             }
-            add_entry(prev_k, prev_offset, count);
+            add_entry(prev_hash, prev_offset, count);
             count = 1;
-            prev_k = curr_k;
+            prev_hash = curr_hash;
             prev_offset = offset;
         }
-        offset ++;
+        offset++;
     }
 
     // last k-mer
-    add_entry(curr_k, prev_offset, count);
+    add_entry(curr_hash, prev_offset, count);
 
     float frac_unique = ((float) tot_occur_once )/ mers_index.size();
     stats.tot_strobemer_count = offset;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -153,7 +153,9 @@ void StrobemerIndex::index_vector(const ind_mers_vector &mers, float f) {
 
             if (count == 1) {
                 add_entry(prev_hash, prev_mer.position, prev_mer.packed | 0x8000'0000);
-                flat_vector[flat_vector.size() - 2] = ReferenceMer{0, 0};  // should never be used
+                flat_vector[flat_vector.size() - 2] = flat_vector[flat_vector.size() - 1];
+                flat_vector.pop_back();
+                offset--;
             } else {
                 add_entry(prev_hash, prev_offset, count);
             }
@@ -256,12 +258,10 @@ void StrobemerIndex::read(const std::string& filename) {
 void StrobemerIndex::populate(float f) {
     auto ind_flat_vector = generate_and_sort_seeds();
     Timer flat_vector_timer;
-    flat_vector.reserve(ind_flat_vector.size());
     stats.elapsed_flat_vector = flat_vector_timer.duration();
 
     Timer hash_index_timer;
     mers_index.reserve(count_unique_hashes(ind_flat_vector));
-    // construct index over flat array
     index_vector(ind_flat_vector, f);
     filter_cutoff = stats.filter_cutoff;
     stats.elapsed_hash_index = hash_index_timer.duration();

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -23,22 +23,26 @@
 class ReferenceMer {
 public:
     ReferenceMer() { }  // TODO should not be needed
-    ReferenceMer(uint32_t position, int32_t packed) : position(position), packed(packed) {
+    ReferenceMer(uint32_t position, uint32_t packed) : position(position), m_packed(packed) {
     }
     uint32_t position;
 
     int reference_index() const {
-        return packed >> bit_alloc;
+        return m_packed >> bit_alloc;
     }
 
     int strobe2_offset() const {
-        return packed & mask;
+        return m_packed & mask;
+    }
+
+    MersIndexEntry::packed_t packed() const {
+        return m_packed;
     }
 
 private:
     static const int bit_alloc = 8;
     static const int mask = (1 << bit_alloc) - 1;
-    int32_t packed;
+    MersIndexEntry::packed_t m_packed;
 };
 
 typedef std::vector<ReferenceMer> mers_vector;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <cmath>
 #include <iostream>
+#include <cassert>
 #include "robin_hood.h"
 #include "exceptions.hpp"
 #include "refs.hpp"
@@ -53,11 +54,25 @@ public:
     KmerLookupEntry(unsigned int offset, unsigned int count) : m_offset(offset), m_count(count) { }
 
     unsigned int count() const {
-        return m_count;
+        if (is_reference_mer()) {
+            return 1;
+        } else {
+            return m_count;
+        }
     }
 
     unsigned int offset() const{
+        assert(!is_reference_mer());
         return m_offset;
+    }
+
+    bool is_reference_mer() const {
+        return m_count & 0x8000'0000;
+    }
+
+    ReferenceMer as_reference_mer() const {
+        assert(is_reference_mer());
+        return ReferenceMer{m_offset, m_count & 0x7fff'ffff};
     }
 
 private:

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -168,7 +168,7 @@ private:
     const References& references;
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
 
-    void index_vector(const hash_vector& h_vector, float f);
+    void index_vector(const ind_mers_vector &mers, float f);
     ind_mers_vector generate_and_sort_seeds() const;
 };
 

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -244,7 +244,7 @@ void randstrobes_reference(
     RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
     while (randstrobe_iter.has_next()) {
         auto randstrobe = randstrobe_iter.next();
-        int packed = (ref_index << 8);
+        MersIndexEntry::packed_t packed = (ref_index << 8);
         packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
         MersIndexEntry s {randstrobe.hash, randstrobe.strobe1_pos, packed};
         flat_vector.push_back(s);

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -8,9 +8,11 @@
 
 // only used during index generation
 struct MersIndexEntry {
+
+    using packed_t = uint32_t;
     uint64_t hash;
     uint32_t position;
-    int32_t packed; // packed representation of ref_index and strobe offset
+    packed_t packed; // packed representation of ref_index and strobe offset
 
     bool operator< (const MersIndexEntry& other) const {
         return std::tie(hash, position, packed) < std::tie(other.hash, other.position, other.packed);


### PR DESCRIPTION
Here’s a draft proposal for reducing memory requirements.

As discussed in #173, each entry in the index hash table (`mers_index`) maps a randstrobe to an (offset, count) pair that point to a slice of the flat vector, where the actual information about the randstrobe is stored. For CHM13, ~500 million unique randstrobes are generated, so the hash table has 500 million entries. However, 97.4% of the randstrobes occur only once, so to store one of those, we need an (offset, count) pair (8 bytes) and the `ReferenceMer` entry in the flat vector itself (another 8 bytes). The idea implemented here is to store those randstrobes directly in the hash table:
- The most significant bit of the "count" value is used as a marker
- If it is set, the (offset, count) pair is re-interpreted as a `ReferenceMer`, where offset is interpreted as position and count is interpreted as the "packed" reference index and strobemer offset.
- If the bit is not set, (offset, count) are interpreted as before.

On constructing the index, we only add randstrobes with count greater than one to the flat vector, which gives us the memory savings.

The reason why I’ve marked this as "draft" is that peak memory on index construction is a bit larger because I had to undo the optimization of throwing away the hash values and filling the mers_index afterwards because I now need both to be available. One option would be to fall back to the previous way of doing things if `--use-index` is not provided.

I also have been working on a way to reduce the memory usage even during index creation time, but that is in a different branch

Here are some numbers on CHM13 using the 10 M 200 bp paired-end reads from your evaluation dataset.

| | main | this branch |
|-|-|-|
| Size of `.sti` file | 11.7 GiB | 8.2 GiB |
| Peak mem when creating index |28.6 GiB | 29.6 GiB |
| Time to create index | ~5:00 | ~5:00 |
| Peak mem with `-t 8 --use-index` |24.4 GiB | 20.7 GiB |
| (User) runtime mapping 10 M paired-end reads | ~2500s | ~2500s |

~~I think there is something fishy going on with the huge peak memory usage while mapping reads. I only discovered this just now when I wanted to see whether runtime changes when mapping a large number of reads. That is a separate issue however.~~ Fixed by #181. (*Edit:* Changed table above to no longer show peak memory for mapping 10 million reads. It’s the same as when mapping any number of reads. *main* includes the fix in #181.)

Note also how the index itself only contains 8.2 GiB of data. When it’s loaded, that becomes 17 GiB because of the maximum load factor of the hashtable and because its size can only be a power of two. If we could reduce this to the absolute minimum somehow, strobealign would only need ~12 GiB of RAM (3.2 GiB for the reference plus 8.2 GiB for the index plus a little extra).
