### PR TITLE
Script for comparing the current commit against the "baseline" commit

### DIFF
--- a/tests/compare-baseline.sh
+++ b/tests/compare-baseline.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Run strobealign on some test data and compare the output against what the
+# baseline version produces.
+#
+# - Test data is automatically downloaded if needed
+#   (and put into tests/drosophila)
+# - The baseline BAM file is generated if necessary
+
+set -euo pipefail
+
+# Fail early if pysam is missing
+python3 -c 'import pysam'
+
+# Ensure test data is available
+tests/download.sh
+ref=tests/drosophila/ref.fasta
+reads=(tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz)
+
+source tests/baseline-commit.txt
+
+baseline_bam=baseline/baseline-${baseline_commit}.bam
+baseline_binary=baseline/strobealign-${baseline_commit}
+cmake_options=-DCMAKE_BUILD_TYPE=RelWithDebInfo
+
+# Generate the baseline BAM if necessary
+mkdir -p baseline
+if ! test -f ${baseline_bam}; then
+  if ! test -f ${baseline_binary}; then
+    srcdir=$(mktemp -p . -d compile.XXXXXXX)
+    git clone . ${srcdir}
+    ( cd ${srcdir} && git checkout ${baseline_commit} )
+    cmake ${srcdir} -B ${srcdir}/build ${cmake_options}
+    if ! make -j 4 -C ${srcdir}/build strobealign; then
+      exit 1
+    fi
+    mv ${srcdir}/build/strobealign ${baseline_binary}
+    rm -rf "${srcdir}"
+  fi
+  ${baseline_binary} -t 4 ${ref} ${reads[@]} | samtools view -o ${baseline_bam}
+fi
+
+# Run strobealign. This recompiles from scratch to ensure we use consistent
+# compiler options.
+builddir=$(mktemp -p . -d build.XXXXXXX)
+cmake . -B ${builddir} ${cmake_options}
+make -j 4 -C ${builddir} strobealign
+set -x
+${builddir}/strobealign -t 4 ${ref} ${reads[@]} | samtools view -o head.bam
+rm -rf ${builddir}
+
+# Do the actual comparison
+tests/samdiff.py ${baseline_bam} head.bam

--- a/tests/download.sh
+++ b/tests/download.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# Test StrobeAlign on a small, but non-toy dataset
+# Download a small test dataset (D. melanogaster genome and some reads from the SRA)
 
-# Downlad data
 mkdir -p tests/drosophila
 cd tests/drosophila
 
@@ -20,4 +19,3 @@ for r in 1 2; do
       mv ${f}.tmp ${f}
     fi
 done
-


### PR DESCRIPTION
We’ve been using something like this in CI, but this is a version that can be run locally. I’ve been using this script for a while and found it very helpful. I run it manually whenever I made a nontrivial change that could change mapping results.