### PR TITLE
Include read length in the index filename

### DIFF
--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -84,13 +84,15 @@ int run_dumpstrobes(int argc, char **argv) {
     }
 
     // Seeding
-    int r{150}, k{20}, s{16}, c{8};
+    int r{150}, k{20}, s{16}, c{8}, l{1}, u{7};
     int max_seed_len{};
 
-    bool k_set{false}, s_set{false}, c_set{false}, max_seed_len_set{false};
+    bool k_set{false}, s_set{false}, c_set{false}, max_seed_len_set{false}, l_set{false}, u_set{false};
     if (seeding.r) { r = args::get(seeding.r); }
     if (seeding.m) { max_seed_len = args::get(seeding.m); max_seed_len_set = true; }
     if (seeding.k) { k = args::get(seeding.k); k_set = true; }
+    if (seeding.l) { l = args::get(seeding.l); l_set = true; }
+    if (seeding.u) { u = args::get(seeding.u); u_set = true; }
     if (seeding.s) { s = args::get(seeding.s); s_set = true; }
     if (seeding.c) { c = args::get(seeding.c); c_set = true; }
 
@@ -100,7 +102,14 @@ int run_dumpstrobes(int argc, char **argv) {
         throw BadParameter("c must be greater than 0 and less than 64");
     }
     IndexParameters index_parameters = IndexParameters::from_read_length(
-        r, c_set ? c : -1, k_set ? k : -1, s_set ? s : -1, max_seed_len_set ? max_seed_len : -1);
+        r,
+        c_set ? c : IndexParameters::DEFAULT,
+        k_set ? k : IndexParameters::DEFAULT,
+        s_set ? s : IndexParameters::DEFAULT,
+        l_set ? l : IndexParameters::DEFAULT,
+        u_set ? u : IndexParameters::DEFAULT,
+        max_seed_len_set ? max_seed_len : IndexParameters::DEFAULT
+    );
 
     logger.info() << index_parameters << '\n';
     logger.info() << "Reading reference ...\n";

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -64,7 +64,11 @@ void StrobemerIndex::write(const std::string& filename) const {
 }
 
 void StrobemerIndex::read(const std::string& filename) {
+    errno = 0;
     std::ifstream ifs(filename, std::ios::binary);
+    if (!ifs.is_open()) {
+        throw InvalidIndexFile(filename + ": " + strerror(errno));
+    }
 
     union {
         char s[4];

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -94,7 +94,6 @@ typedef robin_hood::unordered_map<uint64_t, KmerLookupEntry> kmer_lookup;
 
 typedef std::vector<uint64_t> hash_vector; //only used during index generation
 
-
 struct IndexCreationStatistics {
     unsigned int flat_vector_size = 0;
     unsigned int tot_strobemer_count = 0;

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -6,7 +6,8 @@
 #include "io.hpp"
 
 
-/* Pre-defined index parameters */
+/* Pre-defined index parameters that work well for a certain
+ * "canonical" read length (and similar read lengths)  */
 struct Profile {
     int canonical_read_length;
     int r_threshold;
@@ -19,12 +20,13 @@ struct Profile {
 static auto max{std::numeric_limits<int>::max()};
 
 static std::vector<Profile> profiles = {
-        Profile{50, 75, 20, -4, -4, 2},
-        Profile{100, 125, 20, -4, -2, 2},
-        Profile{150, 175, 20, -4, 1, 7},
-        Profile{225, 275, 20, -4, 4, 13},
-        Profile{325, 375, 22, -4, 2, 12},
-        Profile{400, max, 23, -6, 2, 12},
+        Profile{ 50,  90, 20, -4, -4,  2},
+        Profile{100, 110, 20, -4, -2,  2},
+        Profile{125, 135, 20, -4, -1,  4},
+        Profile{150, 175, 20, -4,  1,  7},
+        Profile{250, 275, 20, -4,  4, 13},
+        Profile{300, 375, 22, -4,  2, 12},
+        Profile{400, max, 23, -6,  2, 12},
     };
 
 /* Create an IndexParameters instance based on a given read length.

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -33,7 +33,7 @@ static std::vector<Profile> profiles = {
  */
 IndexParameters IndexParameters::from_read_length(int read_length, int c, int k, int s, int l, int u, int max_seed_len) {
     const int default_c = 8;
-    size_t canonical_read_length;
+    size_t canonical_read_length = 50;
     for (const auto& p : profiles) {
         if (read_length <= p.r_threshold) {
             if (k == DEFAULT) {
@@ -55,7 +55,7 @@ IndexParameters IndexParameters::from_read_length(int read_length, int c, int k,
 
     int max_dist;
     if (max_seed_len == DEFAULT) {
-        max_dist = std::max(read_length - 70, k);
+        max_dist = std::max(static_cast<int>(canonical_read_length) - 70, k);
         max_dist = std::min(255, max_dist);
     } else {
         max_dist = max_seed_len - k; // convert to distance in start positions

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -1,12 +1,14 @@
 #include "indexparameters.hpp"
 #include <vector>
 #include <cmath>
+#include <sstream>
 #include <iostream>
 #include "io.hpp"
 
 
 /* Pre-defined index parameters */
 struct Profile {
+    int canonical_read_length;
     int r_threshold;
     int k;
     int s_offset;
@@ -17,12 +19,12 @@ struct Profile {
 static auto max{std::numeric_limits<int>::max()};
 
 static std::vector<Profile> profiles = {
-        Profile{75, 20, -4, -4, 2},
-        Profile{125, 20, -4, -2, 2},
-        Profile{175, 20, -4, 1, 7},
-        Profile{275, 20, -4, 4, 13},
-        Profile{375, 22, -4, 2, 12},
-        Profile{max, 23, -6, 2, 12},
+        Profile{50, 75, 20, -4, -4, 2},
+        Profile{100, 125, 20, -4, -2, 2},
+        Profile{150, 175, 20, -4, 1, 7},
+        Profile{225, 275, 20, -4, 4, 13},
+        Profile{325, 375, 22, -4, 2, 12},
+        Profile{400, max, 23, -6, 2, 12},
     };
 
 /* Create an IndexParameters instance based on a given read length.
@@ -31,6 +33,7 @@ static std::vector<Profile> profiles = {
  */
 IndexParameters IndexParameters::from_read_length(int read_length, int c, int k, int s, int l, int u, int max_seed_len) {
     const int default_c = 8;
+    size_t canonical_read_length;
     for (const auto& p : profiles) {
         if (read_length <= p.r_threshold) {
             if (k == DEFAULT) {
@@ -45,6 +48,7 @@ IndexParameters IndexParameters::from_read_length(int read_length, int c, int k,
             if (u == DEFAULT) {
                 u = p.u;
             }
+            canonical_read_length = p.canonical_read_length;
             break;
         }
     }
@@ -57,10 +61,11 @@ IndexParameters IndexParameters::from_read_length(int read_length, int c, int k,
         max_dist = max_seed_len - k; // convert to distance in start positions
     }
     int q = std::pow(2, c == DEFAULT ? default_c : c) - 1;
-    return IndexParameters(k, s, l, u, q, max_dist);
+    return IndexParameters(canonical_read_length, k, s, l, u, q, max_dist);
 }
 
 void IndexParameters::write(std::ostream& os) const {
+    write_int_to_ostream(os, canonical_read_length);
     write_int_to_ostream(os, k);
     write_int_to_ostream(os, s);
     write_int_to_ostream(os, l);
@@ -70,18 +75,20 @@ void IndexParameters::write(std::ostream& os) const {
 }
 
 IndexParameters IndexParameters::read(std::istream& is) {
+    size_t canonical_read_length = read_int_from_istream(is);
     int k = read_int_from_istream(is);
     int s = read_int_from_istream(is);
     int l = read_int_from_istream(is);
     int u = read_int_from_istream(is);
     int q = read_int_from_istream(is);
     int max_dist = read_int_from_istream(is);
-    return IndexParameters(k, s, l, u, q, max_dist);
+    return IndexParameters(canonical_read_length, k, s, l, u, q, max_dist);
 }
 
 bool IndexParameters::operator==(const IndexParameters& other) const {
     return
-        this->k == other.k
+        this->canonical_read_length == other.canonical_read_length
+        && this->k == other.k
         && this->s == other.s
         && this->l == other.l
         && this->u == other.u
@@ -92,14 +99,25 @@ bool IndexParameters::operator==(const IndexParameters& other) const {
         && this->w_max == other.w_max;
 }
 
-// Return a parameter-specific filename extension. Example: ".r100.sti"
+/*
+ * Return a parameter-specific filename extension such as ".r100.sti"
+ * If any of the parameters deviate from the defaults for the current
+ * canonical read length, the returned extension is just ".sti".
+ */
 std::string IndexParameters::filename_extension() const {
-    return ".sti";
+    std::stringstream sstream;
+    if (*this == from_read_length(canonical_read_length)) {
+        // nothing was overridden
+        sstream << ".r" << canonical_read_length;
+    }
+    sstream << ".sti";
+    return sstream.str();
 }
 
 std::ostream& operator<<(std::ostream& os, const IndexParameters& parameters) {
     os << "IndexParameters("
-        << "k=" << parameters.k
+        << "r=" << parameters.canonical_read_length
+        << ", k=" << parameters.k
         << ", s=" << parameters.s
         << ", l=" << parameters.l
         << ", u=" << parameters.u

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -10,6 +10,7 @@
 /* Settings that influence index creation */
 class IndexParameters {
 public:
+    const size_t canonical_read_length;
     const int k;
     const int s;
     const int l;
@@ -21,8 +22,9 @@ public:
     const unsigned w_max;
 
     static const int DEFAULT = std::numeric_limits<int>::min();
-    IndexParameters(int k, int s, int l, int u, int q, int max_dist)
-        : k(k)
+    IndexParameters(size_t canonical_read_length, int k, int s, int l, int u, int q, int max_dist)
+        : canonical_read_length(canonical_read_length)
+        , k(k)
         , s(s)
         , l(l)
         , u(u)

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=8440ac80c9a3dfcb64cb93267d40fbab01481b39
+baseline_commit=e1400593eed623ea3e637a7a0096bbe119c1c25b

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -37,6 +37,14 @@ TEST_CASE("parameters in sti file do not match") {
     REQUIRE_THROWS_AS(other_index.read(sti_path), InvalidIndexFile);
 }
 
+TEST_CASE("Missing sti file") {
+    TemporaryDirectory tmp_dir;
+    auto references = References::from_fasta("tests/phix.fasta");
+    auto parameters = IndexParameters::from_read_length(300);
+    StrobemerIndex index(references, parameters);
+    REQUIRE_THROWS_AS(index.read(tmp_dir.path() / "index.sti"), InvalidIndexFile);
+}
+
 TEST_CASE("Reads file missing") {
     std::string filename("does-not-exist.fastq");
     REQUIRE_THROWS_AS(open_fastq(filename), InvalidFile);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -20,18 +20,21 @@ TEST_CASE("IndexParameters==") {
     CHECK(a == b);
 }
 
-TEST_CASE("sti file same parameters") {
-    auto references = References::from_fasta("tests/phix.fasta");
+TEST_CASE("parameters in sti file do not match") {
+    TemporaryDirectory tmp_dir;
+    std::string ref_path = tmp_dir.path() / "ref.fasta";
+    std::filesystem::copy("tests/phix.fasta", ref_path);
+    auto references = References::from_fasta(ref_path);
     auto parameters = IndexParameters::from_read_length(300, 8);
     StrobemerIndex index(references, parameters);
     index.populate(0.0002, 1);
-    index.write("tmpindex.sti");
+    std::string sti_path = tmp_dir.path() / "index.sti";
+    index.write(sti_path);
 
     auto other_parameters = IndexParameters::from_read_length(30, 8);
     StrobemerIndex other_index(references, other_parameters);
 
-    REQUIRE_THROWS_AS(other_index.read("tmpindex.sti"), InvalidIndexFile);
-    std::remove("tmpindex.sti");
+    REQUIRE_THROWS_AS(other_index.read(sti_path), InvalidIndexFile);
 }
 
 TEST_CASE("Reads file missing") {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -15,8 +15,8 @@ TEST_CASE("estimate_read_length") {
 }
 
 TEST_CASE("IndexParameters==") {
-    IndexParameters a = IndexParameters::from_read_length(150, 8);
-    IndexParameters b = IndexParameters::from_read_length(150, 8);
+    IndexParameters a = IndexParameters::from_read_length(150);
+    IndexParameters b = IndexParameters::from_read_length(150);
     CHECK(a == b);
 }
 
@@ -25,13 +25,13 @@ TEST_CASE("parameters in sti file do not match") {
     std::string ref_path = tmp_dir.path() / "ref.fasta";
     std::filesystem::copy("tests/phix.fasta", ref_path);
     auto references = References::from_fasta(ref_path);
-    auto parameters = IndexParameters::from_read_length(300, 8);
+    auto parameters = IndexParameters::from_read_length(300);
     StrobemerIndex index(references, parameters);
     index.populate(0.0002, 1);
     std::string sti_path = tmp_dir.path() / "index.sti";
     index.write(sti_path);
 
-    auto other_parameters = IndexParameters::from_read_length(30, 8);
+    auto other_parameters = IndexParameters::from_read_length(50);
     StrobemerIndex other_index(references, other_parameters);
 
     REQUIRE_THROWS_AS(other_index.read(sti_path), InvalidIndexFile);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -20,7 +20,15 @@ TEST_CASE("IndexParameters==") {
     CHECK(a == b);
 }
 
-TEST_CASE("parameters in sti file do not match") {
+TEST_CASE("IndexParameters identical for slight read-length differences") {
+    IndexParameters a = IndexParameters::from_read_length(150);
+    IndexParameters b = IndexParameters::from_read_length(151);
+    IndexParameters c = IndexParameters::from_read_length(149);
+    CHECK(a == b);
+    CHECK(a == c);
+}
+
+TEST_CASE("Parameters in sti file do not match") {
     TemporaryDirectory tmp_dir;
     std::string ref_path = tmp_dir.path() / "ref.fasta";
     std::filesystem::copy("tests/phix.fasta", ref_path);


### PR DESCRIPTION
Closes #133.

We currently have the concept of an (actual) read length, which is either estimated from the input FASTQs or provided using the `-r` command-line option. This PR introduces the concept of a "canonical read length". The canonical read length is one of 50, 100, 150, 225, 325 and 400 (we choose the one that is closest to the actual read length) and represents one of the six pre-defined index parameter settings.

With this PR, all parameters are entirely based on the canonical read length only, which means that it can be re-used for datasets that have similar read lengths. This was almost the case before except that the `max_dist` parameter was computed from the actual read length. Commit 8ba1f937bbd14cfaad4c264346ffce3669cf3b49 changes this so that `max_dist` is computed from the canonical read length. (This changes mapping results when actual and canonical read length differ.)

To make it possible to store multiple indices with different canonical read lengths alongside each other, the canonical read length is also included in the index filename, as in `ref.fasta.r100.sti`. I chose to include the `r` here mainly because I think it may be clearer that way what the number represents. Another minor reason is that we could extend the naming scheme at a later point to include other parameters. For example, `.r100k24.sti` could mean that one needs to use `-r 100 -k 24` to reproduce the settings the index was created with.

At the moment, if the user overrides any indexing parameters, the file name extension is going to be just `.sti` as before. The user then again has the problem that they cannot store multiple of these indices in the same directory, but I think solving this has much lower priority. (One workaround is to symlink the reference into separate directories for each parameter setting and then create the index there.) If the index doesn’t match the command-line settings, then there’s an error message in any case, so accidentally using the incorrect index should not be possible.

---

* [x] Update documentation
* [x] Update changelog
* [x] Ensure we get sensible error messages if index settings don’t match or an index couldn’t be found
* [x] Measure how accuracy changes due to `max_dist` now being based on canonical, not actual read length
* [x] Update baseline commit