### PR TITLE
Fix: Pass by reference

### DIFF
--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -47,7 +47,7 @@ void add_to_hits_per_ref(
 }
 
 std::vector<Nam> merge_hits_into_nams(
-    robin_hood::unordered_map<unsigned int, std::vector<Hit>> hits_per_ref,
+    robin_hood::unordered_map<unsigned int, std::vector<Hit>>& hits_per_ref,
     int k,
     bool sort
 ) {


### PR DESCRIPTION
PR #243 introduced a regression in that it made mapping a little bit slower because I accidentally passed `hits_per_ref` by by value to `merge_hits_into_nams()`. This changes it to pass by reference. With this, speed is as before.