### PR TITLE
Clean up NAMs a little bit

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1546,20 +1546,19 @@ void align_PE_read(
     Timer nam_timer;
     std::vector<nam> nams1;
     std::vector<nam> nams2;
-    std::pair<float, int> info1, info2;
-    info1 = find_nams(nams1, query_randstrobes1, index);
-    info2 = find_nams(nams2, query_randstrobes2, index);
+    auto nonrepetitive_fraction1 = find_nams(nams1, query_randstrobes1, index);
+    auto nonrepetitive_fraction2 = find_nams(nams2, query_randstrobes2, index);
     statistics.tot_find_nams += nam_timer.duration();
 
     if (map_param.R > 1) {
         Timer rescue_timer;
-        if (nams1.empty() || info1.first < 0.7) {
+        if (nams1.empty() || nonrepetitive_fraction1 < 0.7) {
             statistics.tried_rescue += 1;
             nams1.clear();
             find_nams_rescue(nams1, query_randstrobes1, index, map_param.rescue_cutoff);
         }
 
-        if (nams2.empty() || info2.first < 0.7) {
+        if (nams2.empty() || nonrepetitive_fraction2 < 0.7) {
             statistics.tried_rescue += 1;
             nams2.clear();
             find_nams_rescue(nams2, query_randstrobes2, index, map_param.rescue_cutoff);
@@ -1616,12 +1615,12 @@ void align_SE_read(
     // Find NAMs
     Timer nam_timer;
     std::vector<nam> nams;
-    std::pair<float, int> info = find_nams(nams, query_randstrobes, index);
+    auto nonrepetitive_fraction = find_nams(nams, query_randstrobes, index);
     statistics.tot_find_nams += nam_timer.duration();
 
     if (map_param.R > 1) {
         Timer rescue_timer;
-        if (nams.empty() || info.first < 0.7) {
+        if (nams.empty() || nonrepetitive_fraction < 0.7) {
             statistics.tried_rescue += 1;
             nams.clear();
             find_nams_rescue(nams, query_randstrobes, index, map_param.rescue_cutoff);

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1533,19 +1533,13 @@ void align_PE_read(
     const References& references,
     const StrobemerIndex& index
 ) {
-    QueryRandstrobeVector query_randstrobes1, query_randstrobes2;
-
-    // generate mers here
     Timer strobe_timer;
-
-    query_randstrobes1 = randstrobes_query(
+    auto query_randstrobes1 = randstrobes_query(
         index_parameters.k, index_parameters.w_min, index_parameters.w_max, record1.seq, index_parameters.s, index_parameters.t_syncmer,
         index_parameters.q, index_parameters.max_dist);
-
-    query_randstrobes2 = randstrobes_query(
+    auto query_randstrobes2 = randstrobes_query(
         index_parameters.k, index_parameters.w_min, index_parameters.w_max, record2.seq, index_parameters.s, index_parameters.t_syncmer,
         index_parameters.q, index_parameters.max_dist);
-
     statistics.tot_construct_strobemers += strobe_timer.duration();
 
     // Find NAMs
@@ -1573,7 +1567,6 @@ void align_PE_read(
         statistics.tot_time_rescue += rescue_timer.duration();
     }
 
-    //Sort hits based on start choordinate on query sequence
     Timer nam_sort_timer;
     std::sort(nams1.begin(), nams1.end(), score);
     std::sort(nams2.begin(), nams2.end(), score);
@@ -1602,8 +1595,6 @@ void align_PE_read(
                  map_param.dropoff_threshold, isize_est, map_param.maxTries, map_param.max_secondary);
     }
     statistics.tot_extend += extend_timer.duration();
-    nams1.clear();
-    nams2.clear();
 }
 
 
@@ -1618,15 +1609,13 @@ void align_SE_read(
     const References& references,
     const StrobemerIndex& index
 ) {
-    std::vector<nam> nams;
-
-    // generate mers here
     Timer strobe_timer;
     auto query_randstrobes = randstrobes_query(index_parameters.k, index_parameters.w_min, index_parameters.w_max, record.seq, index_parameters.s, index_parameters.t_syncmer, index_parameters.q, index_parameters.max_dist);
     statistics.tot_construct_strobemers += strobe_timer.duration();
 
     // Find NAMs
     Timer nam_timer;
+    std::vector<nam> nams;
     std::pair<float, int> info = find_nams(nams, query_randstrobes, index);
     statistics.tot_find_nams += nam_timer.duration();
 
@@ -1640,7 +1629,6 @@ void align_SE_read(
         statistics.tot_time_rescue += rescue_timer.duration();
     }
 
-    // Sort hits by score
     Timer nam_sort_timer;
     std::sort(nams.begin(), nams.end(), score);
     statistics.tot_sort_nams += nam_sort_timer.duration();
@@ -1657,5 +1645,4 @@ void align_SE_read(
         );
     }
     statistics.tot_extend += extend_timer.duration();
-    nams.clear();
 }

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -12,13 +12,13 @@ using namespace klibpp;
 
 static inline alignment get_alignment(
     const Aligner& aligner,
-    const nam &n,
+    const Nam &n,
     const References& references,
     const Read& read,
     bool fits
 );
 
-static inline bool score(const nam &a, const nam &b) {
+static inline bool score(const Nam &a, const Nam &b) {
     return a.score > b.score;
 }
 
@@ -195,7 +195,7 @@ aln_info hamming_align(
  *   in place and return true.
  * - If first and last strobe do not match consistently, return false.
  */
-bool reverse_nam_if_needed(nam& n, const Read& read, const References& references, int k) {
+bool reverse_nam_if_needed(Nam& n, const Read& read, const References& references, int k) {
     auto read_len = read.size();
     std::string ref_start_kmer = references.sequences[n.ref_id].substr(n.ref_s, k);
     std::string ref_end_kmer = references.sequences[n.ref_id].substr(n.ref_e-k, k);
@@ -233,7 +233,7 @@ bool reverse_nam_if_needed(nam& n, const Read& read, const References& reference
 static inline void align_SE_secondary_hits(
     const Aligner& aligner,
     Sam& sam,
-    std::vector<nam> &all_nams,
+    std::vector<Nam>& all_nams,
     const KSeq& record,
     int k,
     const References& references,
@@ -252,7 +252,7 @@ static inline void align_SE_secondary_hits(
     std::vector<alignment> alignments;
     int cnt = 0;
     float score_dropoff;
-    nam n_max = all_nams[0];
+    Nam n_max = all_nams[0];
 
     int best_align_dist = ~0U >> 1;
     int best_align_sw_score = -1000;
@@ -389,7 +389,7 @@ static inline alignment align_segment(
 
 static inline alignment get_alignment(
     const Aligner& aligner,
-    const nam &n,
+    const Nam &n,
     const References& references,
     const Read& read,
     bool fits
@@ -440,7 +440,7 @@ static inline alignment get_alignment(
 
 static inline alignment get_alignment_unused(
     const Aligner& aligner,
-    const nam &n,
+    const Nam &n,
     const References& references,
     const Read& read,
     int k,
@@ -680,12 +680,12 @@ static inline alignment get_alignment_unused(
 
 
 
-static inline int get_MAPQ(const std::vector<nam> &all_nams, const nam &n_max) {
+static inline int get_MAPQ(const std::vector<Nam> &all_nams, const Nam &n_max) {
     const float s1 = n_max.score;
     if (all_nams.size() <= 1) {
         return 60;
     }
-    const nam n_second = all_nams[1];
+    const Nam n_second = all_nams[1];
     const float s2 = n_second.score;
     // from minimap2: MAPQ = 40(1−s2/s1) ·min{1,|M|/10} · log s1
     const float min_matches = std::min(n_max.n_hits / 10.0, 1.0);
@@ -756,13 +756,13 @@ static inline void get_best_scoring_pair(
     std::sort(high_scores.begin(), high_scores.end(), sort_scores); // Sorting by highest score first
 }
 
-static inline std::vector<std::tuple<int,nam,nam>> get_best_scoring_NAM_locations(
-    const std::vector<nam> &all_nams1,
-    const std::vector<nam> &all_nams2,
+static inline std::vector<std::tuple<int,Nam,Nam>> get_best_scoring_NAM_locations(
+    const std::vector<Nam> &all_nams1,
+    const std::vector<Nam> &all_nams2,
     float mu,
     float sigma
 ) {
-    std::vector<std::tuple<int,nam,nam>> joint_NAM_scores;
+    std::vector<std::tuple<int,Nam,Nam>> joint_NAM_scores;
     if (all_nams1.empty() && all_nams2.empty()) {
         return joint_NAM_scores;
     }
@@ -791,7 +791,7 @@ static inline std::vector<std::tuple<int,nam,nam>> get_best_scoring_NAM_location
 //                    int diff2 = (n2.query_e - n2.query_s) - (n2.ref_e - n2.ref_s);
 //                    int  n2_penalty = diff2 > 0 ? diff2 : - diff2;
                     joint_hits = n1.n_hits + n2.n_hits; // - n1_penalty - n2_penalty; // trying out idea about penalty but it needs to be on the individual seed level - to late on merged match level.
-                    std::tuple<int, nam, nam> t (joint_hits, n1, n2);
+                    std::tuple<int, Nam, Nam> t (joint_hits, n1, n2);
                     joint_NAM_scores.push_back(t);
                     added_n1.insert(n1.nam_id);
                     added_n2.insert(n2.nam_id);
@@ -803,7 +803,7 @@ static inline std::vector<std::tuple<int,nam,nam>> get_best_scoring_NAM_location
         }
     }
 
-    nam dummy_nan;
+    Nam dummy_nan;
     dummy_nan.ref_s = -1;
     if (!all_nams1.empty()) {
         int hjss1 = hjss > 0 ? hjss : all_nams1[0].n_hits;
@@ -817,7 +817,7 @@ static inline std::vector<std::tuple<int,nam,nam>> get_best_scoring_NAM_location
 //            int diff1 = (n1.query_e - n1.query_s) - (n1.ref_e - n1.ref_s);
 //            int  n1_penalty = diff1 > 0 ? diff1 : - diff1;
             joint_hits = n1.n_hits;
-            std::tuple<int, nam, nam> t (joint_hits, n1, dummy_nan);
+            std::tuple<int, Nam, Nam> t{joint_hits, n1, dummy_nan};
             joint_NAM_scores.push_back(t);
         }
     }
@@ -836,7 +836,7 @@ static inline std::vector<std::tuple<int,nam,nam>> get_best_scoring_NAM_location
 //            int  n2_penalty = diff2 > 0 ? diff2 : - diff2;
             joint_hits = n2.n_hits;
             //                        std::cerr << S << " individual score " << x << " " << std::endl;
-            std::tuple<int, nam, nam> t (joint_hits, dummy_nan, n2);
+            std::tuple<int, Nam, Nam> t{joint_hits, dummy_nan, n2};
             joint_NAM_scores.push_back(t);
         }
     }
@@ -847,7 +847,7 @@ static inline std::vector<std::tuple<int,nam,nam>> get_best_scoring_NAM_location
     std::sort(
         joint_NAM_scores.begin(),
         joint_NAM_scores.end(),
-        [](const std::tuple<int, nam, nam> &a, const std::tuple<int, nam, nam> &b) -> bool {
+        [](const std::tuple<int, Nam, Nam>& a, const std::tuple<int, Nam, Nam>& b) -> bool {
             return std::get<0>(a) > std::get<0>(b);
         }
     ); // Sort by highest score first
@@ -874,7 +874,7 @@ bool has_shared_substring(const std::string& read_seq, const std::string& ref_se
 
 static inline void rescue_mate(
     const Aligner& aligner,
-    nam &n,
+    Nam &n,
     const References& references,
     const Read& guide,
     const Read& read,
@@ -969,7 +969,7 @@ void rescue_read(
     const Read& read1,  // read that has NAMs
     const Aligner& aligner,
     const References& references,
-    std::vector<nam> &all_nams1,
+    std::vector<Nam> &all_nams1,
     int max_tries,
     float dropoff,
     AlignmentStatistics &statistics,
@@ -984,7 +984,7 @@ void rescue_read(
     bool swap_r1r2  // TODO get rid of this
 ) {
     float score_dropoff1;
-    nam n_max1 = all_nams1[0];
+    Nam n_max1 = all_nams1[0];
     int cnt1 = 0;
 
     std::vector<alignment> aln_scores1;
@@ -1118,8 +1118,8 @@ std::pair<int, int> joint_mapq_from_high_scores(const std::vector<std::tuple<dou
 inline void align_PE(
     const Aligner& aligner,
     Sam &sam,
-    std::vector<nam> &all_nams1,
-    std::vector<nam> &all_nams2,
+    std::vector<Nam> &all_nams1,
+    std::vector<Nam> &all_nams2,
     const KSeq &record1,
     const KSeq &record2,
     int k,
@@ -1195,8 +1195,8 @@ inline void align_PE(
 
     int cnt = 0;
     double S = 0.0;
-    nam n_max1 = all_nams1[0];
-    nam n_max2 = all_nams2[0];
+    Nam n_max1 = all_nams1[0];
+    Nam n_max2 = all_nams2[0];
 
     float score_dropoff1 = all_nams1.size() > 1 ? (float) all_nams1[1].n_hits / n_max1.n_hits : 0.0;
     float score_dropoff2 = all_nams2.size() > 1 ? (float) all_nams2[1].n_hits / n_max2.n_hits : 0.0;
@@ -1243,7 +1243,7 @@ inline void align_PE(
     // Get top hit counts for all locations. The joint hit count is the sum of hits of the two mates. Then align as long as score dropoff or cnt < 20
 
     // (score, aln1, aln2)
-    std::vector<std::tuple<int,nam,nam>> joint_NAM_scores = get_best_scoring_NAM_locations(all_nams1, all_nams2, mu, sigma);
+    std::vector<std::tuple<int,Nam,Nam>> joint_NAM_scores = get_best_scoring_NAM_locations(all_nams1, all_nams2, mu, sigma);
     auto nam_max = joint_NAM_scores[0];
     auto max_score = std::get<0>(nam_max);
 
@@ -1442,9 +1442,9 @@ inline void align_PE(
 }
 
 
-inline void get_best_map_location(std::vector<nam> &nams1, std::vector<nam> &nams2, i_dist_est &isize_est, nam &best_nam1,  nam &best_nam2 ) {
-    std::vector<std::tuple<int,nam,nam>> joint_NAM_scores = get_best_scoring_NAM_locations(nams1, nams2, isize_est.mu, isize_est.sigma);
-    nam n1_joint_max, n2_joint_max, n1_indiv_max, n2_indiv_max;
+inline void get_best_map_location(std::vector<Nam> &nams1, std::vector<Nam> &nams2, i_dist_est &isize_est, Nam &best_nam1,  Nam &best_nam2 ) {
+    std::vector<std::tuple<int,Nam,Nam>> joint_NAM_scores = get_best_scoring_NAM_locations(nams1, nams2, isize_est.mu, isize_est.sigma);
+    Nam n1_joint_max, n2_joint_max, n1_indiv_max, n2_indiv_max;
     float score_joint = 0;
     float score_indiv = 0;
     best_nam1.ref_s = -1; //Unmapped until proven mapped
@@ -1536,8 +1536,8 @@ void align_PE_read(
 
     // Find NAMs
     Timer nam_timer;
-    std::vector<nam> nams1;
-    std::vector<nam> nams2;
+    std::vector<Nam> nams1;
+    std::vector<Nam> nams2;
     auto nonrepetitive_fraction1 = find_nams(nams1, query_randstrobes1, index);
     auto nonrepetitive_fraction2 = find_nams(nams2, query_randstrobes2, index);
     statistics.tot_find_nams += nam_timer.duration();
@@ -1565,8 +1565,8 @@ void align_PE_read(
 
     Timer extend_timer;
     if (!map_param.is_sam_out) {
-        nam nam_read1;
-        nam nam_read2;
+        Nam nam_read1;
+        Nam nam_read2;
         get_best_map_location(nams1, nams2, isize_est,
                               nam_read1,
                               nam_read2);
@@ -1606,7 +1606,7 @@ void align_SE_read(
 
     // Find NAMs
     Timer nam_timer;
-    std::vector<nam> nams;
+    std::vector<Nam> nams;
     auto nonrepetitive_fraction = find_nams(nams, query_randstrobes, index);
     statistics.tot_find_nams += nam_timer.duration();
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1279,26 +1279,19 @@ inline void align_PE(
 //            int ref_start, ref_len, ref_end;
 //            std::cerr << "LOOOOOOOOOOOOOOOOOOOL " << min_ed << std::endl;
     std::vector<std::tuple<double,alignment,alignment>> high_scores; // (score, aln1, aln2)
-    for (auto &t : joint_NAM_scores) {
-        auto score_ = std::get<0>(t);
-        auto n1 = std::get<1>(t);
-        auto n2 = std::get<2>(t);
+    for (auto &[score_, n1, n2] : joint_NAM_scores) {
         score_dropoff1 = (float) score_ / max_score;
-//                std::cerr << "Min ed: " << min_ed << std::endl;
         if ( (cnt >= max_tries) || (score_dropoff1 < dropoff) ){ // only consider top 20 if there are more.
             break;
         }
 
         //////// the actual testing of base pair alignment part start ////////
         //////////////////////////////////////////////////////////////////////
-        //////////////////////////////////////////////////////////////////////
         alignment a1;
         if (n1.ref_s >= 0) {
             if (is_aligned1.find(n1.nam_id) != is_aligned1.end() ){
-//                    std::cerr << "Already aligned a1! " << std::endl;
                 a1 = is_aligned1[n1.nam_id];
             } else {
-//                    std::cerr << query_acc1 << std::endl;
                 bool fits = reverse_nam_if_needed(n1, read1, references, k);
                 if (!fits) {
                     statistics.did_not_fit++;
@@ -1307,11 +1300,10 @@ inline void align_PE(
                 is_aligned1[n1.nam_id] = a1;
                 statistics.tot_all_tried++;
             }
-        } else { //rescue
-//                    std::cerr << "RESCUE HERE1" << std::endl;
+        } else {
             //////// Force SW alignment to rescue mate /////////
 //                    std::cerr << query_acc2 << " RESCUE MATE 1" << a1.is_rc << " " n1.is_rc << std::endl;
-            rescue_mate( aligner, n2, references, read2, read1, a1, mu, sigma, statistics.tot_rescued, k);
+            rescue_mate(aligner, n2, references, read2, read1, a1, mu, sigma, statistics.tot_rescued, k);
 //                    is_aligned1[n1.nam_id] = a1;
             statistics.tot_all_tried ++;
         }

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1536,24 +1536,20 @@ void align_PE_read(
 
     // Find NAMs
     Timer nam_timer;
-    std::vector<Nam> nams1;
-    std::vector<Nam> nams2;
-    auto nonrepetitive_fraction1 = find_nams(nams1, query_randstrobes1, index);
-    auto nonrepetitive_fraction2 = find_nams(nams2, query_randstrobes2, index);
+    auto [nonrepetitive_fraction1, nams1] = find_nams(query_randstrobes1, index);
+    auto [nonrepetitive_fraction2, nams2] = find_nams(query_randstrobes2, index);
     statistics.tot_find_nams += nam_timer.duration();
 
     if (map_param.R > 1) {
         Timer rescue_timer;
         if (nams1.empty() || nonrepetitive_fraction1 < 0.7) {
             statistics.tried_rescue += 1;
-            nams1.clear();
-            find_nams_rescue(nams1, query_randstrobes1, index, map_param.rescue_cutoff);
+            nams1 = find_nams_rescue(query_randstrobes1, index, map_param.rescue_cutoff);
         }
 
         if (nams2.empty() || nonrepetitive_fraction2 < 0.7) {
             statistics.tried_rescue += 1;
-            nams2.clear();
-            find_nams_rescue(nams2, query_randstrobes2, index, map_param.rescue_cutoff);
+            nams2 = find_nams_rescue(query_randstrobes2, index, map_param.rescue_cutoff);
         }
         statistics.tot_time_rescue += rescue_timer.duration();
     }
@@ -1606,16 +1602,14 @@ void align_SE_read(
 
     // Find NAMs
     Timer nam_timer;
-    std::vector<Nam> nams;
-    auto nonrepetitive_fraction = find_nams(nams, query_randstrobes, index);
+    auto [nonrepetitive_fraction, nams] = find_nams(query_randstrobes, index);
     statistics.tot_find_nams += nam_timer.duration();
 
     if (map_param.R > 1) {
         Timer rescue_timer;
         if (nams.empty() || nonrepetitive_fraction < 0.7) {
             statistics.tried_rescue += 1;
-            nams.clear();
-            find_nams_rescue(nams, query_randstrobes, index, map_param.rescue_cutoff);
+            nams = find_nams_rescue(query_randstrobes, index, map_param.rescue_cutoff);
         }
         statistics.tot_time_rescue += rescue_timer.duration();
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -326,7 +326,7 @@ void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) c
     std::vector<uint64_t> log_count_1000_limit(max_size, 0);  // stores count and each index represents the length
     uint64_t tot_seed_count_1000_limit = 0;
 
-    size_t seed_length;
+    size_t seed_length = 0;
     for (auto &it : randstrobe_map) {
         auto ref_mer = it.second;
         auto offset = ref_mer.offset();

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -47,7 +47,7 @@ void add_to_hits_per_ref(
 void merge_hits_into_nams(
     robin_hood::unordered_map<unsigned int, std::vector<Hit>> hits_per_ref,
     int k,
-    std::vector<nam> &final_nams,
+    std::vector<Nam> &final_nams,
     bool sort
 ) {
     int nam_id_cnt = 0;
@@ -60,7 +60,7 @@ void merge_hits_into_nams(
             );
         }
 
-        std::vector<nam> open_nams;
+        std::vector<Nam> open_nams;
         unsigned int prev_q_start = 0;
         for (auto &h : hits) {
             bool is_added = false;
@@ -95,7 +95,7 @@ void merge_hits_into_nams(
             }
             // Add the hit to open matches
             if (!is_added){
-                nam n;
+                Nam n;
                 n.nam_id = nam_id_cnt;
                 nam_id_cnt ++;
                 n.query_s = h.query_s;
@@ -157,7 +157,7 @@ void merge_hits_into_nams(
  * Return the fraction of nonrepetitive hits (those not above the filter_cutoff threshold)
  */
 float find_nams(
-    std::vector<nam> &final_nams,
+    std::vector<Nam> &final_nams,
     const QueryRandstrobeVector &query_randstrobes,
     const StrobemerIndex& index
 ) {
@@ -187,7 +187,7 @@ float find_nams(
  * than filter_cutoff.
  */
 void find_nams_rescue(
-    std::vector<nam> &final_nams,
+    std::vector<Nam> &final_nams,
     const QueryRandstrobeVector &query_randstrobes,
     const StrobemerIndex& index,
     unsigned int filter_cutoff
@@ -240,7 +240,7 @@ void find_nams_rescue(
     merge_hits_into_nams(hits_per_ref, index.k(), final_nams, true);
 }
 
-std::ostream& operator<<(std::ostream& os, const nam& n) {
+std::ostream& operator<<(std::ostream& os, const Nam& n) {
     os << "Nam(query: " << n.query_s << ".." << n.query_e << ", ref: " << n.ref_s << ".." << n.ref_e << ", score=" << n.score << ")";
     return os;
 }

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -1,5 +1,7 @@
 #include "nam.hpp"
 
+namespace {
+
 struct Hit {
     int query_s;
     int query_e;
@@ -150,6 +152,8 @@ std::vector<Nam> merge_hits_into_nams(
     }
     return nams;
 }
+
+} // namespace
 
 /*
  * Find a query’s NAMs, ignoring randstrobes that occur too often in the

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -57,7 +57,10 @@ void add_to_hits_per_ref(
     }
 }
 
-std::pair<float,int> find_nams(
+/* Return the fraction of nonrepetitive hits (those not above the filter_cutoff threshold)
+ *
+ */
+float find_nams(
     std::vector<nam> &final_nams,
     const QueryRandstrobeVector &query_randstrobes,
     const StrobemerIndex& index
@@ -77,10 +80,7 @@ std::pair<float,int> find_nams(
             add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, ref_hit->second, 100'000);
         }
     }
-
-    std::pair<float, int> info(0.0, 0); // (nr_nonrepetitive_hits/total_hits, max_nam_n_hits)
-    info.first = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
-    int max_nam_n_hits = 0;
+    float nonrepetitive_fraction = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
     int nam_id_cnt = 0;
 
     for (const auto &[ref_id, hits] : hits_per_ref) {
@@ -150,7 +150,6 @@ std::pair<float,int> find_nams(
 //                        n_score = n.n_hits * n.query_span();
                         n.score = n_score;
                         final_nams.push_back(n);
-                        max_nam_n_hits = std::max(n.n_hits, max_nam_n_hits);
                     }
                 }
 
@@ -171,11 +170,10 @@ std::pair<float,int> find_nams(
 //            n_score = n.n_hits * n.query_span();
             n.score = n_score;
             final_nams.push_back(n);
-            max_nam_n_hits = std::max(n.n_hits, max_nam_n_hits);
         }
     }
-    info.second = max_nam_n_hits;
-    return info;
+
+    return nonrepetitive_fraction;
 }
 
 void find_nams_rescue(

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -66,7 +66,7 @@ std::pair<float,int> find_nams(
     hits_per_ref.reserve(100);
 
     int nr_good_hits = 0, total_hits = 0;
-    for (auto &q : query_randstrobes) {
+    for (const auto &q : query_randstrobes) {
         auto ref_hit = index.find(q.hash);
         if (ref_hit != index.end()) {
             total_hits++;
@@ -74,22 +74,19 @@ std::pair<float,int> find_nams(
                 continue;
             }
             nr_good_hits++;
-            add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, ref_hit->second, 100000);
+            add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, ref_hit->second, 100'000);
         }
     }
 
-    std::pair<float,int> info (0.0f,0); // (nr_nonrepetitive_hits/total_hits, max_nam_n_hits)
+    std::pair<float, int> info(0.0, 0); // (nr_nonrepetitive_hits/total_hits, max_nam_n_hits)
     info.first = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
     int max_nam_n_hits = 0;
     int nam_id_cnt = 0;
-    std::vector<nam> open_nams;
 
-    for (auto &it : hits_per_ref) {
-        auto ref_id = it.first;
-        const std::vector<hit>& hits = it.second;
-        open_nams = std::vector<nam> (); // Initialize vector
+    for (const auto &[ref_id, hits] : hits_per_ref) {
+        std::vector<nam> open_nams;
         unsigned int prev_q_start = 0;
-        for (auto &h : hits){
+        for (auto &h : hits) {
             bool is_added = false;
             for (auto & o : open_nams) {
 
@@ -120,7 +117,6 @@ std::pair<float,int> find_nams(
                 }
 
             }
-//            }
             // Add the hit to open matches
             if (!is_added){
                 nam n;
@@ -167,7 +163,7 @@ std::pair<float,int> find_nams(
         }
 
         // Add all current open_matches to final NAMs
-        for (auto &n : open_nams){
+        for (auto &n : open_nams) {
             int n_max_span = std::max(n.query_span(), n.ref_span());
             int n_min_span = std::min(n.query_span(), n.ref_span());
             float n_score;

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -192,47 +192,47 @@ void find_nams_rescue(
     const StrobemerIndex& index,
     unsigned int filter_cutoff
 ) {
-    struct Hit {
+    struct RescueHit {
         unsigned int count;
         RandstrobeMapEntry randstrobe_map_entry;
         unsigned int query_s;
         unsigned int query_e;
         bool is_rc;
 
-        bool operator< (const Hit& rhs) const {
+        bool operator< (const RescueHit& rhs) const {
             return std::tie(count, query_s, query_e, is_rc)
                 < std::tie(rhs.count, rhs.query_s, rhs.query_e, rhs.is_rc);
         }
     };
 
     robin_hood::unordered_map<unsigned int, std::vector<hit>> hits_per_ref;
-    std::vector<Hit> hits_fw;
-    std::vector<Hit> hits_rc;
+    std::vector<RescueHit> hits_fw;
+    std::vector<RescueHit> hits_rc;
     hits_per_ref.reserve(100);
     hits_fw.reserve(5000);
     hits_rc.reserve(5000);
 
-    for (auto &q : query_randstrobes) {
-        auto ref_hit = index.find(q.hash);
+    for (auto &qr : query_randstrobes) {
+        auto ref_hit = index.find(qr.hash);
         if (ref_hit != index.end()) {
-            Hit s{ref_hit->second.count(), ref_hit->second, q.start, q.end, q.is_reverse};
-            if (q.is_reverse){
-                hits_rc.push_back(s);
+            RescueHit rh{ref_hit->second.count(), ref_hit->second, qr.start, qr.end, qr.is_reverse};
+            if (qr.is_reverse){
+                hits_rc.push_back(rh);
             } else {
-                hits_fw.push_back(s);
+                hits_fw.push_back(rh);
             }
         }
     }
 
     std::sort(hits_fw.begin(), hits_fw.end());
     std::sort(hits_rc.begin(), hits_rc.end());
-    for (auto& hits : {hits_fw, hits_rc}) {
+    for (auto& rescue_hits : {hits_fw, hits_rc}) {
         int cnt = 0;
-        for (auto &q : hits) {
-            if ((q.count > filter_cutoff && cnt >= 5) || q.count > 1000) {
+        for (auto &rh : rescue_hits) {
+            if ((rh.count > filter_cutoff && cnt >= 5) || rh.count > 1000) {
                 break;
             }
-            add_to_hits_per_ref(hits_per_ref, q.query_s, q.query_e, q.is_rc, index, q.randstrobe_map_entry, 1000);
+            add_to_hits_per_ref(hits_per_ref, rh.query_s, rh.query_e, rh.is_rc, index, rh.randstrobe_map_entry, 1000);
             cnt++;
         }
     }

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -8,19 +8,6 @@ struct hit {
     bool is_rc = false;
 };
 
-struct Hit {
-    unsigned int count;
-    RandstrobeMapEntry randstrobe_map_entry;
-    unsigned int query_s;
-    unsigned int query_e;
-    bool is_rc;
-
-    bool operator< (const Hit& rhs) const {
-        return std::tie(count, query_s, query_e, is_rc)
-            < std::tie(rhs.count, rhs.query_s, rhs.query_e, rhs.is_rc);
-    }
-};
-
 void add_to_hits_per_ref(
     robin_hood::unordered_map<unsigned int, std::vector<hit>>& hits_per_ref,
     int query_s,
@@ -182,6 +169,19 @@ void find_nams_rescue(
     const StrobemerIndex& index,
     unsigned int filter_cutoff
 ) {
+    struct Hit {
+        unsigned int count;
+        RandstrobeMapEntry randstrobe_map_entry;
+        unsigned int query_s;
+        unsigned int query_e;
+        bool is_rc;
+
+        bool operator< (const Hit& rhs) const {
+            return std::tie(count, query_s, query_e, is_rc)
+                < std::tie(rhs.count, rhs.query_s, rhs.query_e, rhs.is_rc);
+        }
+    };
+
     robin_hood::unordered_map<unsigned int, std::vector<hit>> hits_per_ref;
     std::vector<Hit> hits_fw;
     std::vector<Hit> hits_rc;

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -44,33 +44,22 @@ void add_to_hits_per_ref(
     }
 }
 
-/* Return the fraction of nonrepetitive hits (those not above the filter_cutoff threshold)
- *
- */
-float find_nams(
+void merge_hits_into_nams(
+    robin_hood::unordered_map<unsigned int, std::vector<hit>> hits_per_ref,
+    int k,
     std::vector<nam> &final_nams,
-    const QueryRandstrobeVector &query_randstrobes,
-    const StrobemerIndex& index
+    bool sort
 ) {
-    robin_hood::unordered_map<unsigned int, std::vector<hit>> hits_per_ref;
-    hits_per_ref.reserve(100);
-
-    int nr_good_hits = 0, total_hits = 0;
-    for (const auto &q : query_randstrobes) {
-        auto ref_hit = index.find(q.hash);
-        if (ref_hit != index.end()) {
-            total_hits++;
-            if (ref_hit->second.count() > index.filter_cutoff) {
-                continue;
-            }
-            nr_good_hits++;
-            add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, ref_hit->second, 100'000);
-        }
-    }
-    float nonrepetitive_fraction = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
     int nam_id_cnt = 0;
+    for (auto &[ref_id, hits] : hits_per_ref) {
+        if (sort) {
+            std::sort(hits.begin(), hits.end(), [](const hit& a, const hit& b) -> bool {
+                    // first sort on query starts, then on reference starts
+                    return (a.query_s < b.query_s) || ( (a.query_s == b.query_s) && (a.ref_s < b.ref_s) );
+                }
+            );
+        }
 
-    for (const auto &[ref_id, hits] : hits_per_ref) {
         std::vector<nam> open_nams;
         unsigned int prev_q_start = 0;
         for (auto &h : hits) {
@@ -125,7 +114,7 @@ float find_nams(
             }
 
             // Only filter if we have advanced at least k nucleotides
-            if (h.query_s > prev_q_start + index.k()) {
+            if (h.query_s > prev_q_start + k) {
 
                 // Output all NAMs from open_matches to final_nams that the current hit have passed
                 for (auto &n : open_nams) {
@@ -159,7 +148,33 @@ float find_nams(
             final_nams.push_back(n);
         }
     }
+}
 
+/* Return the fraction of nonrepetitive hits (those not above the filter_cutoff threshold)
+ */
+float find_nams(
+    std::vector<nam> &final_nams,
+    const QueryRandstrobeVector &query_randstrobes,
+    const StrobemerIndex& index
+) {
+    robin_hood::unordered_map<unsigned int, std::vector<hit>> hits_per_ref;
+    hits_per_ref.reserve(100);
+
+    int nr_good_hits = 0, total_hits = 0;
+    for (const auto &q : query_randstrobes) {
+        auto ref_hit = index.find(q.hash);
+        if (ref_hit != index.end()) {
+            total_hits++;
+            if (ref_hit->second.count() > index.filter_cutoff) {
+                continue;
+            }
+            nr_good_hits++;
+            add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, ref_hit->second, 100'000);
+        }
+    }
+    float nonrepetitive_fraction = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
+
+    merge_hits_into_nams(hits_per_ref, index.k(), final_nams, false);
     return nonrepetitive_fraction;
 }
 
@@ -215,103 +230,7 @@ void find_nams_rescue(
         }
     }
 
-    std::vector<nam> open_nams;
-    int nam_id_cnt = 0;
-
-    for (auto &it : hits_per_ref) {
-        auto ref_id = it.first;
-        std::vector<hit>& hits = it.second;
-        std::sort(hits.begin(), hits.end(), [](const hit& a, const hit& b) -> bool {
-                // first sort on query starts, then on reference starts
-                return (a.query_s < b.query_s) || ( (a.query_s == b.query_s) && (a.ref_s < b.ref_s) );
-            }
-        );
-        open_nams = std::vector<nam> (); // Initialize vector
-        unsigned int prev_q_start = 0;
-        for (auto &h : hits){
-            bool is_added = false;
-            for (auto & o : open_nams) {
-                // Extend NAM
-                if (o.is_rc == h.is_rc && o.query_prev_hit_startpos < h.query_s && h.query_s <= o.query_e && o.ref_prev_hit_startpos < h.ref_s && h.ref_s <= o.ref_e) {
-                    if (h.query_e > o.query_e && h.ref_e > o.ref_e) {
-                        o.query_e = h.query_e;
-                        o.ref_e = h.ref_e;
-//                        o.previous_query_start = h.query_s;
-//                        o.previous_ref_start = h.ref_s; // keeping track so that we don't . Can be caused by interleaved repeats.
-                        o.query_prev_hit_startpos = h.query_s; // log the last strobemer hit in case of outputting paf
-                        o.ref_prev_hit_startpos = h.ref_s; // log the last strobemer hit in case of outputting paf
-                        o.n_hits ++;
-//                        o.score += (float)1/ (float)h.count;
-                        is_added = true;
-                        break;
-                    }
-                    else if (h.query_e <= o.query_e && h.ref_e <= o.ref_e) {
-//                        o.previous_query_start = h.query_s;
-//                        o.previous_ref_start = h.ref_s; // keeping track so that we don't . Can be caused by interleaved repeats.
-                        o.query_prev_hit_startpos = h.query_s; // log the last strobemer hit in case of outputting paf
-                        o.ref_prev_hit_startpos = h.ref_s; // log the last strobemer hit in case of outputting paf
-                        o.n_hits ++;
-//                        o.score += (float)1/ (float)h.count;
-                        is_added = true;
-                        break;
-                    }
-                }
-            }
-            // Add the hit to open matches
-            if (!is_added){
-                nam n;
-                n.nam_id = nam_id_cnt;
-                nam_id_cnt ++;
-                n.query_s = h.query_s;
-                n.query_e = h.query_e;
-                n.ref_s = h.ref_s;
-                n.ref_e = h.ref_e;
-                n.ref_id = ref_id;
-//                n.previous_query_start = h.query_s;
-//                n.previous_ref_start = h.ref_s;
-                n.query_prev_hit_startpos = h.query_s;
-                n.ref_prev_hit_startpos = h.ref_s;
-                n.n_hits = 1;
-                n.is_rc = h.is_rc;
-//                n.score += (float)1/ (float)h.count;
-                open_nams.push_back(n);
-            }
-
-            // Only filter if we have advanced at least k nucleotides
-            if (h.query_s > prev_q_start + index.k()) {
-
-                // Output all NAMs from open_matches to final_nams that the current hit have passed
-                for (auto &n : open_nams) {
-                    if (n.query_e < h.query_s) {
-                        int n_max_span = std::max(n.query_span(), n.ref_span());
-                        int n_min_span = std::min(n.query_span(), n.ref_span());
-                        float n_score;
-                        n_score = ( 2*n_min_span -  n_max_span) > 0 ? (float) (n.n_hits * ( 2*n_min_span -  n_max_span) ) : 1;   // this is really just n_hits * ( min_span - (offset_in_span) ) );
-//                        n_score = n.n_hits * n.query_span();
-                        n.score = n_score;
-                        final_nams.push_back(n);
-                    }
-                }
-
-                // Remove all NAMs from open_matches that the current hit have passed
-                auto c = h.query_s;
-                auto predicate = [c](decltype(open_nams)::value_type const &nam) { return nam.query_e < c; };
-                open_nams.erase(std::remove_if(open_nams.begin(), open_nams.end(), predicate), open_nams.end());
-                prev_q_start = h.query_s;
-            }
-        }
-
-        // Add all current open_matches to final NAMs
-        for (auto &n : open_nams){
-            int n_max_span = std::max(n.query_span(), n.ref_span());
-            int n_min_span = std::min(n.query_span(), n.ref_span());
-            float n_score;
-            n_score = ( 2*n_min_span -  n_max_span) > 0 ? (float) (n.n_hits * ( 2*n_min_span -  n_max_span) ) : 1;   // this is really just n_hits * ( min_span - (offset_in_span) ) );
-//            n_score = n.n_hits * (n.query_e - n.query_s);
-            n.score = n_score;
-            final_nams.push_back(n);
-        }
-    }
+    merge_hits_into_nams(hits_per_ref, index.k(), final_nams, true);
 }
 
 std::ostream& operator<<(std::ostream& os, const nam& n) {

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -1,6 +1,6 @@
 #include "nam.hpp"
 
-struct hit {
+struct Hit {
     int query_s;
     int query_e;
     int ref_s;
@@ -9,7 +9,7 @@ struct hit {
 };
 
 void add_to_hits_per_ref(
-    robin_hood::unordered_map<unsigned int, std::vector<hit>>& hits_per_ref,
+    robin_hood::unordered_map<unsigned int, std::vector<Hit>>& hits_per_ref,
     int query_s,
     int query_e,
     bool is_rc,
@@ -26,7 +26,7 @@ void add_to_hits_per_ref(
         int ref_e = r.position + r.strobe2_offset() + index.k();
         int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
         if (diff <= min_diff) {
-            hits_per_ref[r.reference_index()].push_back(hit{query_s, query_e, ref_s, ref_e, is_rc});
+            hits_per_ref[r.reference_index()].push_back(Hit{query_s, query_e, ref_s, ref_e, is_rc});
             min_diff = diff;
         }
     } else {
@@ -37,7 +37,7 @@ void add_to_hits_per_ref(
 
             int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
             if (diff <= min_diff) {
-                hits_per_ref[r.reference_index()].push_back(hit{query_s, query_e, ref_s, ref_e, is_rc});
+                hits_per_ref[r.reference_index()].push_back(Hit{query_s, query_e, ref_s, ref_e, is_rc});
                 min_diff = diff;
             }
         }
@@ -45,7 +45,7 @@ void add_to_hits_per_ref(
 }
 
 void merge_hits_into_nams(
-    robin_hood::unordered_map<unsigned int, std::vector<hit>> hits_per_ref,
+    robin_hood::unordered_map<unsigned int, std::vector<Hit>> hits_per_ref,
     int k,
     std::vector<nam> &final_nams,
     bool sort
@@ -53,7 +53,7 @@ void merge_hits_into_nams(
     int nam_id_cnt = 0;
     for (auto &[ref_id, hits] : hits_per_ref) {
         if (sort) {
-            std::sort(hits.begin(), hits.end(), [](const hit& a, const hit& b) -> bool {
+            std::sort(hits.begin(), hits.end(), [](const Hit& a, const Hit& b) -> bool {
                     // first sort on query starts, then on reference starts
                     return (a.query_s < b.query_s) || ( (a.query_s == b.query_s) && (a.ref_s < b.ref_s) );
                 }
@@ -161,7 +161,7 @@ float find_nams(
     const QueryRandstrobeVector &query_randstrobes,
     const StrobemerIndex& index
 ) {
-    robin_hood::unordered_map<unsigned int, std::vector<hit>> hits_per_ref;
+    robin_hood::unordered_map<unsigned int, std::vector<Hit>> hits_per_ref;
     hits_per_ref.reserve(100);
 
     int nr_good_hits = 0, total_hits = 0;
@@ -205,7 +205,7 @@ void find_nams_rescue(
         }
     };
 
-    robin_hood::unordered_map<unsigned int, std::vector<hit>> hits_per_ref;
+    robin_hood::unordered_map<unsigned int, std::vector<Hit>> hits_per_ref;
     std::vector<RescueHit> hits_fw;
     std::vector<RescueHit> hits_rc;
     hits_per_ref.reserve(100);

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -150,7 +150,11 @@ void merge_hits_into_nams(
     }
 }
 
-/* Return the fraction of nonrepetitive hits (those not above the filter_cutoff threshold)
+/*
+ * Find a query’s NAMs, ignoring randstrobes that occur too often in the
+ * reference (have a count above filter_cutoff).
+ *
+ * Return the fraction of nonrepetitive hits (those not above the filter_cutoff threshold)
  */
 float find_nams(
     std::vector<nam> &final_nams,
@@ -178,6 +182,10 @@ float find_nams(
     return nonrepetitive_fraction;
 }
 
+/*
+ * Find a query’s NAMs, using also some of the randstrobes that occur more often
+ * than filter_cutoff.
+ */
 void find_nams_rescue(
     std::vector<nam> &final_nams,
     const QueryRandstrobeVector &query_randstrobes,
@@ -221,8 +229,7 @@ void find_nams_rescue(
     for (auto& hits : {hits_fw, hits_rc}) {
         int cnt = 0;
         for (auto &q : hits) {
-            auto count = q.count;
-            if ((count > filter_cutoff && cnt >= 5) || count > 1000) {
+            if ((q.count > filter_cutoff && cnt >= 5) || q.count > 1000) {
                 break;
             }
             add_to_hits_per_ref(hits_per_ref, q.query_s, q.query_e, q.is_rc, index, q.randstrobe_map_entry, 1000);

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -30,14 +30,12 @@ struct Nam {
     }
 };
 
-float find_nams(
-    std::vector<Nam> &final_nams,
+std::pair<float, std::vector<Nam>> find_nams(
     const QueryRandstrobeVector &query_randstrobes,
     const StrobemerIndex& index
 );
 
-void find_nams_rescue(
-    std::vector<Nam> &final_nams,
+std::vector<Nam> find_nams_rescue(
     const QueryRandstrobeVector &query_randstrobes,
     const StrobemerIndex& index,
     unsigned int filter_cutoff

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -30,7 +30,7 @@ struct nam {
     }
 };
 
-std::pair<float,int> find_nams(
+float find_nams(
     std::vector<nam> &final_nams,
     const QueryRandstrobeVector &query_randstrobes,
     const StrobemerIndex& index

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -6,7 +6,7 @@
 #include "randstrobes.hpp"
 
 // Non-overlapping approximate match
-struct nam {
+struct Nam {
     int nam_id;
     int query_s;
     int query_e;
@@ -31,18 +31,18 @@ struct nam {
 };
 
 float find_nams(
-    std::vector<nam> &final_nams,
+    std::vector<Nam> &final_nams,
     const QueryRandstrobeVector &query_randstrobes,
     const StrobemerIndex& index
 );
 
 void find_nams_rescue(
-    std::vector<nam> &final_nams,
+    std::vector<Nam> &final_nams,
     const QueryRandstrobeVector &query_randstrobes,
     const StrobemerIndex& index,
     unsigned int filter_cutoff
 );
 
-std::ostream& operator<<(std::ostream& os, const nam& thenam);
+std::ostream& operator<<(std::ostream& os, const Nam& nam);
 
 #endif

--- a/src/paf.cpp
+++ b/src/paf.cpp
@@ -14,7 +14,7 @@
  * 11 alignment block length
  * 12 mapping quality (0-255; 255 for missing)
  */
-void output_hits_paf_PE(std::string &paf_output, const nam &n, const std::string &query_name, const References& references, int k, int read_len) {
+void output_hits_paf_PE(std::string &paf_output, const Nam &n, const std::string &query_name, const References& references, int k, int read_len) {
     if (n.ref_s < 0 ) {
         return;
     }
@@ -43,12 +43,12 @@ void output_hits_paf_PE(std::string &paf_output, const nam &n, const std::string
 }
 
 
-void output_hits_paf(std::string &paf_output, const std::vector<nam> &all_nams, const std::string& query_name, const References& references, int k, int read_len) {
+void output_hits_paf(std::string &paf_output, const std::vector<Nam> &all_nams, const std::string& query_name, const References& references, int k, int read_len) {
     // Output results
     if (all_nams.empty()) {
         return;
     }
     // Only output single best hit based on: number of randstrobe-matches times span of the merged match.
-    nam n = all_nams[0];
+    Nam n = all_nams[0];
     output_hits_paf_PE(paf_output, n, query_name, references, k, read_len);
 }

--- a/src/paf.hpp
+++ b/src/paf.hpp
@@ -6,11 +6,11 @@
 #include "nam.hpp"
 
 void output_hits_paf_PE(
-    std::string &paf_output, const nam &n, const std::string &query_name, const References& references, int k, int read_len
+    std::string &paf_output, const Nam &n, const std::string &query_name, const References& references, int k, int read_len
 );
 
 void output_hits_paf(
-    std::string &paf_output, const std::vector<nam> &all_nams, const std::string& query_name, const References& references, int k, int read_len
+    std::string &paf_output, const std::vector<Nam> &all_nams, const std::string& query_name, const References& references, int k, int read_len
 );
 
 #endif

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -152,7 +152,6 @@ private:
     const unsigned w_max;
     const uint64_t q;
     const unsigned int max_dist;
-    unsigned int strobe1_index = 0;
     std::deque<Syncmer> syncmers;
 };
 

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -1187,7 +1187,7 @@ static inline bool sort_hits(const hit &a, const hit &b)
 
 
 static inline void find_nams_rescue(
-    std::vector<nam> &final_nams,
+    std::vector<Nam> &final_nams,
     robin_hood::unordered_map<unsigned int, std::vector<hit>> &hits_per_ref,
     const QueryRandstrobeVector &query_mers,
     const RefRandstrobeVector &ref_mers,
@@ -1367,7 +1367,7 @@ static inline void find_nams_rescue(
 //    std::cerr << "NUMBER OF HITS GENERATED: " << hit_count_all << std::endl;
 //    info.first = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
     int max_nam_n_hits = 0;
-    std::vector<nam> open_nams;
+    std::vector<Nam> open_nams;
     int nam_id_cnt = 0;
 //    std::vector<nam> final_nams; // [ref_id] -> vector(struct nam)
 
@@ -1376,7 +1376,7 @@ static inline void find_nams_rescue(
         auto ref_id = it.first;
         std::vector<hit> hits = it.second;
         std::sort(hits.begin(), hits.end(), sort_hits);
-        open_nams = std::vector<nam> (); // Initialize vector
+        open_nams = std::vector<Nam> (); // Initialize vector
         unsigned int prev_q_start = 0;
         for (auto &h : hits){
             bool is_added = false;
@@ -1419,7 +1419,7 @@ static inline void find_nams_rescue(
 //            }
             // Add the hit to open matches
             if (!is_added){
-                nam n;
+                Nam n;
                 n.nam_id = nam_id_cnt;
                 nam_id_cnt ++;
                 n.query_s = h.query_s;
@@ -1484,7 +1484,7 @@ static inline void find_nams_rescue(
 
 
 static inline std::pair<float,int> find_nams(
-    std::vector<nam> &final_nams,
+    std::vector<Nam> &final_nams,
     robin_hood::unordered_map<unsigned int, std::vector<hit>> &hits_per_ref,
     const QueryRandstrobeVector &query_mers,
     const RefRandstrobeVector &ref_mers,
@@ -1591,7 +1591,7 @@ static inline std::pair<float,int> find_nams(
     info.first = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
     int max_nam_n_hits = 0;
     int nam_id_cnt = 0;
-    std::vector<nam> open_nams;
+    std::vector<Nam> open_nams;
 //    std::vector<nam> final_nams; // [ref_id] -> vector(struct nam)
 
     for (auto &it : hits_per_ref)
@@ -1602,7 +1602,7 @@ static inline std::pair<float,int> find_nams(
 //    for(size_t i = 0; i < hits_per_ref.size(); ++i){
 //        unsigned int ref_id = i;
 //        auto hits = hits_per_ref[i];
-        open_nams = std::vector<nam> (); // Initialize vector
+        open_nams = std::vector<Nam> (); // Initialize vector
         unsigned int prev_q_start = 0;
         for (auto &h : hits){
             bool is_added = false;
@@ -1669,7 +1669,7 @@ static inline std::pair<float,int> find_nams(
 //            }
             // Add the hit to open matches
             if (!is_added){
-                nam n;
+                Nam n;
                 n.nam_id = nam_id_cnt;
                 nam_id_cnt ++;
                 n.query_s = h.query_s;


### PR DESCRIPTION
The main change in this PR is to factor out a `merge_hits_into_nams` function that removes a nice chunk of duplicated code from `find_nams` and `find_nams_rescue`. Also:
* Rename `nam` to `Nam`
* Move `Hit` struct declaration into `find_nams_rescue` as it is used only there (and rename to `RescueHit`)
* Rename `hit` to `Hit`
