### PR TITLE
"Speed up" reverse-complementing

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -576,11 +576,11 @@ bool reverse_nam_if_needed(nam& n, const Read& read, const References& reference
 
     std::string seq, seq_rc;
     if (n.is_rc) {
-        seq = read.rc();
+        seq = read.rc;
         seq_rc = read.seq;
     } else {
         seq = read.seq;
-        seq_rc = read.rc();
+        seq_rc = read.rc;
     }
     std::string read_start_kmer = seq.substr(n.query_s, k);
     std::string read_end_kmer = seq.substr(n.query_e-k, k);
@@ -671,7 +671,7 @@ inline void align_SE(
         std::string r_tmp;
         bool is_rc;
         if (n.is_rc){
-            r_tmp = read.rc();
+            r_tmp = read.rc;
             is_rc = true;
         }else{
             r_tmp = read.seq;
@@ -776,7 +776,7 @@ inline void align_SE(
 
     if (!all_nams.empty()) {
         sam_aln.mapq = std::min(min_mapq_diff, 60);
-        sam.add(sam_aln, record, read.rc());
+        sam.add(sam_aln, record, read.rc);
     }
 }
 
@@ -853,7 +853,7 @@ static inline void align_SE_secondary_hits(
         std::string r_tmp;
         bool is_rc;
         if (n.is_rc){
-            r_tmp = read.rc();
+            r_tmp = read.rc;
             is_rc = true;
         }else{
             r_tmp = read.seq;
@@ -982,7 +982,7 @@ static inline void align_SE_secondary_hits(
             } else {
                 sam_aln.mapq = std::min(min_mapq_diff, 60);
             }
-            sam.add(sam_aln, record, read.rc(), is_secondary);
+            sam.add(sam_aln, record, read.rc, is_secondary);
         }
     }
 }
@@ -1095,7 +1095,7 @@ static inline void get_alignment(
     std::string r_tmp;
     bool is_rc;
     if (n.is_rc){
-        r_tmp = read.rc();
+        r_tmp = read.rc;
         is_rc = true;
     }else{
         r_tmp = read.seq;
@@ -1589,7 +1589,7 @@ static inline void rescue_mate(
         b = n.ref_s - n.query_s + read_len/2; // at most half read overlap
         a_is_rc = false;
     } else {
-        r_tmp = read.rc(); // mate is rc since fr orientation
+        r_tmp = read.rc; // mate is rc since fr orientation
         a = n.ref_e + (read_len - n.query_e) - read_len/2; // at most half read overlap
         b = n.ref_e + (read_len - n.query_e) + (mu+5*sigma);
         a_is_rc = true;
@@ -1733,9 +1733,9 @@ void rescue_read(
 //            get_MAPQ(all_nams1, n_max1, mapq1);
 //            mapq2 = 0;
         if (swap_r1r2) {
-            sam.add_pair(sam_aln2, sam_aln1, record2, record1, read2.rc(), read1.rc(), mapq2, mapq1, is_proper_pair(sam_aln2, sam_aln1, mu, sigma), true);
+            sam.add_pair(sam_aln2, sam_aln1, record2, record1, read2.rc, read1.rc, mapq2, mapq1, is_proper_pair(sam_aln2, sam_aln1, mu, sigma), true);
         } else {
-            sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(), mapq1, mapq2, is_proper_pair(sam_aln1, sam_aln2, mu, sigma), true);
+            sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc, read2.rc, mapq1, mapq2, is_proper_pair(sam_aln1, sam_aln2, mu, sigma), true);
         }
     } else {
         int max_out = std::min(high_scores.size(), max_secondary);
@@ -1756,10 +1756,10 @@ void rescue_read(
             if (s_max - s_score < secondary_dropoff) {
                 if (swap_r1r2) {
                     bool is_proper = is_proper_pair(sam_aln2, sam_aln1, mu, sigma);
-                    sam.add_pair(sam_aln2, sam_aln1, record2, record1, read2.rc(), read1.rc(), mapq2, mapq1, is_proper, is_primary);
+                    sam.add_pair(sam_aln2, sam_aln1, record2, record1, read2.rc, read1.rc, mapq2, mapq1, is_proper, is_primary);
                 } else {
                     bool is_proper = is_proper_pair(sam_aln1, sam_aln2, mu, sigma);
-                    sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(), mapq1, mapq2, is_proper, is_primary);
+                    sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc, read2.rc, mapq1, mapq2, is_proper, is_primary);
                 }
             } else {
                 break;
@@ -1910,7 +1910,7 @@ inline void align_PE(
         int mapq1 = get_MAPQ(all_nams1, n_max1);
         int mapq2 = get_MAPQ(all_nams2, n_max2);
         bool is_proper = is_proper_pair(sam_aln1, sam_aln2, mu, sigma);
-        sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(), mapq1, mapq2, is_proper, true);
+        sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc, read2.rc, mapq1, mapq2, is_proper, true);
 
         if ((isize_est.sample_size < 400) && ((sam_aln1.ed + sam_aln2.ed) < 3) && is_proper) {
             isize_est.update(std::abs(sam_aln1.ref_start - sam_aln2.ref_start));
@@ -2076,7 +2076,7 @@ inline void align_PE(
     if (max_secondary == 0) {
 //            get_MAPQ_aln(sam_aln1, sam_aln2);
         bool is_proper = is_proper_pair(sam_aln1, sam_aln2, mu, sigma);
-        sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(),
+        sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc, read2.rc,
                         mapq1, mapq2, is_proper, true);
     } else {
         int max_out = std::min(high_scores.size(), max_secondary);
@@ -2105,7 +2105,7 @@ inline void align_PE(
 
             if (s_max - s_score < secondary_dropoff) {
                 bool is_proper = is_proper_pair(sam_aln1, sam_aln2, mu, sigma);
-                sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc(), read2.rc(),
+                sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc, read2.rc,
                                 mapq1, mapq2, is_proper, is_primary);
             } else {
                 break;

--- a/src/revcomp.hpp
+++ b/src/revcomp.hpp
@@ -4,18 +4,38 @@
 #include <string>
 #include <algorithm>
 
-static inline std::string reverse_complement(const std::string &read) {
-    auto read_rev = read;
-    std::reverse(read_rev.begin(), read_rev.end()); // reverse
-    for (size_t j = 0; j < read_rev.length(); ++j) { // complement
-        if (read_rev[j] == 'A') read_rev[j] = 'T';
-        else if (read_rev[j] == 'T') read_rev[j] = 'A';
-        else if (read_rev[j] == 'C') read_rev[j] = 'G';
-        else if (read_rev[j] == 'G') read_rev[j] = 'C';
-    }
-    return read_rev;
-}
+// a, A -> T
+// c, C -> G
+// g, G -> C
+// t, T, u, U -> A
+static unsigned char revcomp_table[256] = {
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'T', 'N', 'G',  'N', 'N', 'N', 'C',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'A', 'A', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'T', 'N', 'G',  'N', 'N', 'N', 'C',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'A', 'A', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N',  'N', 'N', 'N', 'N'
+};
 
+static inline std::string reverse_complement(const std::string &sequence) {
+    std::string result;
+    result.reserve(sequence.size());
+    for (size_t i = 0; i < sequence.length(); ++i) {
+        auto ch = sequence[sequence.length() - i - 1];
+        result.push_back(revcomp_table[static_cast<int>(ch)]);
+    }
+    return result;
+}
 
 /* A (nucleotide) sequence and its reverse complement.
  * The reverse complement is computed on first access only

--- a/src/revcomp.hpp
+++ b/src/revcomp.hpp
@@ -37,33 +37,21 @@ static inline std::string reverse_complement(const std::string &sequence) {
     return result;
 }
 
-/* A (nucleotide) sequence and its reverse complement.
- * The reverse complement is computed on first access only
- * (and cached).
- */
+/* A (nucleotide) sequence and its reverse complement. */
 class Read {
 public:
     const std::string& seq;
+    const std::string rc;
 
-    Read(const std::string& s) : seq(s) {
-    }
-
-    /* Return reverse complemented sequence */
-    std::string rc() const {
-        if (!has_reverse_complement) {
-            rc_sequence = reverse_complement(seq);
-            has_reverse_complement = true;
-        }
-        return rc_sequence;
+    Read(const std::string& s)
+      : seq(s)
+      , rc(reverse_complement(s))
+    {
     }
 
     std::string::size_type size() const {
         return seq.size();
     }
-
-private:
-    mutable std::string rc_sequence;
-    mutable bool has_reverse_complement = false;
 };
 
 #endif

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -8,6 +8,7 @@
 #include "aln.hpp"
 #include "tmpdir.hpp"
 #include "io.hpp"
+#include "revcomp.hpp"
 
 TEST_CASE("estimate_read_length") {
     CHECK(estimate_read_length("tests/phix.1.fastq", "") == 289);
@@ -78,4 +79,16 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
         CHECK(randstrobe2 != iter2.end());
         CHECK(randstrobe1 == randstrobe2);
     }
+}
+
+TEST_CASE("reverse complement") {
+    CHECK(reverse_complement("") == "");
+    CHECK(reverse_complement("A") == "T");
+    CHECK(reverse_complement("C") == "G");
+    CHECK(reverse_complement("G") == "C");
+    CHECK(reverse_complement("T") == "A");
+    CHECK(reverse_complement("TG") == "CA");
+    CHECK(reverse_complement("AC") == "GT");
+    CHECK(reverse_complement("ACG") == "CGT");
+    CHECK(reverse_complement("AACGT") == "ACGTT");
 }


### PR DESCRIPTION
I wrote a small test program to measure the differences in runtime. Reading in and reverse-complementing 1 million 150 bp reads takes 4.5 µs per read with the previous code and 2.2 µs per read with this version using a lookup table. Just parsing the FASTQ takes 1.2 µs, so reverse complementing time goes from 3.3 µs to 1.0 µs per read.

I tried to measure what the effect is on mapping time, but it makes nearly no difference (less than 1%). For the fruit fly dataset, mapping time per read went from something like 194.7±0.5µs before to 194.0±0.5 µs after the change.

It appears to me that reverse complementing is not responsible for any significant part of the mapping runtime. We currently have a caching mechanism for reverse complements, but I’m tempted to remove that and just *always* compute each read’s reverse complement because the caching itself complicates the code and also makes it slower.

Closes #174