### PR TITLE
Correctly initialize AlignmentStatistics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
-add_compile_options(-Wall -Wextra)
+add_compile_options(-Wall -Wextra -Werror=maybe-uninitialized)
 
 FetchContent_Declare(cmake_git_version_tracking
   GIT_REPOSITORY https://github.com/andrew-hardin/cmake-git-version-tracking.git

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -27,14 +27,14 @@ struct aln_info {
 };
 
 struct AlignmentStatistics {
-    std::chrono::duration<double> tot_read_file;
-    std::chrono::duration<double> tot_construct_strobemers;
-    std::chrono::duration<double> tot_find_nams;
-    std::chrono::duration<double> tot_time_rescue;
-    std::chrono::duration<double> tot_find_nams_alt;
-    std::chrono::duration<double> tot_sort_nams;
-    std::chrono::duration<double> tot_extend;
-    std::chrono::duration<double> tot_write_file;
+    std::chrono::duration<double> tot_read_file{0};
+    std::chrono::duration<double> tot_construct_strobemers{0};
+    std::chrono::duration<double> tot_find_nams{0};
+    std::chrono::duration<double> tot_time_rescue{0};
+    std::chrono::duration<double> tot_find_nams_alt{0};
+    std::chrono::duration<double> tot_sort_nams{0};
+    std::chrono::duration<double> tot_extend{0};
+    std::chrono::duration<double> tot_write_file{0};
 
     unsigned int n_reads = 0;
     unsigned int tot_aligner_calls = 0;


### PR DESCRIPTION
I got complaints from valgrind and also the compiler has been warning about this for a while. This finally fixes that and also changes the compiler settings so that this type of problem becomes an error in the future (`-Werror=maybe-uninitialized`).