### PR TITLE
Memory reduction II

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@
 
 ### Features
 
+* PR #191 and PR #192: RAM usage has been decreased significantly. For the
+  human genome, for example, it went from from 28 GiB to 21 GiB. (Mapping
+  runtime is unaffected.)
 * There is now a Conda package for StrobeAlign on Bioconda.
 * The index can now be pre-generated and safed to disk.
 * Invalid or missing input files no longer lead to a crash.

--- a/ext/hyperloglog/hyperloglog.hpp
+++ b/ext/hyperloglog/hyperloglog.hpp
@@ -1,0 +1,374 @@
+#if !defined(HYPERLOGLOG_HPP)
+#define HYPERLOGLOG_HPP
+
+/**
+ * @file hyperloglog.hpp
+ * @brief HyperLogLog cardinality estimator
+ * @date Created 2013/3/20
+ * @author Hideaki Ohno
+ */
+
+#include <vector>
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+#include <algorithm>
+#include "murmur3.h"
+
+#define HLL_HASH_SEED 313
+
+#if defined(__has_builtin) && (defined(__GNUC__) || defined(__clang__))
+
+#define _GET_CLZ(x, b) (uint8_t)std::min(b, ::__builtin_clz(x)) + 1
+
+#else
+
+inline uint8_t _get_leading_zero_count(uint32_t x, uint8_t b) {
+
+#if defined (_MSC_VER)
+    uint32_t leading_zero_len = 32;
+    ::_BitScanReverse(&leading_zero_len, x);
+    --leading_zero_len;
+    return std::min(b, (uint8_t)leading_zero_len);
+#else
+    uint8_t v = 1;
+    while (v <= b && !(x & 0x80000000)) {
+        v++;
+        x <<= 1;
+    }
+    return v;
+#endif
+
+}
+#define _GET_CLZ(x, b) _get_leading_zero_count(x, b)
+#endif /* defined(__GNUC__) */
+
+namespace hll {
+
+static const double pow_2_32 = 4294967296.0; ///< 2^32
+static const double neg_pow_2_32 = -4294967296.0; ///< -(2^32)
+
+/** @class HyperLogLog
+ *  @brief Implement of 'HyperLogLog' estimate cardinality algorithm
+ */
+class HyperLogLog {
+public:
+
+    /**
+     * Constructor
+     *
+     * @param[in] b bit width (register size will be 2 to the b power).
+     *            This value must be in the range[4,30].Default value is 4.
+     *
+     * @exception std::invalid_argument the argument is out of range.
+     */
+    HyperLogLog(uint8_t b = 4) throw (std::invalid_argument) :
+            b_(b), m_(1 << b), M_(m_, 0) {
+
+        if (b < 4 || 30 < b) {
+            throw std::invalid_argument("bit width must be in the range [4,30]");
+        }
+
+        double alpha;
+        switch (m_) {
+            case 16:
+                alpha = 0.673;
+                break;
+            case 32:
+                alpha = 0.697;
+                break;
+            case 64:
+                alpha = 0.709;
+                break;
+            default:
+                alpha = 0.7213 / (1.0 + 1.079 / m_);
+                break;
+        }
+        alphaMM_ = alpha * m_ * m_;
+    }
+
+    /**
+     * Adds element to the estimator
+     *
+     * @param[in] str string to add
+     * @param[in] len length of string
+     */
+    void add(const char* str, uint32_t len) {
+        uint32_t hash;
+        MurmurHash3_x86_32(str, len, HLL_HASH_SEED, (void*) &hash);
+        uint32_t index = hash >> (32 - b_);
+        uint8_t rank = _GET_CLZ((hash << b_), 32 - b_);
+        if (rank > M_[index]) {
+            M_[index] = rank;
+        }
+    }
+
+    /**
+     * Estimates cardinality value.
+     *
+     * @return Estimated cardinality value.
+     */
+    double estimate() const {
+        double estimate;
+        double sum = 0.0;
+        for (uint32_t i = 0; i < m_; i++) {
+            sum += 1.0 / (1 << M_[i]);
+        }
+        estimate = alphaMM_ / sum; // E in the original paper
+        if (estimate <= 2.5 * m_) {
+            uint32_t zeros = 0;
+            for (uint32_t i = 0; i < m_; i++) {
+                if (M_[i] == 0) {
+                    zeros++;
+                }
+            }
+            if (zeros != 0) {
+                estimate = m_ * std::log(static_cast<double>(m_)/ zeros);
+            }
+        } else if (estimate > (1.0 / 30.0) * pow_2_32) {
+            estimate = neg_pow_2_32 * log(1.0 - (estimate / pow_2_32));
+        }
+        return estimate;
+    }
+
+    /**
+     * Merges the estimate from 'other' into this object, returning the estimate of their union.
+     * The number of registers in each must be the same.
+     *
+     * @param[in] other HyperLogLog instance to be merged
+     * 
+     * @exception std::invalid_argument number of registers doesn't match.
+     */
+    void merge(const HyperLogLog& other) throw (std::invalid_argument) {
+        if (m_ != other.m_) {
+            std::stringstream ss;
+            ss << "number of registers doesn't match: " << m_ << " != " << other.m_;
+            throw std::invalid_argument(ss.str().c_str());
+        }
+        for (uint32_t r = 0; r < m_; ++r) {
+            if (M_[r] < other.M_[r]) {
+                M_[r] |= other.M_[r];
+            }
+        }
+    }
+
+    /**
+     * Clears all internal registers.
+     */
+    void clear() {
+        std::fill(M_.begin(), M_.end(), 0);
+    }
+
+    /**
+     * Returns size of register.
+     *
+     * @return Register size
+     */
+    uint32_t registerSize() const {
+        return m_;
+    }
+
+    /**
+     * Exchanges the content of the instance
+     *
+     * @param[in,out] rhs Another HyperLogLog instance
+     */
+    void swap(HyperLogLog& rhs) {
+        std::swap(b_, rhs.b_);
+        std::swap(m_, rhs.m_);
+        std::swap(alphaMM_, rhs.alphaMM_);
+        M_.swap(rhs.M_);       
+    }
+
+    /**
+     * Dump the current status to a stream
+     *
+     * @param[out] os The output stream where the data is saved
+     *
+     * @exception std::runtime_error When failed to dump.
+     */
+    void dump(std::ostream& os) const throw(std::runtime_error){
+        os.write((char*)&b_, sizeof(b_));
+        os.write((char*)&M_[0], sizeof(M_[0]) * M_.size());
+        if(os.fail()){
+            throw std::runtime_error("Failed to dump");
+        }
+    }
+
+    /**
+     * Restore the status from a stream
+     * 
+     * @param[in] is The input stream where the status is saved
+     *
+     * @exception std::runtime_error When failed to restore.
+     */
+    void restore(std::istream& is) throw(std::runtime_error){
+        uint8_t b = 0;
+        is.read((char*)&b, sizeof(b));
+        HyperLogLog tempHLL(b);
+        is.read((char*)&(tempHLL.M_[0]), sizeof(M_[0]) * tempHLL.m_);
+        if(is.fail()){
+           throw std::runtime_error("Failed to restore");
+        }       
+        swap(tempHLL);
+    }
+
+protected:
+    uint8_t b_; ///< register bit width
+    uint32_t m_; ///< register size
+    double alphaMM_; ///< alpha * m^2
+    std::vector<uint8_t> M_; ///< registers
+};
+
+/**
+ * @brief HIP estimator on HyperLogLog counter.
+ */
+class HyperLogLogHIP : public HyperLogLog {
+public:
+
+    /**
+     * Constructor
+     *
+     * @param[in] b bit width (register size will be 2 to the b power).
+     *            This value must be in the range[4,30].Default value is 4.
+     *
+     * @exception std::invalid_argument the argument is out of range.
+     */
+    HyperLogLogHIP(uint8_t b = 4) throw (std::invalid_argument) : HyperLogLog(b), register_limit_((1 << 5) - 1), c_(0.0), p_(1 << b) {
+    }
+
+    /**
+     * Adds element to the estimator
+     *
+     * @param[in] str string to add
+     * @param[in] len length of string
+     */
+    void add(const char* str, uint32_t len) {
+        uint32_t hash;
+        MurmurHash3_x86_32(str, len, HLL_HASH_SEED, (void*) &hash);
+        uint32_t index = hash >> (32 - b_);
+        uint8_t rank = _GET_CLZ((hash << b_), 32 - b_);
+        rank = rank == 0 ? register_limit_ : std::min(register_limit_, rank);
+        const uint8_t old = M_[index];
+        if (rank > old) {
+            c_ += 1.0 / (p_/m_);
+            p_ -= 1.0/(1 << old);
+            M_[index] = rank;
+            if(rank < 31){
+                p_ += 1.0/(uint32_t(1) << rank);
+            }
+        }
+    }
+
+    /**
+     * Estimates cardinality value.
+     *
+     * @return Estimated cardinality value.
+     */
+    double estimate() const {
+        return c_;
+    }
+
+    /**
+     * Merges the estimate from 'other' into this object, returning the estimate of their union.
+     * The number of registers in each must be the same.
+     *
+     * @param[in] other HyperLogLog instance to be merged
+     * 
+     * @exception std::invalid_argument number of registers doesn't match.
+     */
+    void merge(const HyperLogLogHIP& other) throw (std::invalid_argument) {
+        if (m_ != other.m_) {
+            std::stringstream ss;
+            ss << "number of registers doesn't match: " << m_ << " != " << other.m_;
+            throw std::invalid_argument(ss.str().c_str());
+        }
+        for (uint32_t r = 0; r < m_; ++r) {
+            const uint8_t b = M_[r];
+            const uint8_t b_other = other.M_[r];
+            if (b < b_other) {
+                c_ += 1.0 / (p_/m_);
+                p_ -= 1.0/(1 << b);
+                M_[r] |= b_other;
+                if(b_other < register_limit_){
+                    p_ += 1.0/(1 << b_other);
+                }
+            }
+        }
+    }
+
+    /**
+     * Clears all internal registers.
+     */
+    void clear() {
+        std::fill(M_.begin(), M_.end(), 0);
+        c_ = 0.0;
+        p_ = 1 << b_;
+    }
+
+    /**
+     * Returns size of register.
+     *
+     * @return Register size
+     */
+    uint32_t registerSize() const {
+        return m_;
+    }
+
+    /**
+     * Exchanges the content of the instance
+     *
+     * @param[in,out] rhs Another HyperLogLog instance
+     */
+    void swap(HyperLogLogHIP& rhs) {
+        std::swap(b_, rhs.b_);
+        std::swap(m_, rhs.m_);
+        std::swap(c_, rhs.c_);
+        M_.swap(rhs.M_);       
+    }
+
+    /**
+     * Dump the current status to a stream
+     *
+     * @param[out] os The output stream where the data is saved
+     *
+     * @exception std::runtime_error When failed to dump.
+     */
+    void dump(std::ostream& os) const throw(std::runtime_error){
+        os.write((char*)&b_, sizeof(b_));
+        os.write((char*)&M_[0], sizeof(M_[0]) * M_.size());
+        os.write((char*)&c_, sizeof(c_));
+        os.write((char*)&p_, sizeof(p_));
+        if(os.fail()){
+            throw std::runtime_error("Failed to dump");
+        }
+    }
+
+    /**
+     * Restore the status from a stream
+     * 
+     * @param[in] is The input stream where the status is saved
+     *
+     * @exception std::runtime_error When failed to restore.
+     */
+    void restore(std::istream& is) throw(std::runtime_error){
+        uint8_t b = 0;
+        is.read((char*)&b, sizeof(b));
+        HyperLogLogHIP tempHLL(b);
+        is.read((char*)&(tempHLL.M_[0]), sizeof(M_[0]) * tempHLL.m_);
+        is.read((char*)&(tempHLL.c_), sizeof(double));
+        is.read((char*)&(tempHLL.p_), sizeof(double));
+        if(is.fail()){
+           throw std::runtime_error("Failed to restore");
+        }       
+        swap(tempHLL);
+    }
+private: 
+    const uint8_t register_limit_;
+    double c_;
+    double p_;
+};
+
+} // namespace hll
+
+#endif // !defined(HYPERLOGLOG_HPP)

--- a/ext/hyperloglog/hyperloglog.hpp
+++ b/ext/hyperloglog/hyperloglog.hpp
@@ -62,7 +62,7 @@ public:
      *
      * @exception std::invalid_argument the argument is out of range.
      */
-    HyperLogLog(uint8_t b = 4) throw (std::invalid_argument) :
+    HyperLogLog(uint8_t b = 4) :
             b_(b), m_(1 << b), M_(m_, 0) {
 
         if (b < 4 || 30 < b) {
@@ -139,7 +139,7 @@ public:
      * 
      * @exception std::invalid_argument number of registers doesn't match.
      */
-    void merge(const HyperLogLog& other) throw (std::invalid_argument) {
+    void merge(const HyperLogLog& other) {
         if (m_ != other.m_) {
             std::stringstream ss;
             ss << "number of registers doesn't match: " << m_ << " != " << other.m_;
@@ -187,7 +187,7 @@ public:
      *
      * @exception std::runtime_error When failed to dump.
      */
-    void dump(std::ostream& os) const throw(std::runtime_error){
+    void dump(std::ostream& os) const {
         os.write((char*)&b_, sizeof(b_));
         os.write((char*)&M_[0], sizeof(M_[0]) * M_.size());
         if(os.fail()){
@@ -202,7 +202,7 @@ public:
      *
      * @exception std::runtime_error When failed to restore.
      */
-    void restore(std::istream& is) throw(std::runtime_error){
+    void restore(std::istream& is) {
         uint8_t b = 0;
         is.read((char*)&b, sizeof(b));
         HyperLogLog tempHLL(b);
@@ -234,7 +234,7 @@ public:
      *
      * @exception std::invalid_argument the argument is out of range.
      */
-    HyperLogLogHIP(uint8_t b = 4) throw (std::invalid_argument) : HyperLogLog(b), register_limit_((1 << 5) - 1), c_(0.0), p_(1 << b) {
+    HyperLogLogHIP(uint8_t b = 4) : HyperLogLog(b), register_limit_((1 << 5) - 1), c_(0.0), p_(1 << b) {
     }
 
     /**
@@ -277,7 +277,7 @@ public:
      * 
      * @exception std::invalid_argument number of registers doesn't match.
      */
-    void merge(const HyperLogLogHIP& other) throw (std::invalid_argument) {
+    void merge(const HyperLogLogHIP& other) {
         if (m_ != other.m_) {
             std::stringstream ss;
             ss << "number of registers doesn't match: " << m_ << " != " << other.m_;
@@ -334,7 +334,7 @@ public:
      *
      * @exception std::runtime_error When failed to dump.
      */
-    void dump(std::ostream& os) const throw(std::runtime_error){
+    void dump(std::ostream& os) const {
         os.write((char*)&b_, sizeof(b_));
         os.write((char*)&M_[0], sizeof(M_[0]) * M_.size());
         os.write((char*)&c_, sizeof(c_));
@@ -351,7 +351,7 @@ public:
      *
      * @exception std::runtime_error When failed to restore.
      */
-    void restore(std::istream& is) throw(std::runtime_error){
+    void restore(std::istream& is) {
         uint8_t b = 0;
         is.read((char*)&b, sizeof(b));
         HyperLogLogHIP tempHLL(b);

--- a/ext/hyperloglog/hyperloglog.hpp
+++ b/ext/hyperloglog/hyperloglog.hpp
@@ -146,9 +146,7 @@ public:
             throw std::invalid_argument(ss.str().c_str());
         }
         for (uint32_t r = 0; r < m_; ++r) {
-            if (M_[r] < other.M_[r]) {
-                M_[r] |= other.M_[r];
-            }
+            M_[r] = std::max(M_[r], other.M_[r]);
         }
     }
 

--- a/ext/hyperloglog/murmur3.h
+++ b/ext/hyperloglog/murmur3.h
@@ -1,0 +1,151 @@
+#ifndef MURMUR3_H
+#define MURMUR3_H
+
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+typedef unsigned char uint8_t;
+typedef unsigned long uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else   // defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+#define FORCE_INLINE __attribute__((always_inline))
+
+inline uint32_t rotl32 ( uint32_t x, uint8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+#define ROTL32(x,y) rotl32(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+/* NO-OP for little-endian platforms */
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+# if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#   define BYTESWAP(x) (x)
+# endif
+/* if __BYTE_ORDER__ is not predefined (like FreeBSD), use arch */
+#elif defined(__i386)  || defined(__x86_64) \
+  ||  defined(__alpha) || defined(__vax)
+
+# define BYTESWAP(x) (x)
+/* use __builtin_bswap32 if available */
+#elif defined(__GNUC__) || defined(__clang__)
+#ifdef __has_builtin
+#if __has_builtin(__builtin_bswap32)
+#define BYTESWAP(x) __builtin_bswap32(x)
+#endif // __has_builtin(__builtin_bswap32)
+#endif // __has_builtin
+#endif // defined(__GNUC__) || defined(__clang__)
+/* last resort (big-endian w/o __builtin_bswap) */
+#ifndef BYTESWAP
+# define BYTESWAP(x)   ((((x)&0xFF)<<24) \
+         |(((x)>>24)&0xFF) \
+         |(((x)&0x0000FF00)<<8)    \
+         |(((x)&0x00FF0000)>>8)    )
+#endif
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+#define getblock(p, i) BYTESWAP(p[i])
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+uint32_t fmix32( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//-----------------------------------------------------------------------------
+
+#ifdef __cplusplus
+extern "C"
+#else
+extern
+#endif
+void MurmurHash3_x86_32( const void * key, int len, uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 4;
+  int i;
+
+  uint32_t h1 = seed;
+
+  uint32_t c1 = 0xcc9e2d51;
+  uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+
+    h1 ^= k1;
+    h1 = ROTL32(h1,13);
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+  {
+    const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+    
+    uint32_t k1 = 0;
+    
+    switch(len & 3)
+    {
+    case 3: k1 ^= tail[2] << 16;
+    case 2: k1 ^= tail[1] << 8;
+    case 1: k1 ^= tail[0];
+            k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+    };
+  }
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix32(h1);
+
+  *(uint32_t*)out = h1;
+}
+
+#endif

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -127,6 +127,7 @@ void StrobemerIndex::index_vector(const ind_mers_vector &mers, float f) {
     unsigned int tot_mid_ab = 0;
     std::vector<unsigned int> strobemer_counts;
 
+    auto prev_mer = mers[0];
     uint64_t prev_hash = mers[0].hash;
     uint64_t curr_hash;
 
@@ -149,10 +150,17 @@ void StrobemerIndex::index_vector(const ind_mers_vector &mers, float f) {
                 tot_mid_ab++;
                 strobemer_counts.push_back(count);
             }
-            add_entry(prev_hash, prev_offset, count);
+
+            if (count == 1) {
+                add_entry(prev_hash, prev_mer.position, prev_mer.packed | 0x8000'0000);
+                flat_vector[flat_vector.size() - 2] = ReferenceMer{0, 0};  // should never be used
+            } else {
+                add_entry(prev_hash, prev_offset, count);
+            }
             count = 1;
             prev_hash = curr_hash;
             prev_offset = offset;
+            prev_mer = mer;
         }
         offset++;
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -207,27 +207,26 @@ size_t count_unique_randstrobe_hashes(const References& references, IndexParamet
     return hashes.size();
 }
 
-size_t estimate_unique_randstrobe_hashes(const References& references, IndexParameters parameters) {
-    auto k = parameters.k;
-    auto s = parameters.s;
-    auto t = parameters.t_syncmer;
-    auto q = parameters.q;
-    auto w_min = parameters.w_min;
-    auto w_max = parameters.w_max;
-    auto max_dist = parameters.max_dist;
-
+hll::HyperLogLog hll_randstrobe_hashes(const std::string& seq, IndexParameters parameters) {
     hll::HyperLogLog hll(10);
-    for(size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
+
+    auto randstrobe_iter = RandstrobeIterator2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+    Randstrobe randstrobe;
+
+    while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
+        hll.add(reinterpret_cast<char*>(&randstrobe.hash), sizeof(randstrobe.hash));
+    }
+    return hll;
+}
+
+size_t estimate_unique_randstrobe_hashes(const References& references, IndexParameters parameters) {
+    hll::HyperLogLog hll(10);
+    for (size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
         auto& seq = references.sequences[ref_index];
         if (seq.length() < parameters.w_max) {
             continue;
         }
-        auto randstrobe_iter = RandstrobeIterator2(seq, k, s, t, w_min, w_max, q, max_dist);
-        Randstrobe randstrobe;
-
-        while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
-            hll.add(reinterpret_cast<char*>(&randstrobe.hash), sizeof(randstrobe.hash));
-        }
+        hll.merge(hll_randstrobe_hashes(seq, parameters));
     }
     return hll.estimate();
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -16,6 +16,9 @@
 #include <atomic>
 #include <hyperloglog/hyperloglog.hpp>
 #include "timer.hpp"
+#include "logger.hpp"
+
+static Logger& logger = Logger::get();
 
 /* Create an IndexParameters instance based on a given read length.
  * k and/or s can be specified explicitly by setting them to a value other than
@@ -270,6 +273,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     Timer estimate_unique;
     auto randstrobe_hashes = estimate_unique_randstrobe_hashes_parallel(references, parameters, n_threads);
     stats.elapsed_unique_hashes = estimate_unique.duration();
+    logger.debug() << "Estimated number of unique randstrobe hashes: " << randstrobe_hashes << '\n';
 
     Timer randstrobes_timer;
     mers_index.reserve(randstrobe_hashes);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -181,11 +181,39 @@ void StrobemerIndex::read(const std::string& filename) {
     }
 }
 
+size_t count_unique_randstrobe_hashes(const References& references, IndexParameters parameters) {
+    auto k = parameters.k;
+    auto s = parameters.s;
+    auto t = parameters.t_syncmer;
+    auto q = parameters.q;
+    auto w_min = parameters.w_min;
+    auto w_max = parameters.w_max;
+    auto max_dist = parameters.max_dist;
+
+    robin_hood::unordered_flat_set<uint64_t> hashes;
+    for(size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
+        auto& seq = references.sequences[ref_index];
+        if (seq.length() < parameters.w_max) {
+            continue;
+        }
+        auto randstrobe_iter = RandstrobeIterator2(seq, k, s, t, w_min, w_max, q, max_dist);
+        Randstrobe randstrobe;
+
+        while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
+            hashes.insert(randstrobe.hash);
+        }
+    }
+    return hashes.size();
+}
+
 void StrobemerIndex::populate(float f) {
     ind_mers_vector ind_flat_vector; //includes hash - for sorting, will be discarded later
     Timer randstrobes_timer;
     unsigned int tot_occur_once;
     stats.tot_strobemer_count = 0;
+
+    auto randstrobe_hashes = count_unique_randstrobe_hashes(references, parameters);
+    mers_index.reserve(randstrobe_hashes);
 
     for(size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
         auto seq = references.sequences[ref_index];

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -184,9 +184,6 @@ void StrobemerIndex::read(const std::string& filename) {
 void StrobemerIndex::populate(float f) {
     ind_mers_vector ind_flat_vector; //includes hash - for sorting, will be discarded later
     Timer randstrobes_timer;
-    int expected_sampling = parameters.k - parameters.s + 1;
-    int approx_vec_size = references.total_length() / expected_sampling;
-    ind_flat_vector.reserve(approx_vec_size);
     unsigned int tot_occur_once;
     stats.tot_strobemer_count = 0;
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <algorithm>
 #include "pdqsort/pdqsort.h"
+#include <iostream>
 #include "timer.hpp"
 
 /* Create an IndexParameters instance based on a given read length.

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -105,6 +105,9 @@ bool IndexParameters::operator==(const IndexParameters& other) const {
 }
 
 uint64_t count_unique_hashes(const ind_mers_vector& mers){
+    if (mers.empty()) {
+        return 0;
+    }
     uint64_t prev_k = mers.at(0).hash;
     uint64_t unique_elements = 1;
     for (auto &curr_k : mers) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -257,22 +257,8 @@ void StrobemerIndex::read(const std::string& filename) {
 }
 
 void StrobemerIndex::populate(float f) {
-    auto ind_flat_vector = generate_and_sort_seeds();
-    Timer flat_vector_timer;
-    stats.elapsed_flat_vector = flat_vector_timer.duration();
-
-    Timer hash_index_timer;
-    mers_index.reserve(count_unique_hashes(ind_flat_vector));
-    index_vector(ind_flat_vector, f);
-    filter_cutoff = stats.filter_cutoff;
-    stats.elapsed_hash_index = hash_index_timer.duration();
-    stats.unique_mers = mers_index.size();
-}
-
-ind_mers_vector StrobemerIndex::generate_and_sort_seeds() const
-{
-    Timer randstrobes_timer;
     ind_mers_vector ind_flat_vector; //includes hash - for sorting, will be discarded later
+    Timer randstrobes_timer;
     int expected_sampling = parameters.k - parameters.s + 1;
     int approx_vec_size = references.total_length() / expected_sampling;
     ind_flat_vector.reserve(approx_vec_size);
@@ -285,9 +271,16 @@ ind_mers_vector StrobemerIndex::generate_and_sort_seeds() const
     pdqsort_branchless(ind_flat_vector.begin(), ind_flat_vector.end());
     stats.elapsed_sorting_seeds = sorting_timer.duration();
 
-    return ind_flat_vector;
-}
+    Timer flat_vector_timer;
+    stats.elapsed_flat_vector = flat_vector_timer.duration();
 
+    Timer hash_index_timer;
+    mers_index.reserve(count_unique_hashes(ind_flat_vector));
+    index_vector(ind_flat_vector, f);
+    filter_cutoff = stats.filter_cutoff;
+    stats.elapsed_hash_index = hash_index_timer.duration();
+    stats.unique_mers = mers_index.size();
+}
 
 void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) const {
     // Prins to csv file the statistics on the number of seeds of a particular length and what fraction of them them are unique in the index:

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -300,9 +300,6 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     pdqsort_branchless(ind_flat_vector.begin(), ind_flat_vector.end());
     stats.elapsed_sorting_seeds = sorting_timer.duration();
 
-    Timer flat_vector_timer;
-    stats.elapsed_flat_vector = flat_vector_timer.duration();
-
     Timer hash_index_timer;
     stats.flat_vector_size = ind_flat_vector.size();
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -128,36 +128,36 @@ void StrobemerIndex::index_vector(const hash_vector &h_vector, float f) {
     unsigned int tot_mid_ab = 0;
     std::vector<unsigned int> strobemer_counts;
 
-    uint64_t prev_k = h_vector[0];
-    uint64_t curr_k;
+    uint64_t prev_hash = h_vector[0];
+    uint64_t curr_hash;
 
-    for ( auto &t : h_vector) {
-        curr_k = t;
-        if (curr_k == prev_k){
-            count ++;
+    for (auto &hash : h_vector) {
+        curr_hash = hash;
+        if (curr_hash == prev_hash){
+            count++;
         }
         else {
-            if (count == 1){
-                tot_occur_once ++;
+            if (count == 1) {
+                tot_occur_once++;
             }
             else if (count > 100){
-                tot_high_ab ++;
+                tot_high_ab++;
                 strobemer_counts.push_back(count);
             }
             else{
-                tot_mid_ab ++;
+                tot_mid_ab++;
                 strobemer_counts.push_back(count);
             }
-            add_entry(prev_k, prev_offset, count);
+            add_entry(prev_hash, prev_offset, count);
             count = 1;
-            prev_k = curr_k;
+            prev_hash = curr_hash;
             prev_offset = offset;
         }
-        offset ++;
+        offset++;
     }
 
     // last k-mer
-    add_entry(curr_k, prev_offset, count);
+    add_entry(curr_hash, prev_offset, count);
 
     float frac_unique = ((float) tot_occur_once )/ mers_index.size();
     stats.tot_strobemer_count = offset;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -330,6 +330,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
 
     uint64_t prev_hash = -1;
 
+    flat_vector.reserve(ind_flat_vector.size());
     for (auto &mer : ind_flat_vector) {
         flat_vector.push_back(ReferenceMer{mer.position, mer.packed});
         if (mer.hash != prev_hash) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -153,7 +153,9 @@ void StrobemerIndex::index_vector(const ind_mers_vector &mers, float f) {
 
             if (count == 1) {
                 add_entry(prev_hash, prev_mer.position, prev_mer.packed | 0x8000'0000);
-                flat_vector[flat_vector.size() - 2] = ReferenceMer{0, 0};  // should never be used
+                flat_vector[flat_vector.size() - 2] = flat_vector[flat_vector.size() - 1];
+                flat_vector.pop_back();
+                offset--;
             } else {
                 add_entry(prev_hash, prev_offset, count);
             }
@@ -256,12 +258,10 @@ void StrobemerIndex::read(const std::string& filename) {
 void StrobemerIndex::populate(float f) {
     auto ind_flat_vector = generate_and_sort_seeds();
     Timer flat_vector_timer;
-    flat_vector.reserve(ind_flat_vector.size());
     stats.elapsed_flat_vector = flat_vector_timer.duration();
 
     Timer hash_index_timer;
     mers_index.reserve(count_unique_hashes(ind_flat_vector));
-    // construct index over flat array
     index_vector(ind_flat_vector, f);
     filter_cutoff = stats.filter_cutoff;
     stats.elapsed_hash_index = hash_index_timer.duration();

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -188,6 +188,8 @@ struct StrobemerIndex {
     }
 
 private:
+    ind_mers_vector add_randstrobes_to_hash_table();
+
     const IndexParameters& parameters;
     const References& references;
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -172,7 +172,7 @@ struct StrobemerIndex {
 
     void write(const std::string& filename) const;
     void read(const std::string& filename);
-    void populate(float f);
+    void populate(float f, size_t n_threads);
     void print_diagnostics(const std::string& logfile_name, int k) const;
 
     kmer_lookup::const_iterator find(uint64_t key) const {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -156,6 +156,7 @@ struct IndexCreationStatistics {
     std::chrono::duration<double> elapsed_flat_vector;
     std::chrono::duration<double> elapsed_hash_index;
     std::chrono::duration<double> elapsed_generating_seeds;
+    std::chrono::duration<double> elapsed_unique_hashes;
     std::chrono::duration<double> elapsed_sorting_seeds;
 };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -23,22 +23,26 @@
 class ReferenceMer {
 public:
     ReferenceMer() { }  // TODO should not be needed
-    ReferenceMer(uint32_t position, int32_t packed) : position(position), packed(packed) {
+    ReferenceMer(uint32_t position, uint32_t packed) : position(position), m_packed(packed) {
     }
     uint32_t position;
 
     int reference_index() const {
-        return packed >> bit_alloc;
+        return m_packed >> bit_alloc;
     }
 
     int strobe2_offset() const {
-        return packed & mask;
+        return m_packed & mask;
+    }
+
+    MersIndexEntry::packed_t packed() const {
+        return m_packed;
     }
 
 private:
     static const int bit_alloc = 8;
     static const int mask = (1 << bit_alloc) - 1;
-    int32_t packed;
+    MersIndexEntry::packed_t m_packed;
 };
 
 typedef std::vector<ReferenceMer> mers_vector;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <cmath>
 #include <iostream>
+#include <cassert>
 #include "robin_hood.h"
 #include "exceptions.hpp"
 #include "refs.hpp"
@@ -53,11 +54,25 @@ public:
     KmerLookupEntry(unsigned int offset, unsigned int count) : m_offset(offset), m_count(count) { }
 
     unsigned int count() const {
-        return m_count;
+        if (is_reference_mer()) {
+            return 1;
+        } else {
+            return m_count;
+        }
     }
 
     unsigned int offset() const{
+        assert(!is_reference_mer());
         return m_offset;
+    }
+
+    bool is_reference_mer() const {
+        return m_count & 0x8000'0000;
+    }
+
+    ReferenceMer as_reference_mer() const {
+        assert(is_reference_mer());
+        return ReferenceMer{m_offset, m_count & 0x7fff'ffff};
     }
 
 private:

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -168,7 +168,7 @@ private:
     const References& references;
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
 
-    void index_vector(const hash_vector& h_vector, float f);
+    void index_vector(const ind_mers_vector &mers, float f);
     ind_mers_vector generate_and_sort_seeds() const;
 };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -153,7 +153,6 @@ struct IndexCreationStatistics {
     unsigned int filter_cutoff = 0;
     uint64_t unique_mers = 0;
 
-    std::chrono::duration<double> elapsed_flat_vector;
     std::chrono::duration<double> elapsed_hash_index;
     std::chrono::duration<double> elapsed_generating_seeds;
     std::chrono::duration<double> elapsed_unique_hashes;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -75,6 +75,15 @@ public:
         return ReferenceMer{m_offset, m_count & 0x7fff'ffff};
     }
 
+    void set_count(unsigned int count) {
+        m_count = count;
+    }
+
+    void set_offset(unsigned int offset) {
+        assert(!is_reference_mer());
+        m_offset = offset;
+    }
+
 private:
     unsigned int m_offset;
     unsigned int m_count;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -184,7 +184,6 @@ private:
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
 
     void index_vector(const ind_mers_vector &mers, float f);
-    ind_mers_vector generate_and_sort_seeds() const;
 };
 
 /* Write a vector to an output stream, preceded by its length */

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -182,8 +182,6 @@ private:
     const IndexParameters& parameters;
     const References& references;
     kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
-
-    void index_vector(const ind_mers_vector &mers, float f);
 };
 
 /* Write a vector to an output stream, preceded by its length */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,7 +128,6 @@ int run_strobealign(int argc, char **argv) {
         logger.info() << "  Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;
         logger.info() << "  Time estimating number of unique hashes: " << index.stats.elapsed_unique_hashes.count() << " s" <<  std::endl;
         logger.info() << "  Time sorting non-unique seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
-        logger.info() << "  Time generating flat vector: " << index.stats.elapsed_flat_vector.count() << " s" <<  std::endl;
         logger.info() << "  Time generating hash table index: " << index.stats.elapsed_hash_index.count() << " s" <<  std::endl;
         logger.info() << "Total time indexing: " << index_timer.elapsed() << " s\n";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,7 @@ int run_strobealign(int argc, char **argv) {
     } else {
         logger.info() << "Indexing ...\n";
         Timer index_timer;
-        index.populate(opt.f);
+        index.populate(opt.f, opt.n_threads);
         
         logger.info() << "  Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;
         logger.info() << "  Time estimating number of unique hashes: " << index.stats.elapsed_unique_hashes.count() << " s" <<  std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,8 @@ int run_strobealign(int argc, char **argv) {
         index.populate(opt.f);
         
         logger.info() << "  Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;
-        logger.info() << "  Time sorting seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
+        logger.info() << "  Time estimating number of unique hashes: " << index.stats.elapsed_unique_hashes.count() << " s" <<  std::endl;
+        logger.info() << "  Time sorting non-unique seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
         logger.info() << "  Time generating flat vector: " << index.stats.elapsed_flat_vector.count() << " s" <<  std::endl;
         logger.info() << "  Time generating hash table index: " << index.stats.elapsed_hash_index.count() << " s" <<  std::endl;
         logger.info() << "Total time indexing: " << index_timer.elapsed() << " s\n";

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -135,7 +135,7 @@ Randstrobe RandstrobeIterator::get(unsigned int strobe1_start) const {
     unsigned int w_end;
     if (strobe1_start + w_max < string_hashes.size()) {
         w_end = strobe1_start + w_max;
-    } else if (strobe1_start + w_min + 1 < string_hashes.size()) {
+    } else if (strobe1_start + w_min < string_hashes.size()) {
         w_end = string_hashes.size() - 1;
     }
 

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -173,36 +173,6 @@ Randstrobe RandstrobeIterator::get(unsigned int strobe1_start) const {
     return Randstrobe { hash_randstrobe2, seq_pos_strobe1, pos_to_seq_coordinate[strobe_pos_next] };
 }
 
-/* Generate randstrobes for a reference sequence. The randstrobes are appended
- * to the given flat_vector, which allows to call this function repeatedly for
- * multiple reference sequences (use a different ref_index each time).
- */
-void randstrobes_reference(
-    ind_mers_vector& flat_vector,
-    int k,
-    int w_min,
-    int w_max,
-    const std::string &seq,
-    int ref_index,
-    int s,
-    int t,
-    uint64_t q,
-    int max_dist
-) {
-    if (seq.length() < w_max) {
-        return;
-    }
-
-    auto randstrobe_iter = RandstrobeIterator2(seq, k, s, t, w_min, w_max, q, max_dist);
-    Randstrobe randstrobe;
-    while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
-        MersIndexEntry::packed_t packed = (ref_index << 8);
-        packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
-        MersIndexEntry s {randstrobe.hash, randstrobe.strobe1_pos, packed};
-        flat_vector.push_back(s);
-    }
-}
-
 Randstrobe RandstrobeIterator2::next() {
     while (syncmers.size() <= w_max) {
         Syncmer syncmer = syncmer_iterator.next();

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -4,6 +4,7 @@
 #include <deque>
 #include <bitset>
 #include <algorithm>
+#include <cassert>
 #include <xxhash.h>
 
 // a, A -> 0
@@ -131,8 +132,6 @@ std::ostream& operator<<(std::ostream& os, const Randstrobe& randstrobe) {
 }
 
 Randstrobe RandstrobeIterator::get(unsigned int strobe1_start) const {
-    unsigned int strobe_pos_next;
-    uint64_t strobe_hashval_next;
     unsigned int w_end;
     if (strobe1_start + w_max < string_hashes.size()) {
         w_end = strobe1_start + w_max;
@@ -145,14 +144,13 @@ Randstrobe RandstrobeIterator::get(unsigned int strobe1_start) const {
 
     unsigned int w_start = strobe1_start + w_min;
     uint64_t strobe_hashval = string_hashes[strobe1_start];
-
     uint64_t min_val = UINT64_MAX;
-    strobe_pos_next = strobe1_start; // Defaults if no nearby syncmer
-    strobe_hashval_next = string_hashes[strobe1_start];
+    unsigned int strobe_pos_next = strobe1_start; // Defaults if no nearby syncmer
+    uint64_t strobe_hashval_next = string_hashes[strobe1_start];
     std::bitset<64> b;
 
     for (auto i = w_start; i <= w_end; i++) {
-
+        assert(i < string_hashes.size());
         // Method 3' skew sample more for prob exact matching
         b = (strobe_hashval ^ string_hashes[i])  & q;
         uint64_t res = b.count();

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -244,7 +244,7 @@ void randstrobes_reference(
     RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
     while (randstrobe_iter.has_next()) {
         auto randstrobe = randstrobe_iter.next();
-        int packed = (ref_index << 8);
+        MersIndexEntry::packed_t packed = (ref_index << 8);
         packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
         MersIndexEntry s {randstrobe.hash, randstrobe.strobe1_pos, packed};
         flat_vector.push_back(s);

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -37,6 +37,11 @@ static inline uint64_t syncmer_kmer_hash(uint64_t packed) {
     return XXH64(&packed, sizeof(uint64_t), 0);
 }
 
+std::ostream& operator<<(std::ostream& os, const Syncmer& syncmer) {
+    os << "Syncmer(hash=" << syncmer.hash << ", position=" << syncmer.position << ")";
+    return os;
+}
+
 Syncmer SyncmerIterator::next() {
     for ( ; i < seq.length(); ++i) {
 //    for (size_t i = 0; i < seq.length(); i++) {
@@ -118,6 +123,11 @@ std::pair<std::vector<uint64_t>, std::vector<unsigned int>> make_string_to_hashv
         pos_to_seq_coordinate.push_back(syncmer.position);
     }
     return make_pair(string_hashes, pos_to_seq_coordinate);
+}
+
+std::ostream& operator<<(std::ostream& os, const Randstrobe& randstrobe) {
+    os << "Randstrobe(hash=" << randstrobe.hash << ", strobe1_pos=" << randstrobe.strobe1_pos << ", strobe2_pos=" << randstrobe.strobe2_pos << ")";
+    return os;
 }
 
 Randstrobe RandstrobeIterator::get(unsigned int strobe1_start) const {

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -193,21 +193,9 @@ void randstrobes_reference(
         return;
     }
 
-    // make string of strobes into hashvalues all at once to avoid repetitive k-mer to hash value computations
-    std::vector<uint64_t> string_hashes;
-    std::vector<unsigned int> pos_to_seq_coordinate;
-//    robin_hood::unordered_map< unsigned int, unsigned int>  pos_to_seq_choord;
-//    make_string_to_hashvalues_random_minimizers(seq, string_hashes, pos_to_seq_choord, k, kmask, w);
-    std::tie(string_hashes, pos_to_seq_coordinate) = make_string_to_hashvalues_open_syncmers_canonical(seq, k, s, t);
-
-    unsigned int nr_hashes = string_hashes.size();
-    if (nr_hashes == 0) {
-        return;
-    }
-
-    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
-    while (randstrobe_iter.has_next()) {
-        auto randstrobe = randstrobe_iter.next();
+    auto randstrobe_iter = RandstrobeIterator2(seq, k, s, t, w_min, w_max, q, max_dist);
+    Randstrobe randstrobe;
+    while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
         MersIndexEntry::packed_t packed = (ref_index << 8);
         packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
         MersIndexEntry s {randstrobe.hash, randstrobe.strobe1_pos, packed};

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include <string>
 #include <tuple>
+#include <deque>
+#include <algorithm>
 #include <inttypes.h>
 
 // only used during index generation
@@ -33,6 +35,91 @@ struct QueryMer {
 typedef std::vector<QueryMer> mers_vector_read;
 
 void randstrobes_reference(ind_mers_vector& flat_vector, int k, int w_min, int w_max, const std::string &seq, int ref_index, int s, int t, uint64_t q, int max_dist);
-mers_vector_read randstrobes_query(             int k, int w_min, int w_max, const std::string &seq,                int s, int t, uint64_t q, int max_dist);
+mers_vector_read randstrobes_query(int k, int w_min, int w_max, const std::string &seq, int s, int t, uint64_t q, int max_dist);
+
+struct Randstrobe {
+    uint64_t hash;
+    unsigned int strobe1_pos;
+    unsigned int strobe2_pos;
+};
+
+class RandstrobeIterator {
+public:
+    RandstrobeIterator(
+        const std::vector<uint64_t> &string_hashes,
+        const std::vector<unsigned int> &pos_to_seq_coordinate,
+        int w_min,
+        int w_max,
+        uint64_t q,
+        int max_dist
+    ) : string_hashes(string_hashes)
+      , pos_to_seq_coordinate(pos_to_seq_coordinate)
+      , w_min(w_min)
+      , w_max(w_max)
+      , q(q)
+      , max_dist(max_dist)
+    {
+    }
+
+    Randstrobe next() {
+        return get(strobe1_start++);
+    }
+
+    bool has_next() {
+        return (strobe1_start + w_max < string_hashes.size())
+            || (strobe1_start + w_min + 1 < string_hashes.size());
+    }
+
+private:
+    Randstrobe get(unsigned int strobe1_start) const;
+    const std::vector<uint64_t> &string_hashes;
+    const std::vector<unsigned int> &pos_to_seq_coordinate;
+    const int w_min;
+    const int w_max;
+    const uint64_t q;
+    const unsigned int max_dist;
+    unsigned int strobe1_start = 0;
+};
+
+struct Syncmer {
+    uint64_t hash;
+    size_t position;
+    bool is_end() const {
+        return hash == 0 && position == 0;
+    }
+};
+
+class SyncmerIterator {
+public:
+    SyncmerIterator(const std::string& seq, size_t k, size_t s, size_t t)
+        : seq(seq), k(k), s(s), t(t) { }
+
+    Syncmer next();
+
+private:
+    const std::string& seq;
+    const size_t k;
+    const size_t s;
+    const size_t t;
+
+    const uint64_t kmask = (1ULL << 2*k) - 1;
+    const uint64_t smask = (1ULL << 2*s) - 1;
+    const uint64_t kshift = (k - 1) * 2;
+    const uint64_t sshift = (s - 1) * 2;
+    std::deque<uint64_t> qs;  // s-mer hashes
+    uint64_t qs_min_val = UINT64_MAX;
+    size_t qs_min_pos = -1;
+    size_t l = 0;
+    uint64_t xk[2] = {0, 0};
+    uint64_t xs[2] = {0, 0};
+    size_t i = 0;
+};
+
+std::pair<std::vector<uint64_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
+    const std::string &seq,
+    const size_t k,
+    const size_t s,
+    const size_t t
+);
 
 #endif

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -36,7 +36,6 @@ struct QueryMer {
 
 typedef std::vector<QueryMer> mers_vector_read;
 
-void randstrobes_reference(ind_mers_vector& flat_vector, int k, int w_min, int w_max, const std::string &seq, int ref_index, int s, int t, uint64_t q, int max_dist);
 mers_vector_read randstrobes_query(int k, int w_min, int w_max, const std::string &seq, int s, int t, uint64_t q, int max_dist);
 
 struct Randstrobe {

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -43,6 +43,14 @@ struct Randstrobe {
     uint64_t hash;
     unsigned int strobe1_pos;
     unsigned int strobe2_pos;
+
+    bool operator==(const Randstrobe& other) const {
+        return hash == other.hash && strobe1_pos == other.strobe1_pos && strobe2_pos == other.strobe2_pos;
+    }
+
+    bool operator!=(const Randstrobe& other) const {
+        return !(*this == other);
+    }
 };
 
 std::ostream& operator<<(std::ostream& os, const Randstrobe& randstrobe);
@@ -122,6 +130,35 @@ private:
     uint64_t xs[2] = {0, 0};
     size_t i = 0;
 };
+
+class RandstrobeIterator2 {
+public:
+    RandstrobeIterator2(
+        const std::string& seq, size_t k, size_t s, size_t t,
+        int w_min,
+        int w_max,
+        uint64_t q,
+        int max_dist
+    ) : syncmer_iterator(SyncmerIterator(seq, k, s, t))
+      , w_min(w_min)
+      , w_max(w_max)
+      , q(q)
+      , max_dist(max_dist)
+    { }
+
+    Randstrobe next();
+    Randstrobe end() const { return Randstrobe{0, 0, 0}; }
+
+private:
+    SyncmerIterator syncmer_iterator;
+    const int w_min;
+    const int w_max;
+    const uint64_t q;
+    const unsigned int max_dist;
+    unsigned int strobe1_index = 0;
+    std::deque<Syncmer> syncmers;
+};
+
 
 std::pair<std::vector<uint64_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
     const std::string &seq,

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -8,9 +8,11 @@
 
 // only used during index generation
 struct MersIndexEntry {
+
+    using packed_t = uint32_t;
     uint64_t hash;
     uint32_t position;
-    int32_t packed; // packed representation of ref_index and strobe offset
+    packed_t packed; // packed representation of ref_index and strobe offset
 
     bool operator< (const MersIndexEntry& other) const {
         return hash < other.hash;

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -70,7 +70,7 @@ public:
 
     bool has_next() {
         return (strobe1_start + w_max < string_hashes.size())
-            || (strobe1_start + w_min + 1 < string_hashes.size());
+            || (strobe1_start + w_min < string_hashes.size());
     }
 
 private:

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -7,6 +7,7 @@
 #include <deque>
 #include <algorithm>
 #include <iostream>
+#include <stdexcept>
 #include <inttypes.h>
 
 // only used during index generation
@@ -62,6 +63,9 @@ public:
       , q(q)
       , max_dist(max_dist)
     {
+        if (w_min > w_max) {
+            throw std::invalid_argument("w_min is greater than w_max");
+        }
     }
 
     Randstrobe next() {
@@ -69,8 +73,7 @@ public:
     }
 
     bool has_next() {
-        return (strobe1_start + w_max < string_hashes.size())
-            || (strobe1_start + w_min < string_hashes.size());
+        return strobe1_start + w_min < string_hashes.size();
     }
 
 private:

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -6,6 +6,7 @@
 #include <tuple>
 #include <deque>
 #include <algorithm>
+#include <iostream>
 #include <inttypes.h>
 
 // only used during index generation
@@ -42,6 +43,8 @@ struct Randstrobe {
     unsigned int strobe1_pos;
     unsigned int strobe2_pos;
 };
+
+std::ostream& operator<<(std::ostream& os, const Randstrobe& randstrobe);
 
 class RandstrobeIterator {
 public:
@@ -88,6 +91,8 @@ struct Syncmer {
         return hash == 0 && position == 0;
     }
 };
+
+std::ostream& operator<<(std::ostream& os, const Syncmer& syncmer);
 
 class SyncmerIterator {
 public:

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1722,3 +1722,45 @@ static inline std::pair<float,int> find_nams(
 //    }
     return info;
 }
+
+void dump_randstrobes(const References& references, const IndexParameters& parameters) {
+    for (size_t i = 0; i < references.size(); ++i) {
+        auto& seq = references.sequences[i];
+
+        std::vector<uint64_t> string_hashes;
+        std::vector<unsigned int> pos_to_seq_coordinate;
+        std::tie(string_hashes, pos_to_seq_coordinate) = make_string_to_hashvalues_open_syncmers_canonical(seq, parameters.k, parameters.s, parameters.t_syncmer);
+
+        unsigned int nr_hashes = string_hashes.size();
+        if (nr_hashes == 0) {
+            continue;
+        }
+
+        RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_coordinate, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
+        while (randstrobe_iter.has_next()) {
+            auto randstrobe = randstrobe_iter.next();
+            std::cout << i << '\t';
+            std::cout.flags(std::ios::right | std::ios::hex);
+            std::cout.width(17);
+            std::cout.fill('0');
+            std::cout << randstrobe.hash;
+            std::cout << std::dec << '\t' << randstrobe.strobe1_pos << '\t' << randstrobe.strobe2_pos << '\n';
+        }
+    }
+}
+
+void dump_randstrobes2(const References& references, const IndexParameters& parameters) {
+    for (size_t i = 0; i < references.size(); ++i) {
+        auto& seq = references.sequences[i];
+        auto randstrobe_iter = RandstrobeIterator2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+        Randstrobe randstrobe;
+        while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
+            std::cout << i << '\t';
+            std::cout.flags(std::ios::right | std::ios::hex);
+            std::cout.width(17);
+            std::cout.fill('0');
+            std::cout << randstrobe.hash;
+            std::cout << std::dec << '\t' << randstrobe.strobe1_pos << '\t' << randstrobe.strobe2_pos << '\n';
+        }
+    }
+}

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=87fb45ec763ca76245c100e67b0f0951d023b387
+baseline_commit=8440ac80c9a3dfcb64cb93267d40fbab01481b39

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=6e451feafc2169dcfa690516fff1dced72bd2b27
+baseline_commit=87fb45ec763ca76245c100e67b0f0951d023b387

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -60,3 +60,22 @@ TEST_CASE("read_/write_vector") {
     }
     CHECK(y == expected);
 }
+
+TEST_CASE("both randstrobes iterator implementations give same results") {
+    auto references = References::from_fasta("tests/phix.fasta");
+    auto& seq = references.sequences[0];
+    auto parameters = IndexParameters::from_read_length(300, 8);
+
+    std::vector<uint64_t> string_hashes;
+    std::vector<unsigned int> pos_to_seq_coordinate;
+    std::tie(string_hashes, pos_to_seq_coordinate) = make_string_to_hashvalues_open_syncmers_canonical(seq, parameters.k, parameters.s, parameters.t_syncmer);
+    RandstrobeIterator iter1{string_hashes, pos_to_seq_coordinate, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
+    RandstrobeIterator2 iter2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+
+    while (iter1.has_next()) {
+        auto randstrobe1 = iter1.next();
+        auto randstrobe2 = iter2.next();
+        CHECK(randstrobe2 != iter2.end());
+        CHECK(randstrobe1 == randstrobe2);
+    }
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -24,7 +24,7 @@ TEST_CASE("sti file same parameters") {
     auto references = References::from_fasta("tests/phix.fasta");
     auto parameters = IndexParameters::from_read_length(300, 8);
     StrobemerIndex index(references, parameters);
-    index.populate(0.0002);
+    index.populate(0.0002, 1);
     index.write("tmpindex.sti");
 
     auto other_parameters = IndexParameters::from_read_length(30, 8);


### PR DESCRIPTION
This is an extension of PR #179 (the first commits are the same). PR #179 reduced memory usage significantly when mapping using a pre-generated index, but increases memory usage at index generation time. The aim of this PR is to reduce memory usage even at index generation time.

It would have been possible to just add these commits to PR #179, but because this goes in a somewhat different direction and has different tradeoffs than what we discussed there, I’m opening a new PR.

The main downside of the method used here is that indexing time increases significantly (definitely more than 25%). I have thought about this a bit over the last weeks and am now at a point where we just need to discuss whether this is acceptable.

Memory usage is reduced to nearly the same level as when using the new index layout introduced in #179 a mapping using a pre-generated index.

Since UPPMAX servers are down for maintenance, I will need to add runtime and memory usage numbers later.

The main idea (on top of those in #179) is to [build the index directly while iterating over randstrobes](https://github.com/ksahlin/strobealign/commit/20db8150254e5adeb3e9bc5fc814aa1c8a662541). Previously, the `ind_flat_vector` was filled and then the `mers_index` and `flat_vector` were created from it. Here, we generate the  randstrobes on-the-fly and directly fill the `mers_index` and the flat vector. This is like using a generator in a Python. The previous `RandstrobeIterator` generates a vector of all randstrobes for an entire reference and uses lots of memory for large contigs. The new `RandstrobeIterator2` returns the randstrobes one by one and only keeps a small window of the relevant syncmers in memory. (In a `deque`.)

The biggest problem is that we can no longer easily estimate how much memory to pre-allocate for the hash table (`mers_index`). Previously, we could just count the distinct hash values in the sorted flat vector, which is fast and easy. Since we no longer have a full flat vector available, this is no longer possible.

If we let the hash table resize automatically without pre-allocation, memory usage grows a lot because at resize time, the old and new hash table are kept in memory so that one can be copied to the other.

For the moment, I solved this by adding a pre-processing step that generates all randstrobes without storing them and just counts how many unique hashes are created. This takes of course a lot of extra time. We also save some time because we no longer need to sort the full flat vector, only the part of it that contains randstrobes that occur more than once. Sorting time becomes nearly negligible while it was a big chunk of index generation time previously, but with all randstrobes being generated twice, runtime still increases by a bit. (I will add numbers later.)

To count unique hashes, I initially used a `robin_hood::unordered_flat_set` to keep track of all hashes, but of course also that needs a lot of memory, so I switched to using the [HyperLogLog algorithm by Flajolet et al (2007)](https://en.wikipedia.org/wiki/HyperLogLog), which uses only $O(1)$ memory.

## To Do

- [x] Add runtime and memory usage numbers
- [x] `StrobemerIndex::populate()` became quite large because I inlined `index_vector()`, `generate_and_sort_seeds()` and `randstrobes_reference()` into it. Clean it up (probably by factoring out some functions).
- [X] ~~HyperLogLog cannot deal with more than $2^{32}$ unique values, which will give problems for large references. Use HyperLogLog++ instead, which is also more accurate. (Need to find a C++ implementation somewhere.) ~~ Moved to issue #193.
- [x] `RandstrobeIterator2` gives slightly different results than `RandstrobeIterator`. Figure out why.