### PR TITLE
Require read length to be provided if --create-index is used

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -130,7 +130,12 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
         exit(EXIT_FAILURE);
     }
     if (opt.reads_filename1.empty() && !opt.only_gen_index) {
-        std::cerr << "At least one file with reads must be specified." << std::endl;
+        std::cerr << "Error: At least one file with reads must be specified." << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    if (opt.only_gen_index && !(opt.r_set || !opt.reads_filename1.empty())) {
+        std::cerr << "Error: The target read length needs to be known when generating an index.\n"
+            "Use -r to set it explicitly or let the program estimate it by providing at least one read file.\n";
         exit(EXIT_FAILURE);
     }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -36,3 +36,6 @@ strobealign -r 150 -i tests/phix.fasta
 strobealign -r 150 --use-index tests/phix.fasta tests/phix.1.fastq | grep -v '^@PG' > with-sti.sam
 diff -u without-sti.sam with-sti.sam
 rm without-sti.sam with-sti.sam
+
+# Create index requires -r or reads file
+if strobealign --create-index tests/phix.fasta > /dev/null 2> /dev/null; then false; fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,32 +10,29 @@ if strobealign -G > /dev/null 2> /dev/null; then false; fi
 # should succeed when only printing help
 strobealign -h > /dev/null
 
-d=tests
-
 # Single-end SAM
-strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library -v $d/phix.fasta $d/phix.1.fastq | grep -v '^@PG' > phix.se.sam
+strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library -v tests/phix.fasta tests/phix.1.fastq | grep -v '^@PG' > phix.se.sam
 diff -u tests/phix.se.sam phix.se.sam
 rm phix.se.sam
 
 # Paired-end SAM
-strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library $d/phix.fasta $d/phix.1.fastq $d/phix.2.fastq | grep -v '^@PG' > phix.pe.sam
+strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library tests/phix.fasta tests/phix.1.fastq tests/phix.2.fastq | grep -v '^@PG' > phix.pe.sam
 diff -u tests/phix.pe.sam phix.pe.sam
 rm phix.pe.sam
 
 # Single-end PAF
-strobealign -x $d/phix.fasta $d/phix.1.fastq | tail > phix.se.paf
+strobealign -x tests/phix.fasta tests/phix.1.fastq | tail > phix.se.paf
 diff -u tests/phix.se.paf phix.se.paf
 rm phix.se.paf
 
 # Paired-end PAF
-strobealign -x $d/phix.fasta $d/phix.1.fastq $d/phix.2.fastq | tail > phix.pe.paf
+strobealign -x tests/phix.fasta tests/phix.1.fastq tests/phix.2.fastq | tail > phix.pe.paf
 diff -u tests/phix.pe.paf phix.pe.paf
 rm phix.pe.paf
 
 # Build a separate index
-strobealign -r 150 $d/phix.fasta $d/phix.1.fastq | grep -v '^@PG' > without-sti.sam
-strobealign -r 150 -i $d/phix.fasta
-strobealign -r 150 --use-index $d/phix.fasta $d/phix.1.fastq | grep -v '^@PG' > with-sti.sam
+strobealign -r 150 tests/phix.fasta tests/phix.1.fastq | grep -v '^@PG' > without-sti.sam
+strobealign -r 150 -i tests/phix.fasta
+strobealign -r 150 --use-index tests/phix.fasta tests/phix.1.fastq | grep -v '^@PG' > with-sti.sam
 diff -u without-sti.sam with-sti.sam
 rm without-sti.sam with-sti.sam
-


### PR DESCRIPTION
New error message:

```
$ strobealign --create-index tests/phix.fasta
Error: The target read length needs to be known when generating an index.
Use -r to set it explicitly or let the program estimate it by providing at least one read file.
```