### PR TITLE
Simplify syncmer computation

### DIFF
--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -181,15 +181,12 @@ Randstrobe RandstrobeIterator2::next() {
     uint64_t min_val = UINT64_MAX;
     Syncmer strobe2 = syncmers[0]; // Defaults if no nearby syncmer
 
-    for (auto i = w_min; i < syncmers.size(); i++) {
+    for (auto i = w_min; i < syncmers.size() && syncmers[i].position <= max_position; i++) {
         assert(i <= w_max);
         // Method 3' skew sample more for prob exact matching
         std::bitset<64> b;
         b = (strobe1.hash ^ syncmers[i].hash) & q;
         uint64_t res = b.count();
-        if (syncmers[i].position > max_position) {
-            break;
-        }
         if (res < min_val) {
             min_val = res;
             strobe2 = syncmers[i];


### PR DESCRIPTION
We don’t have to do the computations for the current syncmer if the syncmer position exceeds max_position.

No difference in runtime because the compiler does this optimization for us.