### PR TITLE
Suggestion to rename some key types

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -12,7 +12,7 @@ using namespace klibpp;
 
 struct Hit {
     unsigned int count;
-    KmerLookupEntry lookup_entry;
+    RandstrobeMapEntry randstrobe_map_entry;
     unsigned int query_s;
     unsigned int query_e;
     bool is_rc;
@@ -98,14 +98,14 @@ void add_to_hits_per_ref(
     bool is_rc,
     const StrobemerIndex& index,
     int k,
-    KmerLookupEntry lookup_entry,
+    RandstrobeMapEntry randstrobe_map_entry,
     int min_diff
 ) {
     // Determine whether the hash table’s value directly represents a
     // ReferenceMer (this is the case if count==1) or an offset/count
     // pair that refers to entries in the flat_vector.
-    if (lookup_entry.is_reference_mer()) {
-        auto r = lookup_entry.as_reference_mer();
+    if (randstrobe_map_entry.is_reference_mer()) {
+        auto r = randstrobe_map_entry.as_reference_mer();
         int ref_s = r.position;
         int ref_e = r.position + r.strobe2_offset() + k;
         int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
@@ -114,7 +114,7 @@ void add_to_hits_per_ref(
             min_diff = diff;
         }
     } else {
-        for (size_t j = lookup_entry.offset(); j < lookup_entry.offset() + lookup_entry.count(); ++j) {
+        for (size_t j = randstrobe_map_entry.offset(); j < randstrobe_map_entry.offset() + randstrobe_map_entry.count(); ++j) {
             auto r = index.flat_vector[j];
             int ref_s = r.position;
             int ref_e = r.position + r.strobe2_offset() + k;
@@ -163,7 +163,7 @@ static inline void find_nams_rescue(
             if ((count > filter_cutoff && cnt >= 5) || count > 1000) {
                 break;
             }
-            add_to_hits_per_ref(hits_per_ref, q.query_s, q.query_e, q.is_rc, index, k, q.lookup_entry, 1000);
+            add_to_hits_per_ref(hits_per_ref, q.query_s, q.query_e, q.is_rc, index, k, q.randstrobe_map_entry, 1000);
             cnt++;
         }
     }

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -104,8 +104,8 @@ void add_to_hits_per_ref(
     // Determine whether the hash table’s value directly represents a
     // ReferenceMer (this is the case if count==1) or an offset/count
     // pair that refers to entries in the flat_vector.
-    if (randstrobe_map_entry.is_reference_mer()) {
-        auto r = randstrobe_map_entry.as_reference_mer();
+    if (randstrobe_map_entry.is_direct()) {
+        auto r = randstrobe_map_entry.as_ref_randstrobe();
         int ref_s = r.position;
         int ref_e = r.position + r.strobe2_offset() + k;
         int diff = std::abs((query_e - query_s) - (ref_e - ref_s));

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -281,8 +281,8 @@ ind_mers_vector StrobemerIndex::add_randstrobes_to_hash_table() {
                 packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
 
                 // try to insert as direct entry
-                KmerLookupEntry kle{randstrobe.strobe1_pos, packed | 0x8000'0000};
-                auto result = randstrobe_map.insert({randstrobe.hash, kle});
+                RandstrobeMapEntry entry{randstrobe.strobe1_pos, packed | 0x8000'0000};
+                auto result = randstrobe_map.insert({randstrobe.hash, entry});
                 if (result.second) {
                     tot_occur_once++;
                 } else {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -24,7 +24,7 @@ static Logger& logger = Logger::get();
 static const uint32_t STI_FILE_FORMAT_VERSION = 1;
 
 
-uint64_t count_unique_hashes(const ind_mers_vector& mers){
+uint64_t count_unique_hashes(const std::vector<RefRandstrobeWithHash>& mers){
     if (mers.empty()) {
         return 0;
     }
@@ -247,8 +247,8 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
  * - stats.tot_occur_once
  * - stats.tot_strobemer_count
  */
-ind_mers_vector StrobemerIndex::add_randstrobes_to_hash_table() {
-    ind_mers_vector ind_flat_vector;
+std::vector<RefRandstrobeWithHash> StrobemerIndex::add_randstrobes_to_hash_table() {
+    std::vector<RefRandstrobeWithHash> randstrobes_with_hash;
     size_t tot_occur_once = 0;
     for (size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
         auto seq = references.sequences[ref_index];
@@ -292,20 +292,20 @@ ind_mers_vector StrobemerIndex::add_randstrobes_to_hash_table() {
                     if (existing_count == 1) {
                         // current entry is a direct one, convert to an indirect one
                         auto existing_randstrobe = existing->second.as_ref_randstrobe();
-                        ind_flat_vector.push_back(RefRandstrobeWithHash{randstrobe.hash, existing_randstrobe.position, existing_randstrobe.packed()});
+                        randstrobes_with_hash.push_back(RefRandstrobeWithHash{randstrobe.hash, existing_randstrobe.position, existing_randstrobe.packed()});
                         tot_occur_once--;
                     }
                     // offset is adjusted later after sorting
                     existing->second.set_count(existing_count + 1);
 
-                    ind_flat_vector.push_back(RefRandstrobeWithHash{randstrobe.hash, randstrobe.strobe1_pos, packed});
+                    randstrobes_with_hash.push_back(RefRandstrobeWithHash{randstrobe.hash, randstrobe.strobe1_pos, packed});
                 }
             }
             chunk.clear();
         }
     }
     stats.tot_occur_once = tot_occur_once;
-    return ind_flat_vector;
+    return randstrobes_with_hash;
 }
 
 void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) const {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -107,17 +107,17 @@ void StrobemerIndex::read(const std::string& filename) {
     mers_index.reserve(sz);
     // read in big chunks
     const uint64_t chunk_size = pow(2,20);//4 M => chunks of ~10 MB - The chunk size seem not to be that important
-    auto buf_size = std::min(sz, chunk_size) * (sizeof(kmer_lookup::key_type) + sizeof(kmer_lookup::mapped_type));
+    auto buf_size = std::min(sz, chunk_size) * (sizeof(RandstrobeMap::key_type) + sizeof(RandstrobeMap::mapped_type));
     std::unique_ptr<char> buf_ptr(new char[buf_size]);
     char* buf2 = buf_ptr.get();
     auto left_to_read = sz;
     while (left_to_read > 0) {
         auto to_read = std::min(left_to_read, chunk_size);
-        ifs.read(buf2, to_read * (sizeof(kmer_lookup::key_type) + sizeof(kmer_lookup::mapped_type)));
+        ifs.read(buf2, to_read * (sizeof(RandstrobeMap::key_type) + sizeof(RandstrobeMap::mapped_type)));
         //Add the elements directly from the buffer
         for (size_t i = 0; i < to_read; ++i) {
-            auto start = buf2 + i * (sizeof(kmer_lookup::key_type) + sizeof(kmer_lookup::mapped_type));
-            mers_index[*reinterpret_cast<kmer_lookup::key_type*>(start)] = *reinterpret_cast<kmer_lookup::mapped_type*>(start + sizeof(kmer_lookup::key_type));
+            auto start = buf2 + i * (sizeof(RandstrobeMap::key_type) + sizeof(RandstrobeMap::mapped_type));
+            mers_index[*reinterpret_cast<RandstrobeMap::key_type*>(start)] = *reinterpret_cast<RandstrobeMap::mapped_type*>(start + sizeof(RandstrobeMap::key_type));
         }
         left_to_read -= to_read;
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -195,7 +195,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     uint64_t prev_hash = -1;
     flat_vector.reserve(ind_flat_vector.size());
     for (auto &mer : ind_flat_vector) {
-        flat_vector.push_back(ReferenceMer{mer.position, mer.packed});
+        flat_vector.push_back(RefRandstrobe{mer.position, mer.packed});
         if (mer.hash != prev_hash) {
             auto mer_index_entry = randstrobe_map.find(mer.hash);
             assert(mer_index_entry != randstrobe_map.end());
@@ -291,8 +291,8 @@ ind_mers_vector StrobemerIndex::add_randstrobes_to_hash_table() {
                     auto existing_count = existing->second.count();
                     if (existing_count == 1) {
                         // current entry is a direct one, convert to an indirect one
-                        auto refmer = existing->second.as_reference_mer();
-                        ind_flat_vector.push_back(MersIndexEntry{randstrobe.hash, refmer.position, refmer.packed()});
+                        auto existing_randstrobe = existing->second.as_ref_randstrobe();
+                        ind_flat_vector.push_back(MersIndexEntry{randstrobe.hash, existing_randstrobe.position, existing_randstrobe.packed()});
                         tot_occur_once--;
                     }
                     // offset is adjusted later after sorting

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -277,7 +277,7 @@ ind_mers_vector StrobemerIndex::add_randstrobes_to_hash_table() {
             }
             stats.tot_strobemer_count += chunk.size();
             for (auto randstrobe : chunk) {
-                MersIndexEntry::packed_t packed = ref_index << 8;
+                RefRandstrobeWithHash::packed_t packed = ref_index << 8;
                 packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
 
                 // try to insert as direct entry
@@ -292,13 +292,13 @@ ind_mers_vector StrobemerIndex::add_randstrobes_to_hash_table() {
                     if (existing_count == 1) {
                         // current entry is a direct one, convert to an indirect one
                         auto existing_randstrobe = existing->second.as_ref_randstrobe();
-                        ind_flat_vector.push_back(MersIndexEntry{randstrobe.hash, existing_randstrobe.position, existing_randstrobe.packed()});
+                        ind_flat_vector.push_back(RefRandstrobeWithHash{randstrobe.hash, existing_randstrobe.position, existing_randstrobe.packed()});
                         tot_occur_once--;
                     }
                     // offset is adjusted later after sorting
                     existing->second.set_count(existing_count + 1);
 
-                    ind_flat_vector.push_back(MersIndexEntry{randstrobe.hash, randstrobe.strobe1_pos, packed});
+                    ind_flat_vector.push_back(RefRandstrobeWithHash{randstrobe.hash, randstrobe.strobe1_pos, packed});
                 }
             }
             chunk.clear();

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -90,7 +90,7 @@ private:
     unsigned int m_count;
 };
 
-typedef robin_hood::unordered_map<uint64_t, KmerLookupEntry> kmer_lookup;
+using RandstrobeMap = robin_hood::unordered_map<uint64_t, KmerLookupEntry>;
 
 typedef std::vector<uint64_t> hash_vector; //only used during index generation
 
@@ -127,11 +127,11 @@ struct StrobemerIndex {
     void populate(float f, size_t n_threads);
     void print_diagnostics(const std::string& logfile_name, int k) const;
 
-    kmer_lookup::const_iterator find(uint64_t key) const {
+    RandstrobeMap::const_iterator find(uint64_t key) const {
         return mers_index.find(key);
     }
 
-    kmer_lookup::const_iterator end() const {
+    RandstrobeMap::const_iterator end() const {
         return mers_index.cend();
     }
 
@@ -145,7 +145,7 @@ private:
 
     const IndexParameters& parameters;
     const References& references;
-    kmer_lookup mers_index; // k-mer -> (offset in flat_vector, occurence count )
+    RandstrobeMap mers_index; // k-mer -> (offset in flat_vector, occurence count )
 };
 
 #endif

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -47,7 +47,7 @@ private:
     RefRandstrobeWithHash::packed_t m_packed;
 };
 
-typedef std::vector<RefRandstrobe> mers_vector;
+using RefRandstrobeVector = std::vector<RefRandstrobe>;
 
 class RandstrobeMapEntry {
 public:
@@ -119,7 +119,7 @@ struct StrobemerIndex {
         , references(references) {}
     unsigned int filter_cutoff; //This also exists in mapping_params, but is calculated during index generation,
                                 //therefore stored here since it needs to be saved with the index.
-    mers_vector flat_vector;
+    RefRandstrobeVector flat_vector;
     mutable IndexCreationStatistics stats;
 
     void write(const std::string& filename) const;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -37,14 +37,14 @@ public:
         return m_packed & mask;
     }
 
-    MersIndexEntry::packed_t packed() const {
+    RefRandstrobeWithHash::packed_t packed() const {
         return m_packed;
     }
 
 private:
     static const int bit_alloc = 8;
     static const int mask = (1 << bit_alloc) - 1;
-    MersIndexEntry::packed_t m_packed;
+    RefRandstrobeWithHash::packed_t m_packed;
 };
 
 typedef std::vector<RefRandstrobe> mers_vector;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -128,16 +128,16 @@ struct StrobemerIndex {
     void print_diagnostics(const std::string& logfile_name, int k) const;
 
     RandstrobeMap::const_iterator find(uint64_t key) const {
-        return mers_index.find(key);
+        return randstrobe_map.find(key);
     }
 
     RandstrobeMap::const_iterator end() const {
-        return mers_index.cend();
+        return randstrobe_map.cend();
     }
 
     void add_entry(uint64_t key, unsigned int offset, unsigned int count) {
         KmerLookupEntry s{offset, count};
-        mers_index[key] = s;
+        randstrobe_map[key] = s;
     }
 
 private:
@@ -145,7 +145,7 @@ private:
 
     const IndexParameters& parameters;
     const References& references;
-    RandstrobeMap mers_index; // k-mer -> (offset in flat_vector, occurence count )
+    RandstrobeMap randstrobe_map; // k-mer -> (offset in flat_vector, occurence count )
 };
 
 #endif

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -108,7 +108,7 @@ private:
     unsigned int m_count;
 };
 
-using RandstrobeMap = robin_hood::unordered_map<uint64_t, RandstrobeMapEntry>;
+using RandstrobeMap = robin_hood::unordered_map<randstrobe_hash_t, RandstrobeMapEntry>;
 
 typedef std::vector<uint64_t> hash_vector; //only used during index generation
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -22,6 +22,12 @@
 #include "randstrobes.hpp"
 #include "indexparameters.hpp"
 
+/*
+ * This describes where a randstrobe occurs. Info stored:
+ * - reference index
+ * - position of the first strobe
+ * - offset of the second strobe
+*/
 class RefRandstrobe {
 public:
     RefRandstrobe() { }  // TODO should not be needed
@@ -49,6 +55,18 @@ private:
 
 using RefRandstrobeVector = std::vector<RefRandstrobe>;
 
+/*
+ * An entry in the randstrobe map that allows retrieval of randstrobe
+ * occurrences. To save memory, the entry is either a "direct" or an
+ * "indirect" one.
+ *
+ * - A direct entry is used if the randstrobe occurs only once in the reference.
+ *   Then that single occurrence itself is stored and can be retrieved by the
+ *   as_ref_randstrobe() method.
+ * - An indirect entry is used if the randstrobe has multiple occurrences.
+ *   In that case, offset() and count() point to an interval within a second
+ *   table (RandstrobeVector).
+ */
 class RandstrobeMapEntry {
 public:
     RandstrobeMapEntry() { }
@@ -140,7 +158,7 @@ struct StrobemerIndex {
     }
 
 private:
-    ind_mers_vector add_randstrobes_to_hash_table();
+    std::vector<RefRandstrobeWithHash> add_randstrobes_to_hash_table();
 
     const IndexParameters& parameters;
     const References& references;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -49,10 +49,10 @@ private:
 
 typedef std::vector<ReferenceMer> mers_vector;
 
-class KmerLookupEntry {
+class RandstrobeMapEntry {
 public:
-    KmerLookupEntry() { }
-    KmerLookupEntry(unsigned int offset, unsigned int count) : m_offset(offset), m_count(count) { }
+    RandstrobeMapEntry() { }
+    RandstrobeMapEntry(unsigned int offset, unsigned int count) : m_offset(offset), m_count(count) { }
 
     unsigned int count() const {
         if (is_reference_mer()) {
@@ -90,7 +90,7 @@ private:
     unsigned int m_count;
 };
 
-using RandstrobeMap = robin_hood::unordered_map<uint64_t, KmerLookupEntry>;
+using RandstrobeMap = robin_hood::unordered_map<uint64_t, RandstrobeMapEntry>;
 
 typedef std::vector<uint64_t> hash_vector; //only used during index generation
 
@@ -136,8 +136,7 @@ struct StrobemerIndex {
     }
 
     void add_entry(uint64_t key, unsigned int offset, unsigned int count) {
-        KmerLookupEntry s{offset, count};
-        randstrobe_map[key] = s;
+        randstrobe_map[key] = RandstrobeMapEntry{offset, count};
     }
 
 private:

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -22,10 +22,10 @@
 #include "randstrobes.hpp"
 #include "indexparameters.hpp"
 
-class ReferenceMer {
+class RefRandstrobe {
 public:
-    ReferenceMer() { }  // TODO should not be needed
-    ReferenceMer(uint32_t position, uint32_t packed) : position(position), m_packed(packed) {
+    RefRandstrobe() { }  // TODO should not be needed
+    RefRandstrobe(uint32_t position, uint32_t packed) : position(position), m_packed(packed) {
     }
     uint32_t position;
 
@@ -47,7 +47,7 @@ private:
     MersIndexEntry::packed_t m_packed;
 };
 
-typedef std::vector<ReferenceMer> mers_vector;
+typedef std::vector<RefRandstrobe> mers_vector;
 
 class RandstrobeMapEntry {
 public:
@@ -55,7 +55,7 @@ public:
     RandstrobeMapEntry(unsigned int offset, unsigned int count) : m_offset(offset), m_count(count) { }
 
     unsigned int count() const {
-        if (is_reference_mer()) {
+        if (is_direct()) {
             return 1;
         } else {
             return m_count;
@@ -63,17 +63,17 @@ public:
     }
 
     unsigned int offset() const{
-        assert(!is_reference_mer());
+        assert(!is_direct());
         return m_offset;
     }
 
-    bool is_reference_mer() const {
+    bool is_direct() const {
         return m_count & 0x8000'0000;
     }
 
-    ReferenceMer as_reference_mer() const {
-        assert(is_reference_mer());
-        return ReferenceMer{m_offset, m_count & 0x7fff'ffff};
+    RefRandstrobe as_ref_randstrobe() const {
+        assert(is_direct());
+        return RefRandstrobe{m_offset, m_count & 0x7fff'ffff};
     }
 
     void set_count(unsigned int count) {
@@ -81,7 +81,7 @@ public:
     }
 
     void set_offset(unsigned int offset) {
-        assert(!is_reference_mer());
+        assert(!is_direct());
         m_offset = offset;
     }
 

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -30,7 +30,7 @@ static unsigned char seq_nt4_table[256] = {
         4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4
 };
 
-static inline uint64_t syncmer_kmer_hash(uint64_t packed) {
+static inline syncmer_hash_t syncmer_kmer_hash(uint64_t packed) {
     // return robin_hash(yk);
     // return yk;
     // return hash64(yk, mask);
@@ -109,13 +109,13 @@ Syncmer SyncmerIterator::next() {
     return Syncmer{0, 0}; // end marker
 }
 
-std::pair<std::vector<uint64_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
+std::pair<std::vector<syncmer_hash_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
     const std::string &seq,
     const size_t k,
     const size_t s,
     const size_t t
 ) {
-    std::vector<uint64_t> string_hashes;
+    std::vector<syncmer_hash_t> string_hashes;
     std::vector<unsigned int> pos_to_seq_coordinate;
     SyncmerIterator syncmer_iterator{seq, k, s, t};
     Syncmer syncmer;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -203,7 +203,7 @@ Randstrobe RandstrobeIterator2::next() {
  * syncmers. Since creating canonical syncmers is the most time consuming step,
  * we avoid performing it twice for the read and its reverse complement here.
  */
-mers_vector_read randstrobes_query(
+QueryRandstrobeVector randstrobes_query(
     int k,
     unsigned w_min,
     unsigned w_max,
@@ -217,7 +217,7 @@ mers_vector_read randstrobes_query(
     // The seq_to_randstrobes2 stores randstobes only in one direction from canonical syncmers.
     // this function stores randstobes from both directions created from canonical syncmers.
     // Since creating canonical syncmers is the most time consuming step, we avoid perfomring it twice for the read and its RC here
-    mers_vector_read randstrobes2;
+    QueryRandstrobeVector randstrobes2;
     auto read_length = seq.length();
     if (read_length < w_max) {
         return randstrobes2;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -237,8 +237,9 @@ mers_vector_read randstrobes_query(
     RandstrobeIterator randstrobe_fwd_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
     while (randstrobe_fwd_iter.has_next()) {
         auto randstrobe = randstrobe_fwd_iter.next();
-        QueryMer query_mer{randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + k, false};
-        randstrobes2.push_back(query_mer);
+        randstrobes2.push_back(
+            QueryRandstrobe{randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + k, false}
+        );
     }
 
     std::reverse(string_hashes.begin(), string_hashes.end());
@@ -250,8 +251,9 @@ mers_vector_read randstrobes_query(
     RandstrobeIterator randstrobe_rc_iter { string_hashes, pos_to_seq_coordinate, w_min, w_max, q, max_dist };
     while (randstrobe_rc_iter.has_next()) {
         auto randstrobe = randstrobe_rc_iter.next();
-        QueryMer query_mer{randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + k, true};
-        randstrobes2.push_back(query_mer);
+        randstrobes2.push_back(
+            QueryRandstrobe{randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + k, true}
+        );
     }
     return randstrobes2;
 }

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -10,11 +10,13 @@
 #include <stdexcept>
 #include <inttypes.h>
 
+using syncmer_hash_t = uint64_t;
+using randstrobe_hash_t = uint64_t;
+
 // only used during index generation
 struct RefRandstrobeWithHash {
-
     using packed_t = uint32_t;
-    uint64_t hash;
+    randstrobe_hash_t hash;
     uint32_t position;
     packed_t packed; // packed representation of ref_index and strobe offset
 
@@ -24,19 +26,18 @@ struct RefRandstrobeWithHash {
 };
 
 struct QueryRandstrobe {
-    uint64_t hash;
+    randstrobe_hash_t hash;
     unsigned int start;
     unsigned int end;
     bool is_reverse;
 };
-
 
 using QueryRandstrobeVector = std::vector<QueryRandstrobe>;
 
 QueryRandstrobeVector randstrobes_query(int k, unsigned w_min, unsigned w_max, const std::string &seq, int s, int t, uint64_t q, int max_dist);
 
 struct Randstrobe {
-    uint64_t hash;
+    randstrobe_hash_t hash;
     unsigned int strobe1_pos;
     unsigned int strobe2_pos;
 
@@ -92,7 +93,7 @@ private:
 };
 
 struct Syncmer {
-    uint64_t hash;
+    syncmer_hash_t hash;
     size_t position;
     bool is_end() const {
         return hash == 0 && position == 0;
@@ -156,7 +157,7 @@ private:
 };
 
 
-std::pair<std::vector<uint64_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
+std::pair<std::vector<syncmer_hash_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
     const std::string &seq,
     const size_t k,
     const size_t s,

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -25,7 +25,6 @@ struct RefRandstrobeWithHash {
 
 typedef std::vector<RefRandstrobeWithHash> ind_mers_vector;
 
-
 struct QueryRandstrobe {
     uint64_t hash;
     unsigned int start;
@@ -34,9 +33,9 @@ struct QueryRandstrobe {
 };
 
 
-typedef std::vector<QueryRandstrobe> mers_vector_read;
+using QueryRandstrobeVector = std::vector<QueryRandstrobe>;
 
-mers_vector_read randstrobes_query(int k, unsigned w_min, unsigned w_max, const std::string &seq, int s, int t, uint64_t q, int max_dist);
+QueryRandstrobeVector randstrobes_query(int k, unsigned w_min, unsigned w_max, const std::string &seq, int s, int t, uint64_t q, int max_dist);
 
 struct Randstrobe {
     uint64_t hash;

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -11,19 +11,19 @@
 #include <inttypes.h>
 
 // only used during index generation
-struct MersIndexEntry {
+struct RefRandstrobeWithHash {
 
     using packed_t = uint32_t;
     uint64_t hash;
     uint32_t position;
     packed_t packed; // packed representation of ref_index and strobe offset
 
-    bool operator< (const MersIndexEntry& other) const {
+    bool operator< (const RefRandstrobeWithHash& other) const {
         return hash < other.hash;
     }
 };
 
-typedef std::vector<MersIndexEntry> ind_mers_vector;
+typedef std::vector<RefRandstrobeWithHash> ind_mers_vector;
 
 
 struct QueryMer {

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -26,7 +26,7 @@ struct RefRandstrobeWithHash {
 typedef std::vector<RefRandstrobeWithHash> ind_mers_vector;
 
 
-struct QueryMer {
+struct QueryRandstrobe {
     uint64_t hash;
     unsigned int start;
     unsigned int end;
@@ -34,7 +34,7 @@ struct QueryMer {
 };
 
 
-typedef std::vector<QueryMer> mers_vector_read;
+typedef std::vector<QueryRandstrobe> mers_vector_read;
 
 mers_vector_read randstrobes_query(int k, unsigned w_min, unsigned w_max, const std::string &seq, int s, int t, uint64_t q, int max_dist);
 

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -23,8 +23,6 @@ struct RefRandstrobeWithHash {
     }
 };
 
-typedef std::vector<RefRandstrobeWithHash> ind_mers_vector;
-
 struct QueryRandstrobe {
     uint64_t hash;
     unsigned int start;

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1181,7 +1181,7 @@ static inline void find_nams_rescue(
     std::vector<nam> &final_nams,
     robin_hood::unordered_map<unsigned int, std::vector<hit>> &hits_per_ref,
     const mers_vector_read &query_mers,
-    const mers_vector &ref_mers,
+    const RefRandstrobeVector &ref_mers,
     RandstrobeMap &mers_index,
     int k,
     const std::vector<std::string> &ref_seqs,
@@ -1478,7 +1478,7 @@ static inline std::pair<float,int> find_nams(
     std::vector<nam> &final_nams,
     robin_hood::unordered_map<unsigned int, std::vector<hit>> &hits_per_ref,
     const mers_vector_read &query_mers,
-    const mers_vector &ref_mers,
+    const RefRandstrobeVector &ref_mers,
     RandstrobeMap &mers_index,
     int k,
     unsigned int filter_cutoff

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1182,7 +1182,7 @@ static inline void find_nams_rescue(
     robin_hood::unordered_map<unsigned int, std::vector<hit>> &hits_per_ref,
     const mers_vector_read &query_mers,
     const mers_vector &ref_mers,
-    kmer_lookup &mers_index,
+    RandstrobeMap &mers_index,
     int k,
     const std::vector<std::string> &ref_seqs,
     const std::string &read,
@@ -1479,7 +1479,7 @@ static inline std::pair<float,int> find_nams(
     robin_hood::unordered_map<unsigned int, std::vector<hit>> &hits_per_ref,
     const mers_vector_read &query_mers,
     const mers_vector &ref_mers,
-    kmer_lookup &mers_index,
+    RandstrobeMap &mers_index,
     int k,
     unsigned int filter_cutoff
 ) {

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1180,7 +1180,7 @@ static inline bool sort_hits(const hit &a, const hit &b)
 static inline void find_nams_rescue(
     std::vector<nam> &final_nams,
     robin_hood::unordered_map<unsigned int, std::vector<hit>> &hits_per_ref,
-    const mers_vector_read &query_mers,
+    const QueryRandstrobeVector &query_mers,
     const RefRandstrobeVector &ref_mers,
     RandstrobeMap &mers_index,
     int k,
@@ -1477,7 +1477,7 @@ static inline void find_nams_rescue(
 static inline std::pair<float,int> find_nams(
     std::vector<nam> &final_nams,
     robin_hood::unordered_map<unsigned int, std::vector<hit>> &hits_per_ref,
-    const mers_vector_read &query_mers,
+    const QueryRandstrobeVector &query_mers,
     const RefRandstrobeVector &ref_mers,
     RandstrobeMap &mers_index,
     int k,


### PR DESCRIPTION
I’ve been struggling a bit with the names of some of the types and variables. Whenever I haven’t looked at the code in `index.cpp/.h` for a week, I always need to re-read what `mers_vector`, `ind_mers_vector`, `ind_flat_vector`, `ReferenceMer` actually are.

I have a couple of preliminary suggestions for which I’ve added commits in this PR. I want to get some feedback before continuing, and also want to look at the code a bit to see how the new names would "feel". I’ll update this list if I make changes.

## Changed type names

| now | suggested | comment |
|-|-|-|
| `ReferenceMer` | `RefRandstrobe` | location of a randstrobe on the reference (ref. index, position, strobe2_offset)|
| `MersIndexEntry` | `RefRandstrobeWithHash` | same as `RandstrobeOccurrence`, but stores also the hash|
| `kmer_lookup` | `RandstrobeMap` | hash table for looking up reference randstrobes by hash|
| `KmerLookupEntry` | `RandstrobeMapEntry` | result of looking up a randstrobe in `RandstrobeMap`|
| `mers_vector` | `RefRandstrobeVector` | vector of reference randstrobes|
| `QueryMer` | `QueryRandstrobe` | a randstrobe on a query sequence (hash, start, end, is_reverse)|
| `mers_vector_read` | `QueryRandstrobeVector`|


## Other changes

* Added `randstrobe_hash_t` typedef
* Removed the `ind_mers_vector` typedef and wrote `std::vector<RefRandstrobeWithHash>` directly instead (longer but clearer) where necessary.

## Possible further changes

* Some variable names should be changed to be in line with the above renames. I like the convention of having the variable name be the lowercase version of the class name (or at least a variant thereof). So `kmer_index` (which is of type `RandstrobeMap`) would become `randstrobe_map` for example. 
* The two other `...Vector` typedefs could perhaps also be removed, just like `ind_mers_vector`, because there isn’t much benefit of abbreviating e.g. `std::vector<QueryRandstrobe>` as `QueryRandstrobeVector`.

**Updated:** `RandstrobeOccurrence` → `RefRandstrobe`, `RandstrobeOccurrenceWithHash` → `RefRandstrobeWithHash`,  `RandstrobeVector` → `RefRandstrobeVector`
