### PR TITLE
Refactoring, logging, add --create-index alias

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -108,7 +108,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (l) { opt.l = args::get(l); }
     if (u) { opt.u = args::get(u); }
     if (s) { opt.s = args::get(s); opt.s_set = true; }
-    if (c) { opt.c = args::get(c); }
+    if (c) { opt.c = args::get(c); opt.c_set = true; }
 
     // Alignment
     // if (n) { n = args::get(n); }

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -58,8 +58,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::ValueFlag<int> M(parser, "INT", "Maximum number of mapping sites to try [20]", {'M'});
     args::ValueFlag<int> R(parser, "INT", "Rescue level. Perform additional search for reads with many repetitive seeds filtered out. This search includes seeds of R*repetitive_seed_size_filter (default: R=2). Higher R than default makes strobealign significantly slower but more accurate. R <= 1 deactivates rescue and is the fastest.", {'R'});
 
-    // <ref.fa> <reads1.fast[a/q.gz]> [reads2.fast[a/q.gz]]
-    args::Positional<std::string> ref_filename(parser, "reference", "A pregenerated strobemers index file (.sti) or a reference in FASTA format", args::Options::Required);
+    args::Positional<std::string> ref_filename(parser, "reference", "Reference in FASTA format", args::Options::Required);
     args::Positional<std::string> reads1_filename(parser, "reads1", "Reads 1 in FASTA or FASTQ format, optionally gzip compressed");
     args::Positional<std::string> reads2_filename(parser, "reads2", "Reads 2 in FASTA or FASTQ format, optionally gzip compressed");
 

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -31,8 +31,8 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
 
     args::ValueFlag<int> N(parser, "INT", "Retain at most INT secondary alignments (is upper bounded by -M and depends on -S) [0]", {'N'});
     args::ValueFlag<std::string> L(parser, "PATH", "Print statistics of indexing to PATH", {'L'});
-    args::Flag i(parser, "index", "Write the generated index to a file. Do not map reads. If read files are provided, they are used to estimate read length", { 'i' });
-    args::Flag use_index(parser, "use_index", "Use a pre-generated index", { "use-index" });
+    args::Flag i(parser, "index", "Do not map reads; only generate the strobemer index and write it to disk. If read files are provided, they are used to estimate read length", {"create-index", 'i'});
+    args::Flag use_index(parser, "use_index", "Use a pre-generated index previously written with --create-index.", { "use-index" });
 
     args::Group seeding(parser, "Seeding:");
     //args::ValueFlag<int> n(parser, "INT", "Number of strobes [2]", {'n'});

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -6,7 +6,7 @@
 class Version {};
 
 
-std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int argc, char **argv) {
+CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
 
     args::ArgumentParser parser("strobelign " + version_string());
     parser.helpParams.showTerminator = false;
@@ -85,7 +85,6 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     }
 
     CommandLineOptions opt;
-    mapping_params map_param;
 
     // Threading
     if (threads) { opt.n_threads = args::get(threads); }
@@ -94,16 +93,16 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
     // Input/output
     if (o) { opt.output_file_name = args::get(o); opt.write_to_stdout = false; }
     if (v) { opt.verbose = true; }
-    if (x) { map_param.is_sam_out = false; }
+    if (x) { opt.is_sam_out = false; }
     if (rgid) { opt.read_group_id = args::get(rgid); }
     if (rg) { opt.read_group_fields = args::get(rg); }
-    if (N) { map_param.max_secondary = args::get(N); }
+    if (N) { opt.max_secondary = args::get(N); }
     if (L) { opt.logfile_name = args::get(L); }
     if (i) { opt.only_gen_index = true; opt.index_out_filename = args::get(i); }
     if (use_index) { opt.use_index = true; }
 
     // Seeding
-    if (r) { map_param.r = args::get(r); opt.r_set = true; }
+    if (r) { opt.r = args::get(r); opt.r_set = true; }
     if (m) { opt.max_seed_len = args::get(m); opt.max_seed_len_set = true; }
     if (k) { opt.k = args::get(k); opt.k_set = true; }
     if (l) { opt.l = args::get(l); }
@@ -120,9 +119,9 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
 
     // Search parameters
     if (f) { opt.f = args::get(f); }
-    if (S) { map_param.dropoff_threshold = args::get(S); }
-    if (M) { map_param.maxTries = args::get(M); }
-    if (R) { map_param.R = args::get(R); }
+    if (S) { opt.dropoff_threshold = args::get(S); }
+    if (M) { opt.maxTries = args::get(M); }
+    if (R) { opt.R = args::get(R); }
 
     // Reference and read files
     opt.ref_filename = args::get(ref_filename);
@@ -145,5 +144,5 @@ std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int a
         exit(EXIT_FAILURE);
     }
 
-    return std::make_pair(opt, map_param);
+    return opt;
 }

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -98,7 +98,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (rg) { opt.read_group_fields = args::get(rg); }
     if (N) { opt.max_secondary = args::get(N); }
     if (L) { opt.logfile_name = args::get(L); }
-    if (i) { opt.only_gen_index = true; opt.index_out_filename = args::get(i); }
+    if (i) { opt.only_gen_index = true; }
     if (use_index) { opt.use_index = true; }
 
     // Seeding

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -1,10 +1,9 @@
 #ifndef CMDLINE_HPP
 #define CMDLINE_HPP
 
+#include <vector>
 #include <string>
 #include <utility>
-
-#include "aln.hpp"
 
 struct CommandLineOptions {
     int n_threads { 3 };
@@ -19,8 +18,11 @@ struct CommandLineOptions {
     std::string logfile_name { "" };
     bool only_gen_index { false };
     bool use_index { false };
+    bool is_sam_out { true };
+    int max_secondary { 0 };
 
     // Seeding
+    int r { 150 };
     bool r_set { false };
     bool max_seed_len_set { false };
     bool k_set { false };
@@ -40,6 +42,9 @@ struct CommandLineOptions {
 
     // Search parameters
     float f { 0.0002 };
+    float dropoff_threshold { 0.5 };
+    int maxTries { 20 };
+    int R { 2 };
 
     // Reference and read files
     std::string ref_filename; // This is either a fasta file or an index file - if fasta, indexing will be run
@@ -49,6 +54,6 @@ struct CommandLineOptions {
     bool is_SE { true };
 };
 
-std::pair<CommandLineOptions, mapping_params> parse_command_line_arguments(int argc, char **argv);
+CommandLineOptions parse_command_line_arguments(int argc, char **argv);
 
 #endif

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -27,6 +27,7 @@ struct CommandLineOptions {
     bool max_seed_len_set { false };
     bool k_set { false };
     bool s_set { false };
+    bool c_set { false };
     int max_seed_len;
     int k { 20 };
     int l { 0 };

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -51,7 +51,6 @@ struct CommandLineOptions {
     std::string ref_filename; // This is either a fasta file or an index file - if fasta, indexing will be run
     std::string reads_filename1;
     std::string reads_filename2;
-    std::string index_out_filename;
     bool is_SE { true };
 };
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -21,11 +21,12 @@
 static Logger& logger = Logger::get();
 
 /* Create an IndexParameters instance based on a given read length.
- * k and/or s can be specified explicitly by setting them to a value other than
- * -1, but otherwise reasonable defaults are used for them as well.
+ * c, k, s and max_seed_len can be used to override determined parameters
+ * by setting them to a value other than -1.
  */
 IndexParameters IndexParameters::from_read_length(int read_length, int c, int k, int s, int max_seed_len) {
     int l, u;
+    const int default_c = 8;
     struct settings {
         int r_threshold;
         int k;
@@ -62,7 +63,7 @@ IndexParameters IndexParameters::from_read_length(int read_length, int c, int k,
     } else {
         max_dist = max_seed_len - k; // convert to distance in start positions
     }
-    int q = std::pow(2, c) - 1;
+    int q = std::pow(2, c == -1 ? default_c : c) - 1;
     return IndexParameters(k, s, l, u, q, max_dist);
 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -111,6 +111,11 @@ bool IndexParameters::operator==(const IndexParameters& other) const {
         && this->w_max == other.w_max;
 }
 
+// Return a parameter-specific filename extension. Example: ".r100.sti"
+std::string IndexParameters::filename_extension() const {
+    return ".sti";
+}
+
 uint64_t count_unique_hashes(const ind_mers_vector& mers){
     if (mers.empty()) {
         return 0;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -120,7 +120,7 @@ public:
 
     static IndexParameters from_read_length(int read_length, int c = -1, int k = -1, int s = -1, int max_seed_len = -1);
     static IndexParameters read(std::istream& os);
-
+    std::string filename_extension() const;
     void write(std::ostream& os) const;
     bool operator==(const IndexParameters& other) const;
     bool operator!=(const IndexParameters& other) const { return !(*this == other); }

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -118,7 +118,7 @@ public:
         , w_max(k / (k - s + 1) + u) {
     }
 
-    static IndexParameters from_read_length(int read_length, int c, int k = -1, int s = -1, int max_seed_len = -1);
+    static IndexParameters from_read_length(int read_length, int c = -1, int k = -1, int s = -1, int max_seed_len = -1);
     static IndexParameters read(std::istream& os);
 
     void write(std::ostream& os) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,7 @@ int run_strobealign(int argc, char **argv) {
         throw BadParameter("c must be greater than 0 and less than 64");
     }
     IndexParameters index_parameters = IndexParameters::from_read_length(
-        opt.r, opt.c, opt.k_set ? opt.k : -1, opt.s_set ? opt.s : -1, opt.max_seed_len_set ? opt.max_seed_len : -1);
+        opt.r, opt.c_set ? opt.c : -1, opt.k_set ? opt.k : -1, opt.s_set ? opt.s : -1, opt.max_seed_len_set ? opt.max_seed_len : -1);
 
     alignment_params aln_params;
     aln_params.match = opt.A;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,8 +118,12 @@ int run_strobealign(int argc, char **argv) {
     References references;
     Timer read_refs_timer;
     references = References::from_fasta(opt.ref_filename);
-    logger.info() << "Time reading references: " << read_refs_timer.elapsed() << " s\n";
+    logger.info() << "Time reading reference: " << read_refs_timer.elapsed() << " s\n";
 
+    logger.info() << "Reference size: " << references.total_length() / 1E6 << " Mbp ("
+        << references.size() << " contig" << (references.size() == 1 ? "" : "s")
+        << "; largest: "
+        << (*std::max_element(references.lengths.begin(), references.lengths.end()) / 1E6) << " Mbp)\n";
     if (references.total_length() == 0) {
         throw InvalidFasta("No reference sequences found");
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,7 +133,9 @@ int run_strobealign(int argc, char **argv) {
         // Read the index from a file
         assert(!opt.only_gen_index);
         Timer read_index_timer;
-        index.read(opt.ref_filename + ".sti");
+        std::string sti_path = opt.ref_filename + index_parameters.filename_extension();
+        logger.info() << "Reading index from " << sti_path << '\n';
+        index.read(sti_path);
         logger.info() << "Total time reading index: " << read_index_timer.elapsed() << " s\n";
     } else {
         logger.info() << "Indexing ...\n";
@@ -169,7 +171,9 @@ int run_strobealign(int argc, char **argv) {
         }
         if (opt.only_gen_index) {
             Timer index_writing_timer;
-            index.write(opt.ref_filename + ".sti");
+            std::string sti_path = opt.ref_filename + index_parameters.filename_extension();
+            logger.info() << "Writing index to " << sti_path << '\n';
+            index.write(opt.ref_filename + index_parameters.filename_extension());
             logger.info() << "Total time writing index: " << index_writing_timer.elapsed() << " s\n";
             return EXIT_SUCCESS;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,23 @@ void warn_if_no_optimizations() {
     }
 }
 
+void log_parameters(const IndexParameters& index_parameters, const mapping_params& map_param, const alignment_params& aln_params) {
+    logger.debug() << "Using" << std::endl
+        << "k: " << index_parameters.k << std::endl
+        << "s: " << index_parameters.s << std::endl
+        << "w_min: " << index_parameters.w_min << std::endl
+        << "w_max: " << index_parameters.w_max << std::endl
+        << "Read length (r): " << map_param.r << std::endl
+        << "Maximum seed length: " << index_parameters.max_dist + index_parameters.k << std::endl
+        << "R: " << map_param.R << std::endl
+        << "Expected [w_min, w_max] in #syncmers: [" << index_parameters.w_min << ", " << index_parameters.w_max << "]" << std::endl
+        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_min << ", " << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_max << "]" << std::endl
+        << "A: " << aln_params.match << std::endl
+        << "B: " << aln_params.mismatch << std::endl
+        << "O: " << aln_params.gap_open << std::endl
+        << "E: " << aln_params.gap_extend << std::endl;
+}
+
 int run_strobealign(int argc, char **argv) {
     CommandLineOptions opt;
     opt = parse_command_line_arguments(argc, argv);
@@ -89,21 +106,8 @@ int run_strobealign(int argc, char **argv) {
     map_param.maxTries = opt.maxTries;
     map_param.is_sam_out = opt.is_sam_out;
 
-    logger.debug() << "Using" << std::endl
-        << "k: " << index_parameters.k << std::endl
-        << "s: " << index_parameters.s << std::endl
-        << "w_min: " << index_parameters.w_min << std::endl
-        << "w_max: " << index_parameters.w_max << std::endl
-        << "Read length (r): " << map_param.r << std::endl
-        << "Maximum seed length: " << index_parameters.max_dist + index_parameters.k << std::endl
-        << "Threads: " << opt.n_threads << std::endl
-        << "R: " << map_param.R << std::endl
-        << "Expected [w_min, w_max] in #syncmers: [" << index_parameters.w_min << ", " << index_parameters.w_max << "]" << std::endl
-        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_min << ", " << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_max << "]" << std::endl
-        << "A: " << aln_params.match << std::endl
-        << "B: " << aln_params.mismatch << std::endl
-        << "O: " << aln_params.gap_open << std::endl
-        << "E: " << aln_params.gap_extend << std::endl;
+    log_parameters(index_parameters, map_param, aln_params);
+    logger.debug() << "Threads: " << opt.n_threads << std::endl;
 
     map_param.verify();
     index_parameters.verify();


### PR DESCRIPTION
* Let `parse_command_line_arguments()` only return `CommandLineOptions`, not `mapping_params`. This better separates command-line parsing from the rest of the program. In particular, it allows to remove the `#include <aln.hpp>`, which will reduce necessary recompilations. (Command-line parsing should not need to recompile just because an alignment function changed signature.)
* Log total reference size, number of contigs and size of the maximum contig. This helps a little bit to double-check that one is working with the correct reference and may be valuable information when users post a bug report.
* Add `--create-index` as an alias for `-i` for symmetry with `--use-index`. Until/if we get a subcommand for indexing, I would suggest to promote this longer form in the documentation. It’s helpful to have self-explanatory command lines.
* Factor out a function that returns the filename suffix to use when writing/reading an index to/from disk. This is in preparation for read-length-dependent suffixes.