### PR TITLE
Fix handling of -l and -u command-line parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,14 @@ add_library(salib STATIC ${SOURCES}
   src/fastq.cpp
   src/cmdline.cpp
   src/index.cpp
+  src/indexparameters.cpp
   src/sam.cpp
   src/pc.cpp
   src/aln.cpp
   src/randstrobes.cpp
   src/readlen.cpp
   src/version.cpp
+  src/io.cpp
   ext/xxhash.c
   ext/ssw_cpp.cpp
   ext/ssw.c

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -91,9 +91,6 @@ struct mapping_params {
     int maxTries { 20 };
     int rescue_cutoff;
     bool is_sam_out { true };
-
-    void verify() const {
-    }
 };
 
 class i_dist_est {

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -95,8 +95,8 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (seeding.r) { opt.r = args::get(seeding.r); opt.r_set = true; }
     if (seeding.m) { opt.max_seed_len = args::get(seeding.m); opt.max_seed_len_set = true; }
     if (seeding.k) { opt.k = args::get(seeding.k); opt.k_set = true; }
-    if (seeding.l) { opt.l = args::get(seeding.l); }
-    if (seeding.u) { opt.u = args::get(seeding.u); }
+    if (seeding.l) { opt.l = args::get(seeding.l); opt.l_set = true; }
+    if (seeding.u) { opt.u = args::get(seeding.u); opt.u_set = true; }
     if (seeding.s) { opt.s = args::get(seeding.s); opt.s_set = true; }
     if (seeding.c) { opt.c = args::get(seeding.c); opt.c_set = true; }
 

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -27,6 +27,8 @@ struct CommandLineOptions {
     bool max_seed_len_set { false };
     bool k_set { false };
     bool s_set { false };
+    bool l_set { false };
+    bool u_set { false };
     bool c_set { false };
     int max_seed_len;
     int k { 20 };

--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -101,7 +101,6 @@ int run_dumprandstrobes(int argc, char **argv) {
     }
     IndexParameters index_parameters = IndexParameters::from_read_length(
         r, c_set ? c : -1, k_set ? k : -1, s_set ? s : -1, max_seed_len_set ? max_seed_len : -1);
-    index_parameters.verify();
 
     logger.info() << index_parameters << '\n';
     logger.info() << "Reading reference ...\n";

--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -57,12 +57,12 @@ void dump_syncmers(std::ostream& os, const std::string& name, const std::string&
     }
 }
 
-int run_dumprandstrobes(int argc, char **argv) {
-    args::ArgumentParser parser("dumprandstrobes");
+int run_dumpstrobes(int argc, char **argv) {
+    args::ArgumentParser parser("dumpstrobes");
     parser.helpParams.showTerminator = false;
     parser.helpParams.helpindent = 20;
     parser.helpParams.width = 90;
-    parser.helpParams.programName = "dumprandstrobes";
+    parser.helpParams.programName = "dumpstrobes";
     parser.helpParams.shortSeparator = " ";
 
     args::HelpFlag help(parser, "help", "Print help and exit", {'h', "help"});
@@ -130,7 +130,7 @@ int run_dumprandstrobes(int argc, char **argv) {
 
 int main(int argc, char **argv) {
     try {
-        return run_dumprandstrobes(argc, argv);
+        return run_dumpstrobes(argc, argv);
     } catch (BadParameter& e) {
         logger.error() << "A seeding parameter is invalid: " << e.what() << std::endl;
     } catch (const std::runtime_error& e) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -15,6 +15,7 @@
 #include <thread>
 #include <atomic>
 #include <hyperloglog/hyperloglog.hpp>
+#include "io.hpp"
 #include "timer.hpp"
 #include "logger.hpp"
 
@@ -22,116 +23,6 @@ static Logger& logger = Logger::get();
 
 static const uint32_t STI_FILE_FORMAT_VERSION = 1;
 
-/* Create an IndexParameters instance based on a given read length.
- * c, k, s and max_seed_len can be used to override determined parameters
- * by setting them to a value other than -1.
- */
-IndexParameters IndexParameters::from_read_length(int read_length, int c, int k, int s, int max_seed_len) {
-    int l, u;
-    const int default_c = 8;
-    struct settings {
-        int r_threshold;
-        int k;
-        int s_offset;
-        int l;
-        int u;
-    };
-    std::vector<settings> d = {
-        settings {75, 20, -4, -4, 2},
-        settings {125, 20, -4, -2, 2},
-        settings {175, 20, -4, 1, 7},
-        settings {275, 20, -4, 4, 13},
-        settings {375, 22, -4, 2, 12},
-        settings {std::numeric_limits<int>::max(), 23, -6, 2, 12},
-    };
-    for (const auto& v : d) {
-        if (read_length <= v.r_threshold) {
-            if (k == -1) {
-                k = v.k;
-            }
-            if (s == -1) {
-                s = k + v.s_offset;
-            }
-            l = v.l;
-            u = v.u;
-            break;
-        }
-    }
-
-    int max_dist;
-    if (max_seed_len == -1) {
-        max_dist = std::max(read_length - 70, k);
-        max_dist = std::min(255, max_dist);
-    } else {
-        max_dist = max_seed_len - k; // convert to distance in start positions
-    }
-    int q = std::pow(2, c == -1 ? default_c : c) - 1;
-    return IndexParameters(k, s, l, u, q, max_dist);
-}
-
-void write_int_to_ostream(std::ostream& os, int value) {
-    int val;
-    val = value;
-    os.write(reinterpret_cast<const char*>(&val), sizeof(val));
-}
-
-void IndexParameters::write(std::ostream& os) const {
-    write_int_to_ostream(os, k);
-    write_int_to_ostream(os, s);
-    write_int_to_ostream(os, l);
-    write_int_to_ostream(os, u);
-    write_int_to_ostream(os, q);
-    write_int_to_ostream(os, max_dist);
-}
-
-int read_int_from_istream(std::istream& is) {
-    int val;
-    is.read(reinterpret_cast<char*>(&val), sizeof(val));
-    return val;
-}
-
-IndexParameters IndexParameters::read(std::istream& is) {
-    int k = read_int_from_istream(is);
-    int s = read_int_from_istream(is);
-    int l = read_int_from_istream(is);
-    int u = read_int_from_istream(is);
-    int q = read_int_from_istream(is);
-    int max_dist = read_int_from_istream(is);
-    return IndexParameters(k, s, l, u, q, max_dist);
-}
-
-bool IndexParameters::operator==(const IndexParameters& other) const {
-    return
-        this->k == other.k
-        && this->s == other.s
-        && this->l == other.l
-        && this->u == other.u
-        && this->q == other.q
-        && this->max_dist == other.max_dist
-        && this->t_syncmer == other.t_syncmer
-        && this->w_min == other.w_min
-        && this->w_max == other.w_max;
-}
-
-// Return a parameter-specific filename extension. Example: ".r100.sti"
-std::string IndexParameters::filename_extension() const {
-    return ".sti";
-}
-
-std::ostream& operator<<(std::ostream& os, const IndexParameters& parameters) {
-    os << "IndexParameters("
-        << "k=" << parameters.k
-        << ", s=" << parameters.s
-        << ", l=" << parameters.l
-        << ", u=" << parameters.u
-        << ", q=" << parameters.q
-        << ", max_dist=" << parameters.max_dist
-        << ", t_syncmer=" << parameters.t_syncmer
-        << ", w_min=" << parameters.w_min
-        << ", w_max=" << parameters.w_max
-        << ")";
-    return os;
-}
 
 uint64_t count_unique_hashes(const ind_mers_vector& mers){
     if (mers.empty()) {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -117,6 +117,7 @@ public:
         , w_min(std::max(1, k / (k - s + 1) + l))
         , w_max(k / (k - s + 1) + u)
     {
+        verify();
     }
 
     static IndexParameters from_read_length(int read_length, int c = -1, int k = -1, int s = -1, int max_seed_len = -1);
@@ -126,6 +127,7 @@ public:
     bool operator==(const IndexParameters& other) const;
     bool operator!=(const IndexParameters& other) const { return !(*this == other); }
 
+private:
     void verify() const {
         if (k <= 7 || k > 32) {
             throw BadParameter("k not in [8,32]");
@@ -134,7 +136,7 @@ public:
             throw BadParameter("s is larger than k");
         }
         if ((k - s) % 2 != 0) {
-            throw BadParameter("(k - s) should be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...");
+            throw BadParameter("(k - s) must be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...");
         }
         if (max_dist > 255) {
             throw BadParameter("maximum seed length (-m <max_dist>) is larger than 255");

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -1,0 +1,105 @@
+#include "indexparameters.hpp"
+#include <vector>
+#include <limits>
+#include <cmath>
+#include <iostream>
+#include "io.hpp"
+
+/* Create an IndexParameters instance based on a given read length.
+ * c, k, s and max_seed_len can be used to override determined parameters
+ * by setting them to a value other than -1.
+ */
+IndexParameters IndexParameters::from_read_length(int read_length, int c, int k, int s, int max_seed_len) {
+    int l, u;
+    const int default_c = 8;
+    struct settings {
+        int r_threshold;
+        int k;
+        int s_offset;
+        int l;
+        int u;
+    };
+    std::vector<settings> d = {
+        settings {75, 20, -4, -4, 2},
+        settings {125, 20, -4, -2, 2},
+        settings {175, 20, -4, 1, 7},
+        settings {275, 20, -4, 4, 13},
+        settings {375, 22, -4, 2, 12},
+        settings {std::numeric_limits<int>::max(), 23, -6, 2, 12},
+    };
+    for (const auto& v : d) {
+        if (read_length <= v.r_threshold) {
+            if (k == -1) {
+                k = v.k;
+            }
+            if (s == -1) {
+                s = k + v.s_offset;
+            }
+            l = v.l;
+            u = v.u;
+            break;
+        }
+    }
+
+    int max_dist;
+    if (max_seed_len == -1) {
+        max_dist = std::max(read_length - 70, k);
+        max_dist = std::min(255, max_dist);
+    } else {
+        max_dist = max_seed_len - k; // convert to distance in start positions
+    }
+    int q = std::pow(2, c == -1 ? default_c : c) - 1;
+    return IndexParameters(k, s, l, u, q, max_dist);
+}
+
+void IndexParameters::write(std::ostream& os) const {
+    write_int_to_ostream(os, k);
+    write_int_to_ostream(os, s);
+    write_int_to_ostream(os, l);
+    write_int_to_ostream(os, u);
+    write_int_to_ostream(os, q);
+    write_int_to_ostream(os, max_dist);
+}
+
+IndexParameters IndexParameters::read(std::istream& is) {
+    int k = read_int_from_istream(is);
+    int s = read_int_from_istream(is);
+    int l = read_int_from_istream(is);
+    int u = read_int_from_istream(is);
+    int q = read_int_from_istream(is);
+    int max_dist = read_int_from_istream(is);
+    return IndexParameters(k, s, l, u, q, max_dist);
+}
+
+bool IndexParameters::operator==(const IndexParameters& other) const {
+    return
+        this->k == other.k
+        && this->s == other.s
+        && this->l == other.l
+        && this->u == other.u
+        && this->q == other.q
+        && this->max_dist == other.max_dist
+        && this->t_syncmer == other.t_syncmer
+        && this->w_min == other.w_min
+        && this->w_max == other.w_max;
+}
+
+// Return a parameter-specific filename extension. Example: ".r100.sti"
+std::string IndexParameters::filename_extension() const {
+    return ".sti";
+}
+
+std::ostream& operator<<(std::ostream& os, const IndexParameters& parameters) {
+    os << "IndexParameters("
+        << "k=" << parameters.k
+        << ", s=" << parameters.s
+        << ", l=" << parameters.l
+        << ", u=" << parameters.u
+        << ", q=" << parameters.q
+        << ", max_dist=" << parameters.max_dist
+        << ", t_syncmer=" << parameters.t_syncmer
+        << ", w_min=" << parameters.w_min
+        << ", w_max=" << parameters.w_max
+        << ")";
+    return os;
+}

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -1,0 +1,62 @@
+#ifndef INDEXPARAMETERS_HPP
+#define INDEXPARAMETERS_HPP
+
+#include <cstdint>
+#include <algorithm>
+#include <iostream>
+#include "exceptions.hpp"
+
+/* Settings that influence index creation */
+class IndexParameters {
+public:
+    const int k;
+    const int s;
+    const int l;
+    const int u;
+    const uint64_t q;
+    const int max_dist;
+    const int t_syncmer;
+    const unsigned w_min;
+    const unsigned w_max;
+
+    IndexParameters(int k, int s, int l, int u, int q, int max_dist)
+        : k(k)
+        , s(s)
+        , l(l)
+        , u(u)
+        , q(q)
+        , max_dist(max_dist)
+        , t_syncmer((k - s) / 2 + 1)
+        , w_min(std::max(1, k / (k - s + 1) + l))
+        , w_max(k / (k - s + 1) + u)
+    {
+        verify();
+    }
+
+    static IndexParameters from_read_length(int read_length, int c = -1, int k = -1, int s = -1, int max_seed_len = -1);
+    static IndexParameters read(std::istream& os);
+    std::string filename_extension() const;
+    void write(std::ostream& os) const;
+    bool operator==(const IndexParameters& other) const;
+    bool operator!=(const IndexParameters& other) const { return !(*this == other); }
+
+private:
+    void verify() const {
+        if (k <= 7 || k > 32) {
+            throw BadParameter("k not in [8,32]");
+        }
+        if (s > k) {
+            throw BadParameter("s is larger than k");
+        }
+        if ((k - s) % 2 != 0) {
+            throw BadParameter("(k - s) must be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...");
+        }
+        if (max_dist > 255) {
+            throw BadParameter("maximum seed length (-m <max_dist>) is larger than 255");
+        }
+    }
+};
+
+std::ostream& operator<<(std::ostream& os, const IndexParameters& parameters);
+
+#endif

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include "exceptions.hpp"
 
 /* Settings that influence index creation */
@@ -19,6 +20,7 @@ public:
     const unsigned w_min;
     const unsigned w_max;
 
+    static const int DEFAULT = std::numeric_limits<int>::min();
     IndexParameters(int k, int s, int l, int u, int q, int max_dist)
         : k(k)
         , s(s)
@@ -33,7 +35,7 @@ public:
         verify();
     }
 
-    static IndexParameters from_read_length(int read_length, int c = -1, int k = -1, int s = -1, int max_seed_len = -1);
+    static IndexParameters from_read_length(int read_length, int c = DEFAULT, int k = DEFAULT, int s = DEFAULT, int l = DEFAULT, int u = DEFAULT, int max_seed_len = DEFAULT);
     static IndexParameters read(std::istream& os);
     std::string filename_extension() const;
     void write(std::ostream& os) const;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -1,0 +1,13 @@
+#include "io.hpp"
+
+void write_int_to_ostream(std::ostream& os, int value) {
+    int val;
+    val = value;
+    os.write(reinterpret_cast<const char*>(&val), sizeof(val));
+}
+
+int read_int_from_istream(std::istream& is) {
+    int val;
+    is.read(reinterpret_cast<char*>(&val), sizeof(val));
+    return val;
+}

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -1,0 +1,28 @@
+#ifndef IO_HPP
+#define IO_HPP
+
+#include <iostream>
+#include <vector>
+
+void write_int_to_ostream(std::ostream& os, int value);
+int read_int_from_istream(std::istream& is);
+
+/* Write a vector to an output stream, preceded by its length */
+template <typename T>
+void write_vector(std::ostream& os, const std::vector<T>& v) {
+    auto size = uint64_t(v.size());
+    os.write(reinterpret_cast<char*>(&size), sizeof(size));
+    os.write(reinterpret_cast<const char*>(v.data()), v.size() * sizeof(T));
+}
+
+/* Read a vector written by write_vector */
+template <typename T>
+void read_vector(std::istream& is, std::vector<T>& v) {
+    uint64_t size;
+    v.clear();
+    is.read(reinterpret_cast<char*>(&size), sizeof(size));
+    v.resize(size);
+    is.read(reinterpret_cast<char*>(v.data()), size * sizeof(T));
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,8 +66,7 @@ void log_parameters(const IndexParameters& index_parameters, const mapping_param
 }
 
 int run_strobealign(int argc, char **argv) {
-    CommandLineOptions opt;
-    opt = parse_command_line_arguments(argc, argv);
+    auto opt = parse_command_line_arguments(argc, argv);
 
     logger.set_level(opt.verbose ? LOG_DEBUG : LOG_INFO);
     logger.info() << std::setprecision(2) << std::fixed;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,8 +82,15 @@ int run_strobealign(int argc, char **argv) {
         throw BadParameter("c must be greater than 0 and less than 64");
     }
     IndexParameters index_parameters = IndexParameters::from_read_length(
-        opt.r, opt.c_set ? opt.c : -1, opt.k_set ? opt.k : -1, opt.s_set ? opt.s : -1, opt.max_seed_len_set ? opt.max_seed_len : -1);
-
+        opt.r,
+        opt.c_set ? opt.c : IndexParameters::DEFAULT,
+        opt.k_set ? opt.k : IndexParameters::DEFAULT,
+        opt.s_set ? opt.s : IndexParameters::DEFAULT,
+        opt.l_set ? opt.l : IndexParameters::DEFAULT,
+        opt.u_set ? opt.u : IndexParameters::DEFAULT,
+        opt.max_seed_len_set ? opt.max_seed_len : IndexParameters::DEFAULT
+    );
+    logger.debug() << index_parameters << '\n';
     alignment_params aln_params;
     aln_params.match = opt.A;
     aln_params.mismatch = opt.B;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,9 +102,6 @@ int run_strobealign(int argc, char **argv) {
     log_parameters(index_parameters, map_param, aln_params);
     logger.debug() << "Threads: " << opt.n_threads << std::endl;
 
-    map_param.verify();
-    index_parameters.verify();
-
 //    assert(k <= (w/2)*w_min && "k should be smaller than (w/2)*w_min to avoid creating short strobemers");
 
     // Create index

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -7,7 +7,7 @@
 #include "fastq.hpp"
 #include "aln.hpp"
 #include "tmpdir.hpp"
-
+#include "io.hpp"
 
 TEST_CASE("estimate_read_length") {
     CHECK(estimate_read_length("tests/phix.1.fastq", "") == 289);


### PR DESCRIPTION
This does some refactoring and then ensures that the `-l` and `-u` command-line parameters are no longer ignored.

Fixes #199