### PR TITLE
Support reading gzip-compressed references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,10 @@
   without soft clipping are compared more fairly. Use `-L` to change the end
   bonus. (This emulates a feature found in BWA-MEM.)
 * Issue #238: Fix occasionally incorrect soft clipping.
-* PR #239: Align single- and paired-end reads in the same way.
 * PR #239: Fix an uninitialized variable that could lead to nondeterministic
   results.
 * Issue #137: Compute TLEN (in SAM output) correctly
+* PR #255: Add support for reading gzip-compressed reference FASTA files.
 
 ## v0.8.0 (2023-02-01)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ FetchContent_MakeAvailable(cmake_git_version_tracking)
 
 FetchContent_Declare(ZStrGitRepo
   GIT_REPOSITORY    "https://github.com/mateidavid/zstr"
-  GIT_TAG           "master"
+  GIT_TAG           "755da7890ea22478a702e3139092e6c964fab1f5"
 )
 FetchContent_MakeAvailable(ZStrGitRepo)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,12 @@ FetchContent_Declare(cmake_git_version_tracking
 )
 FetchContent_MakeAvailable(cmake_git_version_tracking)
 
+FetchContent_Declare(ZStrGitRepo
+  GIT_REPOSITORY    "https://github.com/mateidavid/zstr"
+  GIT_TAG           "master"
+)
+FetchContent_MakeAvailable(ZStrGitRepo)
+
 add_library(salib STATIC ${SOURCES}
   src/refs.cpp
   src/fastq.cpp
@@ -56,7 +62,7 @@ add_library(salib STATIC ${SOURCES}
   ext/ssw/ssw.c
 )
 target_include_directories(salib PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
-target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads)
+target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr)
 IF(ENABLE_AVX)
   target_compile_options(salib PUBLIC "-mavx2")
 ENDIF()

--- a/tests/test_refs.cpp
+++ b/tests/test_refs.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include "zstr.hpp"
 #include "doctest.h"
 #include "refs.hpp"
 
@@ -50,4 +51,17 @@ TEST_CASE("Reference uppercase") {
     CHECK(refs.sequences[1] == "AACCGGTT");
     CHECK(refs.names.size() == 2);
     CHECK(refs.lengths.size() == 2);
+}
+
+TEST_CASE("Reference gzipped") {
+    {
+        zstr::ofstream ofs("tmpref.fasta.gz");
+        ofs << ">ref1\n"
+            << "acgt\n";
+    }
+    auto refs = References::from_fasta("tmpref.fasta.gz");
+    std::remove("tmpref.fasta.gz");
+    CHECK(refs.sequences.size() == 1);
+    CHECK(refs.names[0] == "ref1");
+    CHECK(refs.sequences[0] == "ACGT");
 }


### PR DESCRIPTION
This PR uses the zstr external library for this. It wraps zlib in a C++-compatible way so that we can use the FASTA parsing function unchanged.

While zstr can also read uncompressed input, it is a bit slower doing so than when using a regular std::ifstream. To avoid a performance regression, we use zstr::ifstream only if the input file name ends with `.gz` but fall back to std::ifstream otherwise.

Supersedes and closes #231