### PR TITLE
Switch to C++ 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(ZLIB)
 find_package(Threads)
 find_package(OpenMP)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g")


### PR DESCRIPTION
I don’t know whether C++ 14 was chosen for a particular reason. If not, can we switch to C++ 17?

It has a couple of nice additions that I have refrained from using because we are still at C++ 14:

- Structured binding: https://en.cppreference.com/w/cpp/language/structured_binding
- string_view: https://en.cppreference.com/w/cpp/string/basic_string_view
- std::filesystem: https://en.cppreference.com/w/cpp/filesystem
- std::clamp https://en.cppreference.com/w/cpp/algorithm/clamp

Summary of C++ 17 changes: https://en.cppreference.com/w/cpp/17 That page also lists compiler support.