### PR TITLE
Warn when binary was compiled without optimizations

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,12 @@ std::string sam_header(const References& references, const std::string& read_gro
     return out.str();
 }
 
+void warn_if_no_optimizations() {
+    if (std::string(CMAKE_BUILD_TYPE) == "Debug") {
+        logger.info() << "\n    ***** Binary was compiled without optimizations - this will be very slow *****\n\n";
+    }
+}
+
 int run_strobealign(int argc, char **argv) {
     CommandLineOptions opt;
     mapping_params map_param;
@@ -57,6 +63,8 @@ int run_strobealign(int argc, char **argv) {
     logger.set_level(opt.verbose ? LOG_DEBUG : LOG_INFO);
     logger.info() << std::setprecision(2) << std::fixed;
     logger.info() << "This is strobealign " << version_string() << '\n';
+    logger.debug() << "Build type: " << CMAKE_BUILD_TYPE << '\n';
+    warn_if_no_optimizations();
 
     if (!opt.r_set && !opt.reads_filename1.empty()) {
         map_param.r = estimate_read_length(opt.reads_filename1, opt.reads_filename2);

--- a/src/version.hpp.in
+++ b/src/version.hpp.in
@@ -14,4 +14,6 @@ extern "C" {
 
 std::string version_string();
 
+#define CMAKE_BUILD_TYPE "@CMAKE_BUILD_TYPE@"
+
 #endif


### PR DESCRIPTION
When switching between branches, it often happens that CMake changes the CMAKE_BUILD_TYPE to Debug, which makes the resulting binary very slow. I have not been able to figure out, yet, why this is the case. I guess that somehow the CMakeCache.txt file is invalidated by changing the branches, and that this leads CMake to ignore the configured build type.

I would like to avoid that anyone benchmarks a strobealign binary compiled without optimizations, so until we’ve solved this, I’d like to print a fat warning when the build type is Debug.