### PR TITLE
Add commandline flag to suppress output of unmapped reads

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -614,7 +614,8 @@ inline void align_SE(
     const References& references,
     AlignmentStatistics &statistics,
     float dropoff,
-    int max_tries
+    int max_tries,
+    bool output_unmapped
 ) {
     auto query_acc = record.name;
     Read read(record.seq);
@@ -622,7 +623,9 @@ inline void align_SE(
     auto read_len = read.size();
 
     if (all_nams.empty()) {
-        sam.add_unmapped(record);
+        if (output_unmapped) {
+            sam.add_unmapped(record);
+        }
         return;
     }
 
@@ -791,7 +794,8 @@ static inline void align_SE_secondary_hits(
     AlignmentStatistics &statistics,
     float dropoff,
     int max_tries,
-    int max_secondary
+    int max_secondary,
+    bool output_unmapped
 ) {
     auto query_acc = record.name;
     Read read(record.seq);
@@ -799,7 +803,9 @@ static inline void align_SE_secondary_hits(
     auto read_len = read.size();
 
     if (all_nams.empty()) {
-        sam.add_unmapped(record);
+        if (output_unmapped) {
+            sam.add_unmapped(record);
+        }
         return;
     }
 
@@ -1821,7 +1827,8 @@ inline void align_PE(
     float dropoff,
     i_dist_est &isize_est,
     int max_tries,
-    size_t max_secondary
+    size_t max_secondary,
+    bool output_unmapped
 ) {
     const auto mu = isize_est.mu;
     const auto sigma = isize_est.sigma;
@@ -1831,7 +1838,9 @@ inline void align_PE(
 
     if (all_nams1.empty() && all_nams2.empty()) {
          // None of the reads have any NAMs
-        sam.add_unmapped_pair(record1, record2);
+        if (output_unmapped) {
+            sam.add_unmapped_pair(record1, record2);
+        }
         return;
     }
 
@@ -2271,7 +2280,8 @@ void align_PE_read(
                  record2,
                  index_parameters.k,
                  references, statistics,
-                 map_param.dropoff_threshold, isize_est, map_param.maxTries, map_param.max_secondary);
+                 map_param.dropoff_threshold, isize_est, map_param.maxTries, map_param.max_secondary,
+                 map_param.output_unmapped);
     }
     statistics.tot_extend += extend_timer.duration();
     nams1.clear();
@@ -2330,10 +2340,12 @@ void align_SE_read(
                 // Such overhead is not present in align_PE - which implements both options in the same function.
 
                 align_SE_secondary_hits(aln_params, sam, nams, record, index_parameters.k,
-                         references, statistics, map_param.dropoff_threshold, map_param.maxTries, map_param.max_secondary);
+                         references, statistics, map_param.dropoff_threshold, map_param.maxTries,
+                         map_param.max_secondary, map_param.output_unmapped);
             } else {
                 align_SE(aln_params, sam, nams, record, index_parameters.k,
-                         references, statistics,  map_param.dropoff_threshold, map_param.maxTries);
+                         references, statistics,  map_param.dropoff_threshold, map_param.maxTries,
+                         map_param.output_unmapped);
             }
         }
         statistics.tot_extend += extend_timer.duration();

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -614,18 +614,14 @@ inline void align_SE(
     const References& references,
     AlignmentStatistics &statistics,
     float dropoff,
-    int max_tries,
-    bool output_unmapped
-) {
+    int max_tries) {
     auto query_acc = record.name;
     Read read(record.seq);
     auto qual = record.qual;
     auto read_len = read.size();
 
     if (all_nams.empty()) {
-        if (output_unmapped) {
-            sam.add_unmapped(record);
-        }
+        sam.add_unmapped(record);
         return;
     }
 
@@ -794,18 +790,14 @@ static inline void align_SE_secondary_hits(
     AlignmentStatistics &statistics,
     float dropoff,
     int max_tries,
-    int max_secondary,
-    bool output_unmapped
-) {
+    int max_secondary) {
     auto query_acc = record.name;
     Read read(record.seq);
     auto qual = record.qual;
     auto read_len = read.size();
 
     if (all_nams.empty()) {
-        if (output_unmapped) {
-            sam.add_unmapped(record);
-        }
+        sam.add_unmapped(record);
         return;
     }
 
@@ -1827,8 +1819,7 @@ inline void align_PE(
     float dropoff,
     i_dist_est &isize_est,
     int max_tries,
-    size_t max_secondary,
-    bool output_unmapped
+    size_t max_secondary
 ) {
     const auto mu = isize_est.mu;
     const auto sigma = isize_est.sigma;
@@ -1838,9 +1829,7 @@ inline void align_PE(
 
     if (all_nams1.empty() && all_nams2.empty()) {
          // None of the reads have any NAMs
-        if (output_unmapped) {
-            sam.add_unmapped_pair(record1, record2);
-        }
+        sam.add_unmapped_pair(record1, record2);
         return;
     }
 
@@ -2280,8 +2269,7 @@ void align_PE_read(
                  record2,
                  index_parameters.k,
                  references, statistics,
-                 map_param.dropoff_threshold, isize_est, map_param.maxTries, map_param.max_secondary,
-                 map_param.output_unmapped);
+                 map_param.dropoff_threshold, isize_est, map_param.maxTries, map_param.max_secondary);
     }
     statistics.tot_extend += extend_timer.duration();
     nams1.clear();
@@ -2341,11 +2329,10 @@ void align_SE_read(
 
                 align_SE_secondary_hits(aln_params, sam, nams, record, index_parameters.k,
                          references, statistics, map_param.dropoff_threshold, map_param.maxTries,
-                         map_param.max_secondary, map_param.output_unmapped);
+                         map_param.max_secondary);
             } else {
                 align_SE(aln_params, sam, nams, record, index_parameters.k,
-                         references, statistics,  map_param.dropoff_threshold, map_param.maxTries,
-                         map_param.output_unmapped);
+                         references, statistics,  map_param.dropoff_threshold, map_param.maxTries);
             }
         }
         statistics.tot_extend += extend_timer.duration();

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -91,6 +91,7 @@ struct mapping_params {
     int maxTries { 20 };
     int rescue_cutoff;
     bool is_sam_out { true };
+    bool output_unmapped { true };
 };
 
 class i_dist_est {

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -26,6 +26,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::ValueFlag<std::string> o(parser, "PATH", "redirect output to file [stdout]", {'o'});
     args::Flag v(parser, "v", "Verbose output", {'v'});
     args::Flag x(parser, "x", "Only map reads, no base level alignment (produces PAF file)", {'x'});
+    args::Flag U(parser, "U", "Suppress output of unmapped reads", {'U'});
     args::ValueFlag<std::string> rgid(parser, "ID", "Read group ID", {"rg-id"});
     args::ValueFlagList<std::string> rg(parser, "TAG:VALUE", "Add read group metadata to SAM header (can be specified multiple times). Example: SM:samplename", {"rg"});
 
@@ -84,6 +85,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (o) { opt.output_file_name = args::get(o); opt.write_to_stdout = false; }
     if (v) { opt.verbose = true; }
     if (x) { opt.is_sam_out = false; }
+    if (U) { opt.output_unmapped = false; }
     if (rgid) { opt.read_group_id = args::get(rgid); }
     if (rg) { opt.read_group_fields = args::get(rg); }
     if (N) { opt.max_secondary = args::get(N); }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -19,6 +19,7 @@ struct CommandLineOptions {
     bool only_gen_index { false };
     bool use_index { false };
     bool is_sam_out { true };
+    bool output_unmapped { true };
     int max_secondary { 0 };
 
     // Seeding

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,7 @@ int run_strobealign(int argc, char **argv) {
     map_param.R = opt.R;
     map_param.maxTries = opt.maxTries;
     map_param.is_sam_out = opt.is_sam_out;
+    map_param.output_unmapped = opt.output_unmapped;
 
     log_parameters(index_parameters, map_param, aln_params);
     logger.debug() << "Threads: " << opt.n_threads << std::endl;

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -95,7 +95,7 @@ void perform_task_PE(
 
         std::string sam_out;
         sam_out.reserve(7*map_param.r *records1.size());
-        Sam sam{sam_out, references, read_group_id};
+        Sam sam{sam_out, references, read_group_id, map_param.output_unmapped};
         for (size_t i = 0; i < records1.size(); ++i) {
             auto record1 = records1[i];
             auto record2 = records2[i];
@@ -132,7 +132,7 @@ void perform_task_SE(
 
         std::string sam_out;
         sam_out.reserve(7*map_param.r *records.size());
-        Sam sam{sam_out, references, read_group_id};
+        Sam sam{sam_out, references, read_group_id, map_param.output_unmapped};
         for (size_t i = 0; i < records.size(); ++i) {
             auto record = records[i];
             to_uppercase(record.seq);

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -29,6 +29,9 @@ void Sam::append_tail() {
 }
 
 void Sam::add_unmapped(const KSeq& record, int flags) {
+    if (!output_unmapped) {
+        return;
+    }
     assert((flags & ~(UNMAP|PAIRED|MUNMAP|READ1|READ2)) == 0);
     assert(flags & UNMAP);
     sam_string.append(record.name);

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -37,9 +37,10 @@ enum SamFlags {
 class Sam {
 
 public:
-    Sam(std::string& sam_string, const References& references, const std::string& read_group_id = "")
+    Sam(std::string& sam_string, const References& references, const std::string& read_group_id = "", bool output_unmapped = true)
         : sam_string(sam_string)
-        , references(references) {
+        , references(references)
+        , output_unmapped(output_unmapped) {
             if (read_group_id.empty()) {
                 tail = "\n";
             } else {
@@ -61,6 +62,7 @@ private:
     std::string& sam_string;
     const References& references;
     std::string tail;
+    bool output_unmapped;
 };
 
 bool is_proper_pair(const alignment& sam_aln1, const alignment& sam_aln2, float mu, float sigma);


### PR DESCRIPTION
This PR introduces a -U parameter to suppress the output of unmapped reads.

See https://github.com/ksahlin/strobealign/issues/206