### PR TITLE
Fix memory leak

### DIFF
--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -66,6 +66,7 @@ void OutputBuffer::output_records(std::string chunk, size_t chunk_index) {
             break;
         }
         out << item->second;
+        chunks.erase(item);
         next_chunk_index++;
     }
     unique_lock.unlock();


### PR DESCRIPTION
The unordered_map storing chunks to be written out to disk in the correct order needs to remove chunks that it wrote. 

Closes #180