### PR TITLE
Fix compilation with MinGW

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -254,7 +254,11 @@ static inline alignment get_alignment(
         const int diff = std::abs(n.ref_span() - n.query_span());
         const int ext_left = std::min(50, projected_ref_start);
         const int ref_start = projected_ref_start - ext_left;
+#if defined (__MINGW32__)
+        const int ext_right = std::min(std::size_t(50), ref.size() - n.ref_e);
+#else
         const int ext_right = std::min(50ul, ref.size() - n.ref_e);
+#endif
         const auto ref_segm_size = read.size() + diff + ext_left + ext_right;
         const auto ref_segm = ref.substr(ref_start, ref_segm_size);
         info = aligner.align(query, ref_segm);


### PR DESCRIPTION
Small fix to fix an error with MinGW. Without the fix aln.cpp has the following error:

```
C:/msys64/home/User/strobealign/src/aln.cpp:260:39: error: no matching function for call to 'min(long unsigned int, std::__cxx11::basic_string<char>::size_type)'
  260 |         const int ext_right = std::min(50ul, ref.size() - n.ref_e);

```
Fix compilation with MinGW. Credits Biswa96

