### PR TITLE
Fix crash in rescue_mate for short reads

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1535,6 +1535,22 @@ static inline std::vector<std::tuple<int,nam,nam>> get_best_scoring_NAM_location
     return joint_NAM_scores;
 }
 
+/*
+ * Determine (roughly) whether the read sequence has some l-mer (with l = k*2/3)
+ * in common with the reference sequence
+ */
+bool has_shared_substring(const std::string& read_seq, const std::string& ref_seq, int k) {
+    int sub_size = 2 * k / 3;
+    int step_size = k / 3;
+    std::string submer;
+    for (size_t i = 0; i <= read_seq.size() - k; i += step_size) {
+        submer = read_seq.substr(i, sub_size);
+        if (ref_seq.find(submer) != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
+}
 
 static inline void rescue_mate(
     const alignment_params &aln_params,
@@ -1586,19 +1602,7 @@ static inline void rescue_mate(
     std::string ref_segm = references.sequences[n.ref_id].substr(ref_start, ref_end - ref_start);
     aln_info info;
 
-    // check that read shares at least some segment with ref otherwise abort
-    int sub_size = 2*k/3;
-    int step_size = k/3;
-    std::string submer;
-    bool found = false;
-    for (size_t i = 0; i <= r_tmp.size()-k; i+=step_size) {
-        submer = r_tmp.substr(i, sub_size);
-        if (ref_segm.find( submer ) != std::string::npos) {
-            found = true;
-            break;
-        }
-    }
-    if (!found){
+    if (!has_shared_substring(r_tmp, ref_segm, k)){
         sam_aln.cigar = "*";
         sam_aln.ed = read_len;
         sam_aln.sw_score = 0;

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1543,7 +1543,7 @@ bool has_shared_substring(const std::string& read_seq, const std::string& ref_se
     int sub_size = 2 * k / 3;
     int step_size = k / 3;
     std::string submer;
-    for (size_t i = 0; i <= read_seq.size() - k; i += step_size) {
+    for (size_t i = 0; i + k <= read_seq.size(); i += step_size) {
         submer = read_seq.substr(i, sub_size);
         if (ref_seq.find(submer) != std::string::npos) {
             return true;

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -112,5 +112,6 @@ void align_PE_read(klibpp::KSeq& record1, klibpp::KSeq& record2, Sam& sam, std::
 
 void align_SE_read(klibpp::KSeq& record, Sam& sam, std::string& outstring, AlignmentStatistics& statistics, const alignment_params& aln_params, const mapping_params& map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index);
 
+bool has_shared_substring(const std::string& read_seq, const std::string& ref_seq, int k);
 
 #endif

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -8,6 +8,7 @@
 #include "index.hpp"
 #include "fastq.hpp"
 #include "sam.hpp"
+#include "aln.hpp"
 
 
 TEST_CASE("References::add") {
@@ -226,4 +227,10 @@ TEST_CASE("TLEN zero when reads map to different contigs") {
     "readname\t65\tcontig1\t2\t55\t2M\tcontig2\t3\t0\tAACC\t#!B<\tNM:i:17\tAS:i:9\n"
     "readname\t129\tcontig2\t3\t57\t3M\tcontig1\t2\t0\tGGTT\tIHB#\tNM:i:2\tAS:i:4\n"
     );
+}
+
+TEST_CASE("has_shared_substring") {
+    std::string ref{"TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"};
+    std::string read{"GGGGGGGGGGGGGGGGG"};
+    CHECK(!has_shared_substring(read, ref, 20));
 }


### PR DESCRIPTION
This factors out a `has_shared_substring` function, adds a (failing) test for it and then fixes the issue.

The problem is that `read_seq.size() - k` becomes negative when the read is shorter than `k`, and
then the comparison is always true (because we compare to a `size_t`).
