### PR TITLE
Show a progress indicator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Strobealign Changelog
 
+## development version
+
+* Add progress report (only shown if output is not a terminal and can be
+  disabled with `--no-progress`)
+
 ## v0.8.0 (2023-02-01)
 
 ### Summary

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -59,6 +59,7 @@ struct AlignmentStatistics {
     std::chrono::duration<double> tot_extend;
     std::chrono::duration<double> tot_write_file;
 
+    unsigned int n_reads = 0;
     unsigned int tot_ksw_aligned = 0;
     unsigned int tot_rescued = 0;
     unsigned int tot_all_tried = 0;
@@ -74,6 +75,7 @@ struct AlignmentStatistics {
         this->tot_sort_nams += other.tot_sort_nams;
         this->tot_extend += other.tot_extend;
         this->tot_write_file += other.tot_write_file;
+        this->n_reads += other.n_reads;
         this->tot_ksw_aligned += other.tot_ksw_aligned;
         this->tot_rescued += other.tot_rescued;
         this->tot_all_tried += other.tot_all_tried;

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -25,6 +25,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::Group io(parser, "Input/output:");
     args::ValueFlag<std::string> o(parser, "PATH", "redirect output to file [stdout]", {'o'});
     args::Flag v(parser, "v", "Verbose output", {'v'});
+    args::Flag no_progress(parser, "no-progress", "Disable progress report (enabled by default if output is a terminal)", {"no-progress"});
     args::Flag x(parser, "x", "Only map reads, no base level alignment (produces PAF file)", {'x'});
     args::Flag U(parser, "U", "Suppress output of unmapped reads", {'U'});
     args::Flag interleaved(parser, "interleaved", "Interleaved input", {"interleaved"});
@@ -85,6 +86,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     // Input/output
     if (o) { opt.output_file_name = args::get(o); opt.write_to_stdout = false; }
     if (v) { opt.verbose = true; }
+    if (no_progress) { opt.show_progress = false; }
     if (x) { opt.is_sam_out = false; }
     if (U) { opt.output_unmapped = false; }
     if (rgid) { opt.read_group_id = args::get(rgid); }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -13,6 +13,7 @@ struct CommandLineOptions {
     std::string output_file_name;
     bool write_to_stdout { true };
     bool verbose { false };
+    bool show_progress { true };
     std::string read_group_id { "" };
     std::vector<std::string> read_group_fields;
     std::string logfile_name { "" };

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -136,6 +136,7 @@ void perform_task(
     InputBuffer &input_buffer,
     OutputBuffer &output_buffer,
     AlignmentStatistics& statistics,
+    int& done,
     const alignment_params &aln_params,
     const mapping_params &map_param,
     const IndexParameters& index_parameters,
@@ -169,13 +170,16 @@ void perform_task(
             strip_suffix(record2.name);
             align_PE_read(record1, record2, sam, sam_out, statistics, isize_est, aln_params,
                         map_param, index_parameters, references, index);
+            statistics.n_reads += 2;
         }
         for (size_t i = 0; i < records3.size(); ++i) {
             auto record = records3[i];
             strip_suffix(record.name);
             align_SE_read(record, sam, sam_out, statistics, aln_params, map_param, index_parameters, references, index);
+            statistics.n_reads++;
         }
         output_buffer.output_records(std::move(sam_out), chunk_index);
         assert(sam_out == "");
     }
+    done = true;
 }

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -64,7 +64,7 @@ public:
 
 
 void perform_task(InputBuffer &input_buffer, OutputBuffer &output_buffer,
-                  AlignmentStatistics& statistics, const alignment_params &aln_params,
+                  AlignmentStatistics& statistics, int& done, const alignment_params &aln_params,
                   const mapping_params &map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index, const std::string& read_group_id);
 
 #endif


### PR DESCRIPTION
I don’t know if this is your style, but I have added something similar to other programs, and I found it made the output just a tad friendlier.

During mapping, this progress indicator displays the number of mapped reads and the average (wall-clock) time per spent per read. 

Because the runtime per read fluctuates a bit in the beginning, the progress indicator is shown only after the first second to ensure we don’t have misleading numbers on the screen in case only a small number of reads were mapped.

Also, the progress indicator is only shown if the program is run interactively (when stderr is an actual terminal) to avoid cluttering log files when the user redirects stderr.

Totally fine with me if you don’t want this.

Animated preview:
[![asciicast](https://asciinema.org/a/JRtBxNjRvTxph3IJpBe4P6mAB.svg)](https://asciinema.org/a/JRtBxNjRvTxph3IJpBe4P6mAB)
