### PR TITLE
Factor out read_/write_vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ install(TARGETS strobealign DESTINATION bin)
 add_executable(test-strobealign
   tests/tests.cpp
   tests/test_refs.cpp
+  tests/test_sam.cpp
 )
 target_link_libraries(test-strobealign salib)
 target_include_directories(test-strobealign PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,10 @@ target_link_libraries(strobealign PUBLIC salib cmake_git_version_tracking)
 install(TARGETS strobealign DESTINATION bin)
 
 
-add_executable(test-strobealign tests/tests.cpp)
+add_executable(test-strobealign
+  tests/tests.cpp
+  tests/test_refs.cpp
+)
 target_link_libraries(test-strobealign salib)
 target_include_directories(test-strobealign PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -190,14 +190,11 @@ void StrobemerIndex::write(const std::string& filename) const {
     write_int_to_ostream(ofs, filter_cutoff);
     parameters.write(ofs);
 
-    //write flat_vector:
-    auto s1 = uint64_t(flat_vector.size());
-    ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
-    ofs.write(reinterpret_cast<const char*>(&flat_vector[0]), flat_vector.size() * sizeof(flat_vector[0]));
+    write_vector(ofs, flat_vector);
 
     //write mers_index:
-    s1 = uint64_t(mers_index.size());
-    ofs.write(reinterpret_cast<char*>(&s1), sizeof(s1));
+    auto size = uint64_t(mers_index.size());
+    ofs.write(reinterpret_cast<char*>(&size), sizeof(size));
     for (auto& p : mers_index) {
         ofs.write(reinterpret_cast<const char*>(&p.first), sizeof(p.first));
         ofs.write(reinterpret_cast<const char*>(&p.second), sizeof(p.second));
@@ -222,13 +219,9 @@ void StrobemerIndex::read(const std::string& filename) {
         throw InvalidIndexFile("Index parameters in .sti file and those specified on command line differ");
     }
 
-    // read flat_vector:
-    uint64_t sz;
-    flat_vector.clear();
-    ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));
-    flat_vector.resize(sz); //annoyingly, this initializes the memory to zero (which is a waste of performance), but let's ignore that for now
-    ifs.read(reinterpret_cast<char*>(&flat_vector[0]), sz*sizeof(flat_vector[0]));
+    read_vector(ifs, flat_vector);
 
+    uint64_t sz;
     // read mers_index:
     mers_index.clear();
     ifs.read(reinterpret_cast<char*>(&sz), sizeof(sz));

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -14,6 +14,7 @@
 #include <deque>
 #include <tuple>
 #include <cmath>
+#include <iostream>
 #include "robin_hood.h"
 #include "exceptions.hpp"
 #include "refs.hpp"
@@ -166,6 +167,23 @@ private:
     void index_vector(const hash_vector& h_vector, float f);
     ind_mers_vector generate_and_sort_seeds() const;
 };
+
+/* Write a vector to an output stream, preceded by its length */
+template <typename T>
+void write_vector(std::ostream& os, const std::vector<T>& v) {
+    auto size = uint64_t(v.size());
+    os.write(reinterpret_cast<char*>(&size), sizeof(size));
+    os.write(reinterpret_cast<const char*>(v.data()), v.size() * sizeof(T));
+}
+
+template <typename T>
+void read_vector(std::istream& is, std::vector<T>& v) {
+    uint64_t size;
+    v.clear();
+    is.read(reinterpret_cast<char*>(&size), sizeof(size));
+    v.resize(size);
+    is.read(reinterpret_cast<char*>(v.data()), size * sizeof(T));
+}
 
 
 #endif

--- a/src/refs.cpp
+++ b/src/refs.cpp
@@ -3,7 +3,6 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
-#include "exceptions.hpp"
 
 References References::from_fasta(const std::string& filename) {
     std::vector<std::string> sequences;

--- a/src/refs.hpp
+++ b/src/refs.hpp
@@ -1,12 +1,12 @@
-#ifndef FASTA_HPP
-#define FASTA_HPP
+#ifndef REFS_HPP
+#define REFS_HPP
 
 #include <cstdint>
 #include <string>
 #include <stdexcept>
 #include <numeric>
 #include <vector>
-
+#include "exceptions.hpp"
 
 class References {
     typedef std::vector<unsigned int> ref_lengths;

--- a/src/revcomp.hpp
+++ b/src/revcomp.hpp
@@ -2,7 +2,7 @@
 #define REVCOMP_HPP
 
 #include <string>
-
+#include <algorithm>
 
 static inline std::string reverse_complement(const std::string &read) {
     auto read_rev = read;

--- a/src/tmpdir.hpp
+++ b/src/tmpdir.hpp
@@ -1,0 +1,38 @@
+#ifndef TMPDIR_HPP
+#define TMPDIR_HPP
+
+#include <filesystem>
+#include <sstream>
+#include <string>
+
+/* Temporary directory that gets deleted automatically by the destructor */
+class TemporaryDirectory {
+public:
+    TemporaryDirectory(const std::string& prefix = "tmp") {
+        int i = 1;
+        std::filesystem::path dir;
+        while (true) {
+            std::stringstream s;
+            s << prefix << "-" << i;
+            dir = std::filesystem::temp_directory_path() / s.str();
+            if (std::filesystem::create_directory(dir)) {
+                break;
+            }
+            i++;
+        }
+        m_path = dir;
+    }
+
+    ~TemporaryDirectory() {
+        std::filesystem::remove_all(m_path);
+    }
+
+    const std::filesystem::path& path() const {
+        return m_path;
+    }
+
+private:
+    std::filesystem::path m_path;
+};
+
+#endif

--- a/tests/test_refs.cpp
+++ b/tests/test_refs.cpp
@@ -1,0 +1,53 @@
+#include <fstream>
+#include "doctest.h"
+#include "refs.hpp"
+
+TEST_CASE("References::add") {
+    References references;
+    references.add(std::string("thename"), std::string("ACGT"));
+
+    CHECK(references.names.size() == 1);
+    CHECK(references.names[0] == "thename");
+    CHECK(references.sequences[0] == "ACGT");
+    CHECK(references.lengths[0] == 4);
+}
+
+TEST_CASE("References::from_fasta") {
+    auto references = References::from_fasta("tests/phix.fasta");
+    CHECK(references.names.size() == 1);
+    CHECK(references.names[0] == "NC_001422.1");
+    CHECK(references.sequences.size() == 1);
+    CHECK(references.lengths.size() == 1);
+    CHECK(references.lengths[0] == 5386);
+    CHECK(references.total_length() == 5386);
+}
+
+TEST_CASE("References::from_fasta parse error") {
+    REQUIRE_THROWS_AS(References::from_fasta("tests/phix.1.fastq"), InvalidFasta);
+}
+
+TEST_CASE("Reference FASTA not found") {
+    REQUIRE_THROWS_AS(References::from_fasta("does-not-exist.fasta"), InvalidFasta);
+}
+
+TEST_CASE("Reference uppercase") {
+    {
+        std::ofstream ofs("tmpref.fasta");
+        ofs
+            << ">ref1\n"
+            << "acgt\n\n"
+            << ">ref2\n"
+            << "aacc\ngg\n\ntt\n"
+            << ">empty\n"
+            << ">empty_at_end_of_file";
+    }
+    auto refs = References::from_fasta("tmpref.fasta");
+    std::remove("tmpref.fasta");
+    CHECK(refs.sequences.size() == 2);
+    CHECK(refs.sequences[0].size() == 4);
+    CHECK(refs.sequences[0] == "ACGT");
+    CHECK(refs.sequences[1].size() == 8);
+    CHECK(refs.sequences[1] == "AACCGGTT");
+    CHECK(refs.names.size() == 2);
+    CHECK(refs.lengths.size() == 2);
+}

--- a/tests/test_sam.cpp
+++ b/tests/test_sam.cpp
@@ -1,0 +1,141 @@
+#include "doctest.h"
+#include "sam.hpp"
+#include "revcomp.hpp"
+
+TEST_CASE("Formatting unmapped SAM record") {
+    klibpp::KSeq kseq;
+    kseq.name = "read1";
+    kseq.seq = "ACGT";
+    kseq.qual = ">#BB";
+    std::string sam_string;
+
+    SUBCASE("without RG") {
+        Sam sam(sam_string, References());
+        sam.add_unmapped(kseq);
+
+        CHECK(sam_string == "read1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\t>#BB\n");
+    }
+
+    SUBCASE("with RG") {
+        Sam sam(sam_string, References(), "rg1");
+        sam.add_unmapped(kseq);
+
+        CHECK(sam_string == "read1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\t>#BB\tRG:Z:rg1\n");
+    }
+}
+
+TEST_CASE("Pair with one unmapped SAM record") {
+    References references;
+    references.add("contig1", "ACGT");
+    std::string sam_string;
+    Sam sam(sam_string, references);
+
+    alignment aln1;
+    aln1.ref_id = 0;
+    aln1.is_unaligned = false;
+    aln1.ref_start = 2;
+    aln1.is_rc = true;
+    aln1.ed = 17;
+    aln1.aln_score = 9;
+    aln1.cigar = "2M";
+
+    alignment aln2;
+    aln2.is_unaligned = true;
+
+    klibpp::KSeq record1;
+    klibpp::KSeq record2;
+    record1.name = "readname";
+    record1.seq = "AACC";
+    record1.qual = "#!B<";
+    record2.name = "readname";
+    record2.seq = "GGTT";
+    record2.qual = "IHB#";
+    std::string read1_rc = reverse_complement(record1.seq);
+    std::string read2_rc = reverse_complement(record2.seq);
+
+    int mapq1 = 55;
+    int mapq2 = 57;
+    bool is_proper = false;
+    bool is_primary = true;
+
+    sam.add_pair(
+        aln1,
+        aln2,
+        record1,
+        record2,
+        read1_rc,
+        read2_rc,
+        mapq1,
+        mapq2,
+        is_proper,
+        is_primary
+    );
+    // 89: PAIRED,MUNMAP,REVERSE,READ1
+    // 165: PAIRED,UNMAP,MREVERSE,READ2
+    CHECK(sam_string ==
+      "readname\t89\tcontig1\t2\t55\t2M\t*\t0\t0\tGGTT\t<B!#\tNM:i:17\tAS:i:9\n"
+      "readname\t165\t*\t0\t0\t*\tcontig1\t2\t0\tGGTT\tIHB#\n"
+    );
+}
+
+TEST_CASE("TLEN zero when reads map to different contigs") {
+    References references;
+    references.add("contig1", "ACGT");
+    references.add("contig2", "GGAA");
+    std::string sam_string;
+
+    alignment aln1;
+    aln1.ref_id = 0;
+    aln1.is_unaligned = false;
+    aln1.ref_start = 2;
+    aln1.is_rc = false;
+    aln1.ed = 17;
+    aln1.aln_score = 9;
+    aln1.cigar = "2M";
+
+    alignment aln2;
+    aln2.is_unaligned = false;
+    aln2.ref_id = 1;
+    aln2.ref_start = 3;
+    aln2.is_rc = false;
+    aln2.ed = 2;
+    aln2.aln_score = 4;
+    aln2.cigar = "3M";
+
+    klibpp::KSeq record1;
+    klibpp::KSeq record2;
+    record1.name = "readname";
+    record1.seq = "AACC";
+    record1.qual = "#!B<";
+    record2.name = "readname";
+    record2.seq = "GGTT";
+    record2.qual = "IHB#";
+    std::string read1_rc = reverse_complement(record1.seq);
+    std::string read2_rc = reverse_complement(record2.seq);
+
+    int mapq1 = 55;
+    int mapq2 = 57;
+    bool is_proper = false;
+    bool is_primary = true;
+
+    Sam sam(sam_string, references);
+
+    sam.add_pair(
+        aln1,
+        aln2,
+        record1,
+        record2,
+        read1_rc,
+        read2_rc,
+        mapq1,
+        mapq2,
+        is_proper,
+        is_primary
+    );
+    // 65: PAIRED,READ1
+    // 129: PAIRED,READ2
+    CHECK(sam_string ==
+    "readname\t65\tcontig1\t2\t55\t2M\tcontig2\t3\t0\tAACC\t#!B<\tNM:i:17\tAS:i:9\n"
+    "readname\t129\tcontig2\t3\t57\t3M\tcontig1\t2\t0\tGGTT\tIHB#\tNM:i:2\tAS:i:4\n"
+    );
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -11,56 +11,6 @@
 #include "aln.hpp"
 
 
-TEST_CASE("References::add") {
-    References references;
-    references.add(std::string("thename"), std::string("ACGT"));
-
-    CHECK(references.names.size() == 1);
-    CHECK(references.names[0] == "thename");
-    CHECK(references.sequences[0] == "ACGT");
-    CHECK(references.lengths[0] == 4);
-}
-
-TEST_CASE("References::from_fasta") {
-    auto references = References::from_fasta("tests/phix.fasta");
-    CHECK(references.names.size() == 1);
-    CHECK(references.names[0] == "NC_001422.1");
-    CHECK(references.sequences.size() == 1);
-    CHECK(references.lengths.size() == 1);
-    CHECK(references.lengths[0] == 5386);
-    CHECK(references.total_length() == 5386);
-}
-
-TEST_CASE("References::from_fasta parse error") {
-    REQUIRE_THROWS_AS(References::from_fasta("tests/phix.1.fastq"), InvalidFasta);
-}
-
-TEST_CASE("Reference FASTA not found") {
-    REQUIRE_THROWS_AS(References::from_fasta("does-not-exist.fasta"), InvalidFasta);
-}
-
-TEST_CASE("Reference uppercase") {
-    {
-        std::ofstream ofs("tmpref.fasta");
-        ofs
-            << ">ref1\n"
-            << "acgt\n\n"
-            << ">ref2\n"
-            << "aacc\ngg\n\ntt\n"
-            << ">empty\n"
-            << ">empty_at_end_of_file";
-    }
-    auto refs = References::from_fasta("tmpref.fasta");
-    std::remove("tmpref.fasta");
-    CHECK(refs.sequences.size() == 2);
-    CHECK(refs.sequences[0].size() == 4);
-    CHECK(refs.sequences[0] == "ACGT");
-    CHECK(refs.sequences[1].size() == 8);
-    CHECK(refs.sequences[1] == "AACCGGTT");
-    CHECK(refs.names.size() == 2);
-    CHECK(refs.lengths.size() == 2);
-}
-
 TEST_CASE("estimate_read_length") {
     CHECK(estimate_read_length("tests/phix.1.fastq", "") == 289);
     CHECK(estimate_read_length("tests/phix.1.fastq", "tests/phix.2.fastq") == 289);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,12 +1,12 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
-
 #include "refs.hpp"
 #include "exceptions.hpp"
 #include "readlen.hpp"
 #include "index.hpp"
 #include "fastq.hpp"
 #include "aln.hpp"
+#include "tmpdir.hpp"
 
 
 TEST_CASE("estimate_read_length") {
@@ -46,7 +46,8 @@ TEST_CASE("has_shared_substring") {
 }
 
 TEST_CASE("read_/write_vector") {
-    std::string filename{"tmp-vector"};
+    TemporaryDirectory tmp_dir;
+    std::string filename = tmp_dir.path() / "vector";
     const std::vector<int> expected{2, 3, 5, 7, 11};
     {
         std::ofstream ofs{filename, std::ios::binary};

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -44,3 +44,18 @@ TEST_CASE("has_shared_substring") {
     std::string read{"GGGGGGGGGGGGGGGGG"};
     CHECK(!has_shared_substring(read, ref, 20));
 }
+
+TEST_CASE("read_/write_vector") {
+    std::string filename{"tmp-vector"};
+    const std::vector<int> expected{2, 3, 5, 7, 11};
+    {
+        std::ofstream ofs{filename, std::ios::binary};
+        write_vector(ofs, expected);
+    }
+    std::vector<int> y;
+    {
+        std::ifstream ifs{filename, std::ios::binary};
+        read_vector(ifs, y);
+    }
+    CHECK(y == expected);
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,13 +1,11 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest.h"
 
-#include "revcomp.hpp"
 #include "refs.hpp"
 #include "exceptions.hpp"
 #include "readlen.hpp"
 #include "index.hpp"
 #include "fastq.hpp"
-#include "sam.hpp"
 #include "aln.hpp"
 
 
@@ -39,144 +37,6 @@ TEST_CASE("sti file same parameters") {
 TEST_CASE("Reads file missing") {
     std::string filename("does-not-exist.fastq");
     REQUIRE_THROWS_AS(open_fastq(filename), InvalidFile);
-}
-
-TEST_CASE("Formatting unmapped SAM record") {
-    klibpp::KSeq kseq;
-    kseq.name = "read1";
-    kseq.seq = "ACGT";
-    kseq.qual = ">#BB";
-    std::string sam_string;
-
-    SUBCASE("without RG") {
-        Sam sam(sam_string, References());
-        sam.add_unmapped(kseq);
-
-        CHECK(sam_string == "read1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\t>#BB\n");
-    }
-
-    SUBCASE("with RG") {
-        Sam sam(sam_string, References(), "rg1");
-        sam.add_unmapped(kseq);
-
-        CHECK(sam_string == "read1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\t>#BB\tRG:Z:rg1\n");
-    }
-}
-
-TEST_CASE("pair with one unmapped SAM record") {
-    References references;
-    references.add("contig1", "ACGT");
-    std::string sam_string;
-    Sam sam(sam_string, references);
-
-    alignment aln1;
-    aln1.ref_id = 0;
-    aln1.is_unaligned = false;
-    aln1.ref_start = 2;
-    aln1.is_rc = true;
-    aln1.ed = 17;
-    aln1.aln_score = 9;
-    aln1.cigar = "2M";
-
-    alignment aln2;
-    aln2.is_unaligned = true;
-
-    klibpp::KSeq record1;
-    klibpp::KSeq record2;
-    record1.name = "readname";
-    record1.seq = "AACC";
-    record1.qual = "#!B<";
-    record2.name = "readname";
-    record2.seq = "GGTT";
-    record2.qual = "IHB#";
-    std::string read1_rc = reverse_complement(record1.seq);
-    std::string read2_rc = reverse_complement(record2.seq);
-
-    int mapq1 = 55;
-    int mapq2 = 57;
-    bool is_proper = false;
-    bool is_primary = true;
-
-    sam.add_pair(
-        aln1,
-        aln2,
-        record1,
-        record2,
-        read1_rc,
-        read2_rc,
-        mapq1,
-        mapq2,
-        is_proper,
-        is_primary
-    );
-    // 89: PAIRED,MUNMAP,REVERSE,READ1
-    // 165: PAIRED,UNMAP,MREVERSE,READ2
-    CHECK(sam_string ==
-      "readname\t89\tcontig1\t2\t55\t2M\t*\t0\t0\tGGTT\t<B!#\tNM:i:17\tAS:i:9\n"
-      "readname\t165\t*\t0\t0\t*\tcontig1\t2\t0\tGGTT\tIHB#\n"
-    );
-}
-
-TEST_CASE("TLEN zero when reads map to different contigs") {
-    References references;
-    references.add("contig1", "ACGT");
-    references.add("contig2", "GGAA");
-    std::string sam_string;
-
-    alignment aln1;
-    aln1.ref_id = 0;
-    aln1.is_unaligned = false;
-    aln1.ref_start = 2;
-    aln1.is_rc = false;
-    aln1.ed = 17;
-    aln1.aln_score = 9;
-    aln1.cigar = "2M";
-
-    alignment aln2;
-    aln2.is_unaligned = false;
-    aln2.ref_id = 1;
-    aln2.ref_start = 3;
-    aln2.is_rc = false;
-    aln2.ed = 2;
-    aln2.aln_score = 4;
-    aln2.cigar = "3M";
-
-    klibpp::KSeq record1;
-    klibpp::KSeq record2;
-    record1.name = "readname";
-    record1.seq = "AACC";
-    record1.qual = "#!B<";
-    record2.name = "readname";
-    record2.seq = "GGTT";
-    record2.qual = "IHB#";
-    std::string read1_rc = reverse_complement(record1.seq);
-    std::string read2_rc = reverse_complement(record2.seq);
-
-    int mapq1 = 55;
-    int mapq2 = 57;
-    bool is_proper = false;
-    bool is_primary = true;
-
-    Sam sam(sam_string, references);
-
-    sam.add_pair(
-        aln1,
-        aln2,
-        record1,
-        record2,
-        read1_rc,
-        read2_rc,
-        mapq1,
-        mapq2,
-        is_proper,
-        is_primary
-    );
-    // 65: PAIRED,READ1
-    // 129: PAIRED,READ2
-    CHECK(sam_string ==
-    "readname\t65\tcontig1\t2\t55\t2M\tcontig2\t3\t0\tAACC\t#!B<\tNM:i:17\tAS:i:9\n"
-    "readname\t129\tcontig2\t3\t57\t3M\tcontig1\t2\t0\tGGTT\tIHB#\tNM:i:2\tAS:i:4\n"
-    );
 }
 
 TEST_CASE("has_shared_substring") {


### PR DESCRIPTION
Factoring out `read_`/`write_vector` should make it easier to continue work on #179 (where one of the suggestions was to write one of the vectors to disk to save memory).

I also added a `TemporaryDirectory` class that when instantiated creates a temporary directory in an appropriate place and deletes it automatically when the instance goes out of scope. This is here only used for testing, but for #179 would also be needed. BTW, this uses `std::filesystem`, which is from C++17.

Also, this splits the tests into multiple files.