### PR TITLE
Add support for gzipped references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Add progress report (only shown if output is not a terminal and can be
   disabled with `--no-progress`)
+* Support gzip-compressed references. Thanks @luispedro
 
 ## v0.8.0 (2023-02-01)
 

--- a/src/refs.cpp
+++ b/src/refs.cpp
@@ -3,52 +3,115 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
+#include <zlib.h>
 
 /* Convert string to uppercase in-place */
 void to_uppercase(std::string& s) {
         std::transform(s.begin(), s.end(), s.begin(),
         [](unsigned char c) {
             return c & ~32;
+        });
+    }
+
+namespace {
+
+unsigned char to_uppercase1(unsigned char c) {
+    return c & ~32;
+}
+class GZFile {
+public:
+    GZFile(const std::string& filename, const char* mode) {
+        file_ = gzopen(filename.c_str(), mode);
+        if (!file_) {
+            throw InvalidFasta("Could not open file " + filename);
         }
-    );
+    }
+    ~GZFile() {
+        gzclose(file_);
+    }
+    int getc() {
+        return gzgetc(file_);
+    }
+
+private:
+    gzFile file_;
+};
+
+enum struct State {
+    Start,
+    Header,
+    HeaderRest,
+    Sequence,
+    EOL
+};
+
 }
 
 References References::from_fasta(const std::string& filename) {
     std::vector<std::string> sequences;
     ref_names names;
 
-    std::ifstream file(filename);
+    GZFile gf(filename, "r");
 
-    if (!file.good()) {
-        throw InvalidFasta("Cannot read from FASTA file");
-    }
-
-    auto c = file.peek();
-    if (c != '>') {
-        std::ostringstream oss;
-        oss << "FASTA file must begin with '>' character, not '"
-            << static_cast<unsigned char>(c) << "'";
-        throw InvalidFasta(oss.str().c_str());
-    }
-
-    std::string line, seq, name;
-    bool eof = false;
-    do {
-        eof = !bool{getline(file, line)};
-        if (eof || (!line.empty() && line[0] == '>')) {
-            if (seq.length() > 0) {
-                to_uppercase(seq);
-                sequences.push_back(seq);
-                names.push_back(name);
+    std::string name, seq;
+    auto state = State::Start;
+    while (true) {
+        const int c = gf.getc();
+        if (c == EOF) {
+            if (seq != "") {
+                names.push_back(std::move(name));
+                sequences.push_back(std::move(seq));
             }
-            if (!eof) {
-                name = line.substr(1, line.find(' ') - 1); // cut at first space
-            }
-            seq = "";
-        } else {
-            seq += line;
+            break;
         }
-    } while (!eof);
+        // If we see a newline, we move to EOL state and ignore the input
+        // character (except if it happens to be the very first character in
+        // the file).
+        if (c == '\n' && state != State::Start) {
+            state = State::EOL;
+            continue;
+        }
+        switch (state) {
+            case State::Start:
+                if (c == '>') {
+                    state = State::Header;
+                } else {
+                    std::ostringstream oss;
+                    oss << "FASTA file ('" << filename << "') must begin with '>' character, not '"
+                        << static_cast<unsigned char>(c) << "'";
+                    throw InvalidFasta(oss.str());
+                }
+                break;
+            case State::Header:
+                if (c == ' ') {
+                    state = State::HeaderRest;
+                } else {
+                    name += static_cast<char>(c);
+                }
+                break;
+            case State::HeaderRest:
+                // Ignore everything until the end of the line
+                break;
+            case State::Sequence:
+                seq += to_uppercase1(static_cast<char>(c));
+                break;
+            case State::EOL:
+                if (c == '>') {
+                    state = State::Header;
+                    if (seq != "") {
+                        names.push_back(std::move(name));
+                        sequences.push_back(std::move(seq));
+                    }
+
+                    name.clear();
+                    seq.clear();
+                } else {
+                    seq += to_uppercase1(static_cast<char>(c));
+                    state = State::Sequence;
+                }
+                break;
+            }
+    }
 
     return References(std::move(sequences), std::move(names));
 }

--- a/src/refs.hpp
+++ b/src/refs.hpp
@@ -31,6 +31,7 @@ public:
 
     void add(std::string&& name, std::string&& sequence);
 
+    /* Read references from a FASTA file (including gzipped files) */
     static References from_fasta(const std::string& filename);
 
     size_t size() const {

--- a/tests/test_refs.cpp
+++ b/tests/test_refs.cpp
@@ -1,4 +1,6 @@
 #include <fstream>
+#include <zlib.h>
+
 #include "doctest.h"
 #include "refs.hpp"
 
@@ -42,6 +44,29 @@ TEST_CASE("Reference uppercase") {
             << ">empty_at_end_of_file";
     }
     auto refs = References::from_fasta("tmpref.fasta");
+    std::remove("tmpref.fasta");
+    CHECK(refs.sequences.size() == 2);
+    CHECK(refs.sequences[0].size() == 4);
+    CHECK(refs.sequences[0] == "ACGT");
+    CHECK(refs.sequences[1].size() == 8);
+    CHECK(refs.sequences[1] == "AACCGGTT");
+    CHECK(refs.names.size() == 2);
+    CHECK(refs.lengths.size() == 2);
+}
+
+// Copy & pasted from the above, but with a gzipped file
+TEST_CASE("Reference gzipped") {
+    {
+        gzFile writer = gzopen("tmpref.fasta.gz", "w");
+        gzputs(writer, ">ref1\n");
+        gzputs(writer, "acgt\n\n");
+        gzputs(writer, ">ref2\n");
+        gzputs(writer, "aacc\ngg\n\ntt\n");
+        gzputs(writer, ">empty\n");
+        gzputs(writer, ">empty_at_end_of_file");
+        gzclose(writer);
+    }
+    auto refs = References::from_fasta("tmpref.fasta.gz");
     std::remove("tmpref.fasta");
     CHECK(refs.sequences.size() == 2);
     CHECK(refs.sequences[0].size() == 4);


### PR DESCRIPTION
Since `zlib.h` was already used, this does not require any new dependencies, but it was easier to change the FASTA parser to work _char by char_ as it matches the `zlib.h` structure better.