### PR TITLE
Get rid of some warnings

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -457,7 +457,7 @@ inline int HammingDistance(const std::string &One, const std::string &Two)
 
     int counter = 0;
 
-    for(int i=0; i<One.length(); i++) {
+    for (size_t i=0; i < One.length(); i++) {
         if (One[i] != Two[i]) counter++;
     }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -237,7 +237,6 @@ size_t estimate_unique_randstrobe_hashes_parallel(const References& references, 
 }
 
 void StrobemerIndex::populate(float f, size_t n_threads) {
-    unsigned int tot_occur_once;
     stats.tot_strobemer_count = 0;
 
     Timer estimate_unique;
@@ -286,9 +285,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
         prev_hash = mer.hash;
         offset++;
     }
-    float frac_unique = ((float) tot_occur_once )/ mers_index.size();
-    stats.tot_occur_once = tot_occur_once;
-    stats.frac_unique = frac_unique;
+    stats.frac_unique = 1.0 * stats.tot_occur_once / mers_index.size();
     stats.tot_high_ab = tot_high_ab;
     stats.tot_mid_ab = tot_mid_ab;
     stats.tot_distinct_strobemer_count = mers_index.size();

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -103,8 +103,8 @@ public:
     const uint64_t q;
     const int max_dist;
     const int t_syncmer;
-    const int w_min;
-    const int w_max;
+    const unsigned w_min;
+    const unsigned w_max;
 
     IndexParameters(int k, int s, int l, int u, int q, int max_dist)
         : k(k)
@@ -115,7 +115,8 @@ public:
         , max_dist(max_dist)
         , t_syncmer((k - s) / 2 + 1)
         , w_min(std::max(1, k / (k - s + 1) + l))
-        , w_max(k / (k - s + 1) + u) {
+        , w_max(k / (k - s + 1) + u)
+    {
     }
 
     static IndexParameters from_read_length(int read_length, int c = -1, int k = -1, int s = -1, int max_seed_len = -1);

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -216,8 +216,8 @@ Randstrobe RandstrobeIterator2::next() {
  */
 mers_vector_read randstrobes_query(
     int k,
-    int w_min,
-    int w_max,
+    unsigned w_min,
+    unsigned w_max,
     const std::string& seq,
     int s,
     int t,

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -132,12 +132,7 @@ std::ostream& operator<<(std::ostream& os, const Randstrobe& randstrobe) {
 }
 
 Randstrobe RandstrobeIterator::get(unsigned int strobe1_start) const {
-    unsigned int w_end;
-    if (strobe1_start + w_max < string_hashes.size()) {
-        w_end = strobe1_start + w_max;
-    } else if (strobe1_start + w_min < string_hashes.size()) {
-        w_end = string_hashes.size() - 1;
-    }
+    unsigned int w_end = std::min(static_cast<size_t>(strobe1_start + w_max), string_hashes.size() - 1);
 
     unsigned int seq_pos_strobe1 = pos_to_seq_coordinate[strobe1_start];
     unsigned int seq_end_constraint = seq_pos_strobe1 + max_dist;
@@ -162,12 +157,9 @@ Randstrobe RandstrobeIterator::get(unsigned int strobe1_start) const {
         if (res < min_val){
             min_val = res;
             strobe_pos_next = i;
-//            std::cerr << strobe_pos_next << " " << min_val << std::endl;
             strobe_hashval_next = string_hashes[i];
         }
     }
-//    std::cerr << "Offset: " <<  strobe_pos_next - w_start << " val: " << min_val <<  ", P exact:" <<  1.0 - pow ( (float) (8-min_val)/9, strobe_pos_next - w_start) << std::endl;
-
     uint64_t hash_randstrobe2 = string_hashes[strobe1_start] + strobe_hashval_next;
 
     return Randstrobe { hash_randstrobe2, seq_pos_strobe1, pos_to_seq_coordinate[strobe_pos_next] };

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -36,7 +36,7 @@ struct QueryMer {
 
 typedef std::vector<QueryMer> mers_vector_read;
 
-mers_vector_read randstrobes_query(int k, int w_min, int w_max, const std::string &seq, int s, int t, uint64_t q, int max_dist);
+mers_vector_read randstrobes_query(int k, unsigned w_min, unsigned w_max, const std::string &seq, int s, int t, uint64_t q, int max_dist);
 
 struct Randstrobe {
     uint64_t hash;
@@ -59,8 +59,8 @@ public:
     RandstrobeIterator(
         const std::vector<uint64_t> &string_hashes,
         const std::vector<unsigned int> &pos_to_seq_coordinate,
-        int w_min,
-        int w_max,
+        unsigned w_min,
+        unsigned w_max,
         uint64_t q,
         int max_dist
     ) : string_hashes(string_hashes)
@@ -87,8 +87,8 @@ private:
     Randstrobe get(unsigned int strobe1_start) const;
     const std::vector<uint64_t> &string_hashes;
     const std::vector<unsigned int> &pos_to_seq_coordinate;
-    const int w_min;
-    const int w_max;
+    const unsigned w_min;
+    const unsigned w_max;
     const uint64_t q;
     const unsigned int max_dist;
     unsigned int strobe1_start = 0;
@@ -134,8 +134,8 @@ class RandstrobeIterator2 {
 public:
     RandstrobeIterator2(
         const std::string& seq, size_t k, size_t s, size_t t,
-        int w_min,
-        int w_max,
+        unsigned w_min,
+        unsigned w_max,
         uint64_t q,
         int max_dist
     ) : syncmer_iterator(SyncmerIterator(seq, k, s, t))
@@ -150,8 +150,8 @@ public:
 
 private:
     SyncmerIterator syncmer_iterator;
-    const int w_min;
-    const int w_max;
+    const unsigned w_min;
+    const unsigned w_max;
     const uint64_t q;
     const unsigned int max_dist;
     unsigned int strobe1_index = 0;


### PR DESCRIPTION
While doing this, I found that the "Total strobemers occur once" and "Fraction unique" statistics (only shown in in the debug log) weren’t computed correctly (broken by one of the recent PRs).
