### PR TITLE
Soft clipping penalty

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -73,12 +73,16 @@ std::tuple<size_t, size_t, int> highest_scoring_segment(
             start = i + 1;
             score = 0;
         }
-        int bonus = i + 1 == n ? end_bonus : 0;
-        if (score + bonus > best_score) {
+        if (score > best_score) {
             best_start = start;
-            best_score = score + bonus;
+            best_score = score;
             best_end = i + 1;
         }
+    }
+    if (score + end_bonus > best_score) {
+        best_score = score + end_bonus;
+        best_end = query.length();
+        best_start = start;
     }
     return std::make_tuple(best_start, best_end, best_score);
 }

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -36,12 +36,6 @@ aln_info Aligner::align(const std::string &query, const std::string &ref) const 
     aln.query_start = alignment_ssw.query_begin;
     aln.query_end = alignment_ssw.query_end + 1;
 
-    if (aln.query_start == 0) {
-        aln.sw_score += parameters.end_bonus;
-    }
-    if (aln.query_start == query.length()) {
-        aln.sw_score += parameters.end_bonus;
-    }
     return aln;
 }
 
@@ -80,9 +74,12 @@ std::tuple<size_t, size_t, int> highest_scoring_segment(
         }
     }
     if (score + end_bonus > best_score) {
-        best_score = score + end_bonus;
+        best_score = score;
         best_end = query.length();
         best_start = start;
+    }
+    if (best_start == 0) {
+        best_score -= end_bonus;
     }
     return std::make_tuple(best_start, best_end, best_score);
 }

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -41,14 +41,17 @@ aln_info Aligner::align(const std::string &query, const std::string &ref) const 
 /*
  * Find highest-scoring segment between reference and query assuming only matches
  * and mismatches are allowed.
+ *
+ * The end_bonus is added to the score if the segment extends until the end
+ * of the query, once for each end.
  */
-std::pair<size_t, size_t> highest_scoring_segment(
-    const std::string& query, const std::string& ref, int match, int mismatch
+std::tuple<size_t, size_t, int> highest_scoring_segment(
+    const std::string& query, const std::string& ref, int match, int mismatch, int end_bonus
 ) {
     size_t n = query.length();
 
     size_t start = 0; // start of the current segment
-    int score = 0; // accumulated score so far in the current segment
+    int score = end_bonus; // accumulated score so far in the current segment
 
     size_t best_start = 0;
     size_t best_end = 0;
@@ -63,24 +66,25 @@ std::pair<size_t, size_t> highest_scoring_segment(
             start = i + 1;
             score = 0;
         }
-        if (score > best_score) {
+        int bonus = i + 1 == n ? end_bonus : 0;
+        if (score + bonus > best_score) {
             best_start = start;
-            best_score = score;
+            best_score = score + bonus;
             best_end = i + 1;
         }
     }
-    return std::make_pair(best_start, best_end);
+    return std::make_tuple(best_start, best_end, best_score);
 }
 
 aln_info hamming_align(
-    const std::string &query, const std::string &ref, int match, int mismatch
+    const std::string &query, const std::string &ref, int match, int mismatch, int end_bonus
 ) {
     aln_info aln;
     if (query.length() != ref.length()) {
         return aln;
     }
 
-    auto [segment_start, segment_end] = highest_scoring_segment(query, ref, match, mismatch);
+    auto [segment_start, segment_end, score] = highest_scoring_segment(query, ref, match, mismatch, end_bonus);
 
     Cigar cigar;
     if (segment_start > 0) {
@@ -106,7 +110,6 @@ aln_info hamming_align(
     if (!first) {
         cigar.push(prev_is_match ? CIGAR_EQ : CIGAR_X, counter);
     }
-    int aln_score = (segment_end - segment_start - mismatches) * match - mismatches * mismatch;
 
     int soft_right = query.length() - segment_end;
     if (soft_right > 0) {
@@ -114,7 +117,7 @@ aln_info hamming_align(
     }
 
     aln.cigar = std::move(cigar);
-    aln.sw_score = aln_score;
+    aln.sw_score = score;
     aln.edit_distance = mismatches;
     aln.ref_start = segment_start;
     aln.ref_end = segment_end;

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -36,6 +36,12 @@ aln_info Aligner::align(const std::string &query, const std::string &ref) const 
     aln.query_start = alignment_ssw.query_begin;
     aln.query_end = alignment_ssw.query_end + 1;
 
+    if (aln.query_start == 0) {
+        aln.sw_score += parameters.end_bonus;
+    }
+    if (aln.query_start == query.length()) {
+        aln.sw_score += parameters.end_bonus;
+    }
     return aln;
 }
 
@@ -74,12 +80,9 @@ std::tuple<size_t, size_t, int> highest_scoring_segment(
         }
     }
     if (score + end_bonus > best_score) {
-        best_score = score;
+        best_score = score + end_bonus;
         best_end = query.length();
         best_start = start;
-    }
-    if (best_start == 0) {
-        best_score -= end_bonus;
     }
     return std::make_tuple(best_start, best_end, best_score);
 }

--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -35,6 +35,13 @@ aln_info Aligner::align(const std::string &query, const std::string &ref) const 
     aln.ref_end = alignment_ssw.ref_end + 1;
     aln.query_start = alignment_ssw.query_begin;
     aln.query_end = alignment_ssw.query_end + 1;
+
+    if (aln.query_start == 0) {
+        aln.sw_score += parameters.end_bonus;
+    }
+    if (aln.query_start == query.length()) {
+        aln.sw_score += parameters.end_bonus;
+    }
     return aln;
 }
 

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -2,6 +2,7 @@
 #define STROBEALIGN_ALIGNER_HPP
 
 #include <string>
+#include <tuple>
 #include "ssw/ssw_cpp.h"
 #include "bindings/cpp/WFAligner.hpp"
 #include "cigar.hpp"
@@ -13,6 +14,7 @@ struct alignment_params {
     int mismatch;
     int gap_open;
     int gap_extend;
+    int end_bonus;
 };
 
 struct aln_info {
@@ -76,12 +78,12 @@ inline int hamming_distance(const std::string &s, const std::string &t) {
     return mismatches;
 }
 
-std::pair<size_t, size_t> highest_scoring_segment(
-    const std::string& query, const std::string& ref, int match, int mismatch
+std::tuple<size_t, size_t, int> highest_scoring_segment(
+    const std::string& query, const std::string& ref, int match, int mismatch, int end_bonus
 );
 
 aln_info hamming_align(
-    const std::string &query, const std::string &ref, int match, int mismatch
+    const std::string &query, const std::string &ref, int match, int mismatch, int end_bonus
 );
 
 #endif

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -293,7 +293,7 @@ static inline alignment get_alignment(
     const std::string right_ref = ref.substr(n.ref_e, ref_projected_end - n.ref_e + 50);
 
     auto right = ksw_extend(right_query, right_ref,
-        aligner.parameters.match, aligner.parameters.mismatch, aligner.parameters.gap_open - aligner.parameters.gap_extend, aligner.parameters.gap_extend
+        aligner.parameters.match, aligner.parameters.mismatch, aligner.parameters.gap_open - aligner.parameters.gap_extend, aligner.parameters.gap_extend, aligner.parameters.end_bonus
     );
 
     // left extension
@@ -305,7 +305,7 @@ static inline alignment get_alignment(
     std::reverse(left_ref.begin(), left_ref.end());
 
     auto left = ksw_extend(left_query, left_ref,
-        aligner.parameters.match, aligner.parameters.mismatch, aligner.parameters.gap_open - aligner.parameters.gap_extend, aligner.parameters.gap_extend
+        aligner.parameters.match, aligner.parameters.mismatch, aligner.parameters.gap_open - aligner.parameters.gap_extend, aligner.parameters.gap_extend, aligner.parameters.end_bonus
     );
 
     // build final CIGAR

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -182,7 +182,7 @@ static inline alignment align_segment(
         auto hamming_dist = hamming_distance(read_segm, ref_segm_ham);
 
         if (hamming_dist >= 0 && (((float) hamming_dist / read_segm_len) < 0.05) ) { //Hamming distance worked fine, no need to ksw align
-            auto info = hamming_align(read_segm, ref_segm_ham, aligner.parameters.match, aligner.parameters.mismatch);
+            auto info = hamming_align(read_segm, ref_segm_ham, aligner.parameters.match, aligner.parameters.mismatch, aligner.parameters.end_bonus);
             sam_aln_segm.cigar = info.cigar.to_string();
             sam_aln_segm.ed = info.edit_distance;
             sam_aln_segm.sw_score = info.sw_score;
@@ -260,7 +260,7 @@ static inline alignment get_alignment(
         auto hamming_dist = hamming_distance(query, ref_segm_ham);
 
         if (hamming_dist >= 0 && (((float) hamming_dist / query.size()) < 0.05) ) { //Hamming distance worked fine, no need to ksw align
-            auto info = hamming_align(query, ref_segm_ham, aligner.parameters.match, aligner.parameters.mismatch);
+            auto info = hamming_align(query, ref_segm_ham, aligner.parameters.match, aligner.parameters.mismatch, aligner.parameters.end_bonus);
             int result_ref_start = projected_ref_start + info.ref_start;
             int softclipped = info.query_start + (query.size() - info.query_end);
             sam_aln.cigar = info.cigar.to_string();
@@ -375,7 +375,7 @@ static inline alignment get_alignment_unused(
         int hamming_dist = hamming_distance(r_tmp, ref_segm);
 
         if (hamming_dist >= 0 && (((float) hamming_dist / ref_segm_size) < 0.05) ) { //Hamming distance worked fine, no need to ksw align
-            const auto info = hamming_align(r_tmp, ref_segm, aligner.parameters.match, aligner.parameters.mismatch);
+            const auto info = hamming_align(r_tmp, ref_segm, aligner.parameters.match, aligner.parameters.mismatch, aligner.parameters.end_bonus);
             sam_aln.cigar = info.cigar.to_string();
             sam_aln.ed = info.edit_distance;
             sam_aln.sw_score = info.sw_score; // aln_params.match*(read_len-hamming_dist) - aln_params.mismatch*hamming_dist;

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -33,7 +33,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::ValueFlagList<std::string> rg(parser, "TAG:VALUE", "Add read group metadata to SAM header (can be specified multiple times). Example: SM:samplename", {"rg"});
 
     args::ValueFlag<int> N(parser, "INT", "Retain at most INT secondary alignments (is upper bounded by -M and depends on -S) [0]", {'N'});
-    args::ValueFlag<std::string> L(parser, "PATH", "Print statistics of indexing to PATH", {'L'});
+    args::ValueFlag<std::string> index_statistics(parser, "PATH", "Print statistics of indexing to PATH", {"index-statistics"});
     args::Flag i(parser, "index", "Do not map reads; only generate the strobemer index and write it to disk. If read files are provided, they are used to estimate read length", {"create-index", 'i'});
     args::Flag use_index(parser, "use_index", "Use a pre-generated index previously written with --create-index.", { "use-index" });
 
@@ -45,6 +45,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::ValueFlag<int> B(parser, "INT", "Mismatch penalty [8]", {'B'});
     args::ValueFlag<int> O(parser, "INT", "Gap open penalty [12]", {'O'});
     args::ValueFlag<int> E(parser, "INT", "Gap extension penalty [1]", {'E'});
+    args::ValueFlag<int> end_bonus(parser, "INT", "Soft clipping penalty [10]", {'L'});
 
     args::Group search(parser, "Search parameters:");
     args::ValueFlag<float> f(parser, "FLOAT", "Top fraction of repetitive strobemers to filter out from sampling [0.0002]", {'f'});
@@ -92,7 +93,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (rgid) { opt.read_group_id = args::get(rgid); }
     if (rg) { opt.read_group_fields = args::get(rg); }
     if (N) { opt.max_secondary = args::get(N); }
-    if (L) { opt.logfile_name = args::get(L); }
+    if (index_statistics) { opt.logfile_name = args::get(index_statistics); }
     if (i) { opt.only_gen_index = true; }
     if (use_index) { opt.use_index = true; }
 
@@ -111,6 +112,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (B) { opt.B = args::get(B); }
     if (O) { opt.O = args::get(O); }
     if (E) { opt.E = args::get(E); }
+    if (end_bonus) { opt.end_bonus = args::get(end_bonus); }
 
     // Search parameters
     if (f) { opt.f = args::get(f); }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -44,6 +44,7 @@ struct CommandLineOptions {
     int B { 8 };
     int O { 12 };
     int E { 1 };
+    int end_bonus { 10 };
 
     // Search parameters
     float f { 0.0002 };

--- a/src/ksw2wrap.cpp
+++ b/src/ksw2wrap.cpp
@@ -94,7 +94,7 @@ aln_info ksw_extend(const std::string& query, const std::string& ref, int8_t mat
     if (ez.reach_end) {
         info.ref_end = ez.mqe_t + 1;
         info.query_end = query.size();
-        info.sw_score = ez.mqe;
+        info.sw_score = ez.mqe + end_bonus;
     } else {
         info.ref_end = ez.max_t + 1;
         info.query_end = ez.max_q + 1;

--- a/src/ksw2wrap.cpp
+++ b/src/ksw2wrap.cpp
@@ -94,7 +94,7 @@ aln_info ksw_extend(const std::string& query, const std::string& ref, int8_t mat
     if (ez.reach_end) {
         info.ref_end = ez.mqe_t + 1;
         info.query_end = query.size();
-        info.sw_score = ez.mqe + end_bonus;
+        info.sw_score = ez.mqe;
     } else {
         info.ref_end = ez.max_t + 1;
         info.query_end = ez.max_q + 1;

--- a/src/ksw2wrap.hpp
+++ b/src/ksw2wrap.hpp
@@ -5,6 +5,6 @@
 #include <cstdint>
 #include "aligner.hpp"
 
-aln_info ksw_extend(const std::string& query, const std::string& ref, int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend);
+aln_info ksw_extend(const std::string& query, const std::string& ref, int8_t match, int8_t mismatch, int8_t gap_open, int8_t gap_extend, int end_bonus);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,8 @@ void log_parameters(const IndexParameters& index_parameters, const mapping_param
         << "A: " << aln_params.match << std::endl
         << "B: " << aln_params.mismatch << std::endl
         << "O: " << aln_params.gap_open << std::endl
-        << "E: " << aln_params.gap_extend << std::endl;
+        << "E: " << aln_params.gap_extend << std::endl
+        << "end bonus: " << aln_params.end_bonus << '\n';
 }
 
 bool avx2_enabled() {
@@ -161,6 +162,7 @@ int run_strobealign(int argc, char **argv) {
     aln_params.mismatch = opt.B;
     aln_params.gap_open = opt.O;
     aln_params.gap_extend = opt.E;
+    aln_params.end_bonus = opt.end_bonus;
 
     mapping_params map_param;
     map_param.r = opt.r;

--- a/tests/test_aligner.cpp
+++ b/tests/test_aligner.cpp
@@ -123,3 +123,36 @@ TEST_CASE("highest_scoring_segment") {
     CHECK(highest_scoring_segment("AAAAAAAAAA", "TTAAAAAATT", 5, 7, 0) == std::make_tuple(2ul, 8ul, 30));
     CHECK(highest_scoring_segment("AAAAAAAAAAAAAAA", "TAAAAAATTTAAAAT", 5, 7, 0) == std::make_tuple(1ul, 7ul, 30));
 }
+
+TEST_CASE("highest_scoring_segment with soft clipping") {
+    auto x = highest_scoring_segment("", "", 2, 4, 5);
+    CHECK(std::get<0>(x) == 0);
+    CHECK(std::get<1>(x) == 0);
+    CHECK(std::get<2>(x) == 10);
+
+    x = highest_scoring_segment("TAAT", "TAAA", 2, 4, 5);
+    CHECK(std::get<0>(x) == 0);
+    CHECK(std::get<1>(x) == 4);
+    CHECK(std::get<2>(x) == 3 * 2 - 4 + 10);
+
+       x = highest_scoring_segment("AAA", "AAA", 2, 4, 5);
+    CHECK(std::get<0>(x) == 0);
+    CHECK(std::get<1>(x) == 3);
+    CHECK(std::get<2>(x) == 3 * 2 + 10);
+
+    x = highest_scoring_segment("TAAT", "AAAA", 2, 4, 5);
+    CHECK(std::get<0>(x) == 0);
+    CHECK(std::get<1>(x) == 4);
+    CHECK(std::get<2>(x) == 2 * 2 - 2 * 4 + 10);
+
+    x = highest_scoring_segment("ATAATA", "AAAAAA", 2, 4, 5);
+    CHECK(std::get<0>(x) == 0);
+    CHECK(std::get<1>(x) == 6);
+    CHECK(std::get<2>(x) == 4 * 2 - 2 * 4 + 10);
+
+    x = highest_scoring_segment("TTAATA", "AAAAAA", 2, 4, 5);
+    CHECK(std::get<0>(x) == 2);
+    CHECK(std::get<1>(x) == 6);
+    CHECK(std::get<2>(x) == 3 * 2 - 1 * 4 + 5);
+
+}

--- a/tests/test_aligner.cpp
+++ b/tests/test_aligner.cpp
@@ -5,7 +5,7 @@ TEST_CASE("hamming_align") {
     // empty sequences
     auto info = hamming_align(
         "", "",
-        7, 5
+        7, 5, 0
     );
     CHECK(info.cigar.to_string() == "");
     CHECK(info.edit_distance == 0);
@@ -18,7 +18,7 @@ TEST_CASE("hamming_align") {
     info = hamming_align(
         "AAXGGG",
         "AAYGGG",
-        1, 1
+        1, 1, 0
     );
     CHECK(info.cigar.to_string() == "2=1X3=");
     CHECK(info.edit_distance == 1);
@@ -31,7 +31,7 @@ TEST_CASE("hamming_align") {
     info = hamming_align(
         "AXGGG",
         "AYGGG",
-        1, 4
+        1, 4, 0
     );
     CHECK(info.cigar.to_string() == "2S3=");
     CHECK(info.edit_distance == 0);
@@ -44,7 +44,7 @@ TEST_CASE("hamming_align") {
     info = hamming_align(
         "NAACCG",
         "TAACCG",
-        3, 7
+        3, 7, 0
     );
     CHECK(info.cigar.to_string() == "1S5=");
     CHECK(info.edit_distance == 0);
@@ -57,7 +57,7 @@ TEST_CASE("hamming_align") {
     info = hamming_align(
         "AACCGN",
         "AACCGT",
-        3, 7
+        3, 7, 0
     );
     CHECK(info.cigar.to_string() == "5=1S");
     CHECK(info.edit_distance == 0);
@@ -71,7 +71,7 @@ TEST_CASE("hamming_align") {
     info = hamming_align(
         "NAAAAAAAAAAAAAA",
         "TAAAATTTTTTTTTT",
-        3, 7
+        3, 7, 0
     );
     CHECK(info.cigar.to_string() == "1S4=10S");
     CHECK(info.edit_distance == 0);
@@ -84,7 +84,7 @@ TEST_CASE("hamming_align") {
     info = hamming_align(
         "NAAAAAAAAAAAAAA",
         "TAAAATTTAAAAAAT",
-        3, 7
+        3, 7, 0
     );
     CHECK(info.cigar.to_string() == "8S6=1S");
     CHECK(info.edit_distance == 0);
@@ -97,7 +97,7 @@ TEST_CASE("hamming_align") {
     info = hamming_align(
         "AAAAAAAAAAAAAAA",
         "TAAAAAATTTAAAAT",
-        3, 7
+        3, 7, 0
     );
     CHECK(info.cigar.to_string() == "1S6=8S");
     CHECK(info.edit_distance == 0);
@@ -109,17 +109,17 @@ TEST_CASE("hamming_align") {
 }
 
 TEST_CASE("highest_scoring_segment") {
-    auto x = highest_scoring_segment("", "", 5, 7);
-    CHECK(x.first == 0);
-    CHECK(x.second == 0);
-    x = highest_scoring_segment("AAAAAAAAAA", "AAAAAATTTT", 5, 7);
-    CHECK(x.first == 0);
-    CHECK(x.second == 6);
-    x = highest_scoring_segment("AAAAAAAAAA", "TTTTAAAAAA", 5, 7);
-    CHECK(x.first == 4);
-    CHECK(x.second == 10);
-    CHECK(highest_scoring_segment("AAAAAAAAAA", "AAAAAATTTT", 5, 7) == std::make_pair(0ul, 6ul));
-    CHECK(highest_scoring_segment("AAAAAAAAAA", "TTTTAAAAAA", 5, 7) == std::make_pair(4ul, 10ul));
-    CHECK(highest_scoring_segment("AAAAAAAAAA", "TTAAAAAATT", 5, 7) == std::make_pair(2ul, 8ul));
-    CHECK(highest_scoring_segment("AAAAAAAAAAAAAAA", "TAAAAAATTTAAAAT", 5, 7) == std::make_pair(1ul, 7ul));
+    auto x = highest_scoring_segment("", "", 5, 7, 0);
+    CHECK(std::get<0>(x) == 0);
+    CHECK(std::get<1>(x) == 0);
+    x = highest_scoring_segment("AAAAAAAAAA", "AAAAAATTTT", 5, 7, 0);
+    CHECK(std::get<0>(x) == 0);
+    CHECK(std::get<1>(x) == 6);
+    x = highest_scoring_segment("AAAAAAAAAA", "TTTTAAAAAA", 5, 7, 0);
+    CHECK(std::get<0>(x) == 4);
+    CHECK(std::get<1>(x) == 10);
+    CHECK(highest_scoring_segment("AAAAAAAAAA", "AAAAAATTTT", 5, 7, 0) == std::make_tuple(0ul, 6ul, 30));
+    CHECK(highest_scoring_segment("AAAAAAAAAA", "TTTTAAAAAA", 5, 7, 0) == std::make_tuple(4ul, 10ul, 30));
+    CHECK(highest_scoring_segment("AAAAAAAAAA", "TTAAAAAATT", 5, 7, 0) == std::make_tuple(2ul, 8ul, 30));
+    CHECK(highest_scoring_segment("AAAAAAAAAAAAAAA", "TAAAAAATTTAAAAT", 5, 7, 0) == std::make_tuple(1ul, 7ul, 30));
 }


### PR DESCRIPTION
In issue #54, we discussed introducing a penalty for soft clipping (just like BWA-MEM). This PR adds this, or rather, the equivalent, an "end bonus", which is what ksw2 supports.

I noticed that the `get_accuracy.py` script considers a read to be mapped correctly as long as the interval to which it is mapped intersects the true interval. This overestimates accuracy a little bit because small variations in start and end coordinates such as those from soft clipping do not affect the accuracy. It also means I cannot measure whether soft clipping improves results the way I would like to.

I therefore added a different metric to my copy of the `get_accuracy.py` script. Instead of giving a 0/1 decision for whether the intervals overlap, it returns the Jaccard index, which is a number between 0 and 1 (0 for no overlap and 1 for identical intervals).
```
def jaccard_overlap(a_start, a_end, b_start, b_end):
    assert a_start < a_end
    assert b_start < b_end

    intersect = min(a_end, b_end) - max(a_start, b_start)
    if intersect < 0:
        return 0
    union = max(a_end, b_end) - min(a_start, b_start)
    result = intersect / union
    assert 0 <= result <= 1.0
    return result
```
I implemented soft clipping on top of the wfa branch because I had hoped it would remedy some of the decreases in accuracy, so the difference column below refers to this PR compared to the wfa branch.

The tables show results only for *single-end* data because the results for paired-end data look quite bad. I believe this is because I do not apply the end bonus/soft clipping penalty when doing rescue alignment, which makes their scores worse than they should be. I have marked this PR as draft until I fix that.

## Accuracy measured with Jaccard index
 
Dataset | main | wfa branch | wfa+this PR | difference |
-|-|-|-|-|
drosophila/1x50-1M | 81.66 | 81.656 | 81.981 | 0.325
drosophila/1x100-1M | 88.882 | 88.876 | 89.068 | 0.192
drosophila/1x150-1M | 90.657 | 90.645 | 90.775 | 0.13
drosophila/1x200-1M | 91.743 | 91.727 | 91.826 | 0.099
drosophila/1x300-1M | 93.063 | 93.045 | 93.112 | 0.067
CHM13/1x50-1M | 80.771 | 80.765 | 81.102 | 0.337
CHM13/1x100-1M | 90.236 | 90.223 | 90.415 | 0.192
CHM13/1x150-1M | 92.118 | 92.087 | 92.221 | 0.134
CHM13/1x200-1M | 92.995 | 92.961 | 93.062 | 0.101
CHM13/1x300-1M | 93.988 | 93.95 | 94.02 | 0.07
rye/1x50-1M | 44.156 | 44.145 | 44.387 | 0.242
rye/1x100-1M | 68.961 | 68.954 | 69.132 | 0.178
rye/1x150-1M | 80.102 | 80.091 | 80.218 | 0.127
rye/1x200-1M | 85.579 | 85.567 | 85.662 | 0.095
rye/1x300-1M | 90.173 | 90.159 | 90.22 | 0.061
maize/1x50-1M | 46.91 | 46.9 | 47.151 | 0.251
maize/1x100-1M | 70.222 | 70.215 | 70.399 | 0.184
maize/1x150-1M | 80.936 | 80.922 | 81.05 | 0.128
maize/1x200-1M | 86.497 | 86.485 | 86.582 | 0.097
maize/1x300-1M | 91.706 | 91.69 | 91.756 | 0.066

The differences to main are not shown, but they are also all positive.

# Accuracy measured as before

Dataset | main | wfa branch | wfa+this PR | difference |
-|-|-|-|-|
drosophila/1x50-1M | 82.0217 | 82.0175 | 82.0314 | 0.0139
drosophila/1x100-1M | 89.1824 | 89.1777 | 89.1866 | 0.0089
drosophila/1x150-1M | 90.904 | 90.8965 | 90.8995 | 0.003
drosophila/1x200-1M | 91.9516 | 91.9417 | 91.943 | 0.0013
drosophila/1x300-1M | 93.2247 | 93.2118 | 93.2124 | 0.0006
CHM13/1x50-1M | 81.1337 | 81.1282 | 81.1604 | 0.0322
CHM13/1x100-1M | 90.5432 | 90.5376 | 90.5426 | 0.005
CHM13/1x150-1M | 92.3735 | 92.3588 | 92.3627 | 0.0039
CHM13/1x200-1M | 93.2063 | 93.1931 | 93.1947 | 0.0016
CHM13/1x300-1M | 94.1502 | 94.1351 | 94.137 | 0.0019
rye/1x50-1M | 44.3501 | 44.3387 | 44.4244 | 0.0857
rye/1x100-1M | 69.2219 | 69.2158 | 69.2549 | 0.0391
rye/1x150-1M | 80.3844 | 80.3764 | 80.3917 | 0.0153
rye/1x200-1M | 85.8692 | 85.8614 | 85.865 | 0.0036
rye/1x300-1M | 90.4895 | 90.4793 | 90.4754 | -0.0039
maize/1x50-1M | 47.1051 | 47.0946 | 47.1755 | 0.0809
maize/1x100-1M | 70.4435 | 70.4372 | 70.4801 | 0.0429
maize/1x150-1M | 81.1458 | 81.1358 | 81.1523 | 0.0165
maize/1x200-1M | 86.6858 | 86.6788 | 86.6832 | 0.0044
maize/1x300-1M | 91.858 | 91.8473 | 91.8471 | -0.0002
