### PR TITLE
Fix has_shared_substring omitting some l-mers

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -695,7 +695,7 @@ bool has_shared_substring(const std::string& read_seq, const std::string& ref_se
     int sub_size = 2 * k / 3;
     int step_size = k / 3;
     std::string submer;
-    for (size_t i = 0; i + k <= read_seq.size(); i += step_size) {
+    for (size_t i = 0; i + sub_size < read_seq.size(); i += step_size) {
         submer = read_seq.substr(i, sub_size);
         if (ref_seq.find(submer) != std::string::npos) {
             return true;

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=2a8797bfffc1dfdc8fdd064af8e4a931529e1280
+baseline_commit=95f0492c1e6e7f46edec8d3d76f306fac44fe171


### PR DESCRIPTION
The iteration stopped a bit too early and therefore did not generate all possible l-mers.

`has_shared_subtring` is a heuristic used in `rescue_mate`. If query and reference do not share any substrings of length $l=\frac23k$, the read is marked as unmapped and no rescue is attempted.

This increases accuracy slightly for very short reads (50 bp).
* CHM13: 90.46475 → 90.48315
* fruit fly: 90.0643 → 90.0838

This changes how often rescue and alignment is done. For CHM13 (2x50):

* Total calls to ssw: 1972617 → 2003581
* Calls to ksw (rescue mode): 1257900 → 1288864

So probably runtime increases (the increase in ssw calls is much lower for the higher read lengths).

It appears to me that the behavior is a bug and should be fixed. If there’s a reason to not look at the last l-mers in the read, then this should be documented. If we want to avoid the runtime penalty, we should think about other ways of improve the heuristic.

But maybe this discussion becomes moot when WFA2 is integrated ... We can just leave this PR upon until then.