### PR TITLE
Emit M instead of =/X CIGAR operations by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * #258: Fix compilation on MinGW. Thanks @teepean.
 * #260: Include full command line in the SAM PG header.
+* #20: Add command-line option `--m-op`. If used, emit `M` CIGAR operations
+  instead of `=` and `X`.
 
 ## v0.9.0 (2023-03-16)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,14 +2,14 @@
 
 ## development version
 
-* #258: Fix compilation on MinGW. Thanks @teepean.
-* #260: Include full command line in the SAM PG header.
-* #20: Add command-line option `--m-op`. If used, emit `M` CIGAR operations
-  instead of `=` and `X`.
+* #258: Fixed compilation on MinGW. Thanks @teepean.
+* #260: Include full command line in the SAM PG header. Thanks @telmin.
+* #20: By default, emit `M` CIGAR operations instead of `=` and `X`.
+  Added option `--eqx` to use `=` and `X` as before.
 
 ## v0.9.0 (2023-03-16)
 
-* Add progress report (only shown if output is not a terminal; can be
+* Added progress report (only shown if output is not a terminal; can be
   disabled with `--no-progress`)
 * PR #250: Avoid overeager soft clipping by adding an “end bonus” to the
   alignment score if the alignment reaches the 5' or 3' end of the read.
@@ -17,12 +17,12 @@
   accuracy, in particular for short reads, as candidate mapping sites with and
   without soft clipping are compared more fairly. Use `-L` to change the end
   bonus. (This emulates a feature found in BWA-MEM.)
-* Issue #238: Fix occasionally incorrect soft clipping.
-* PR #239: Fix an uninitialized variable that could lead to nondeterministic
+* Issue #238: Fixed occasionally incorrect soft clipping.
+* PR #239: Fixed an uninitialized variable that could lead to nondeterministic
   results.
 * Issue #137: Compute TLEN (in SAM output) correctly
-* PR #255: Add support for reading gzip-compressed reference FASTA files.
-* Issue #222: Make it possible again to build strobealign from the release
+* PR #255: Added support for reading gzip-compressed reference FASTA files.
+* Issue #222: Made it possible again to build strobealign from the release
   tarball (not only from the Git repository).
 
 ## v0.8.0 (2023-02-01)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ options. Some important ones are:
   `--create-index`, see [index files](#index-files).
 * `-t N`, `--threads=N`: Use N threads. This mainly applies to the mapping step
   as the indexing step is only partially parallelized.
+* `--eqx`: Emit `=` and `X` CIGAR operations instead of `M`.
 * `-x`: Only map reads, do not do no base-level alignment. This switches the
   output format from SAM to [PAF](https://github.com/lh3/miniasm/blob/master/PAF.md).
 * `--rg-id=ID`: Add RG tag to each SAM record.

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -53,6 +53,7 @@ struct mapping_params {
     int maxTries { 20 };
     int rescue_cutoff;
     bool is_sam_out { true };
+    bool cigar_eqx { true };
     bool output_unmapped { true };
 };
 

--- a/src/cigar.cpp
+++ b/src/cigar.cpp
@@ -2,6 +2,20 @@
 #include <sstream>
 #include "cigar.hpp"
 
+/* Return a new Cigar that uses M operations instead of =/X */
+Cigar Cigar::to_m() const {
+    Cigar cigar;
+    for (auto op_len : m_ops) {
+        auto op = op_len & 0xf;
+        auto len = op_len >> 4;
+        if (op == CIGAR_EQ || op == CIGAR_X) {
+            cigar.push(CIGAR_MATCH, len);
+        } else {
+            cigar.push(op, len);
+        }
+    }
+    return cigar;
+}
 
 Cigar Cigar::to_eqx(const std::string& query, const std::string& ref) const {
     size_t i = 0, j = 0;
@@ -31,9 +45,6 @@ Cigar Cigar::to_eqx(const std::string& query, const std::string& ref) const {
 }
 
 std::string Cigar::to_string() const {
-    if (m_ops.empty()) {
-        return "*";
-    }
     std::stringstream s;
     for (auto op_len : m_ops) {
         s << (op_len >> 4) << "MIDNSHP=X"[op_len & 0xf];

--- a/src/cigar.cpp
+++ b/src/cigar.cpp
@@ -31,6 +31,9 @@ Cigar Cigar::to_eqx(const std::string& query, const std::string& ref) const {
 }
 
 std::string Cigar::to_string() const {
+    if (m_ops.empty()) {
+        return "*";
+    }
     std::stringstream s;
     for (auto op_len : m_ops) {
         s << (op_len >> 4) << "MIDNSHP=X"[op_len & 0xf];

--- a/src/cigar.hpp
+++ b/src/cigar.hpp
@@ -81,6 +81,9 @@ public:
         std::reverse(m_ops.begin(), m_ops.end());
     }
 
+    /* Return a new Cigar that uses M instead of =/X */
+    Cigar to_m() const;
+
     /* Return a new Cigar that uses =/X instead of M */
     Cigar to_eqx(const std::string& query, const std::string& ref) const;
 

--- a/src/cigar.hpp
+++ b/src/cigar.hpp
@@ -26,7 +26,7 @@ public:
 
     explicit Cigar(std::vector<uint32_t> ops) : m_ops(std::move(ops)) { }
 
-    Cigar(Cigar& other) : m_ops(other.m_ops) { }
+    Cigar(const Cigar& other) : m_ops(other.m_ops) { }
 
     explicit Cigar(uint32_t* ops, size_t n) {
         m_ops.assign(ops, ops + n);
@@ -37,6 +37,8 @@ public:
     explicit Cigar(Cigar&& other) noexcept {
         *this = std::move(other);
     }
+
+    Cigar& operator=(const Cigar&) = default;
 
     Cigar& operator=(Cigar&& other) {
         if (this != &other) {

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -26,7 +26,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::ValueFlag<std::string> o(parser, "PATH", "redirect output to file [stdout]", {'o'});
     args::Flag v(parser, "v", "Verbose output", {'v'});
     args::Flag no_progress(parser, "no-progress", "Disable progress report (enabled by default if output is a terminal)", {"no-progress"});
-    args::Flag cigar_m(parser, "cigar-m", "Use CIGAR M instead of =/X", {"m-op"});
+    args::Flag eqx(parser, "eqx", "Emit =/X instead of M CIGAR operations", {"eqx"});
     args::Flag x(parser, "x", "Only map reads, no base level alignment (produces PAF file)", {'x'});
     args::Flag U(parser, "U", "Suppress output of unmapped reads", {'U'});
     args::Flag interleaved(parser, "interleaved", "Interleaved input", {"interleaved"});
@@ -89,7 +89,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (o) { opt.output_file_name = args::get(o); opt.write_to_stdout = false; }
     if (v) { opt.verbose = true; }
     if (no_progress) { opt.show_progress = false; }
-    if (cigar_m) { opt.cigar_eqx = false; }
+    if (eqx) { opt.cigar_eqx = true; }
     if (x) { opt.is_sam_out = false; }
     if (U) { opt.output_unmapped = false; }
     if (rgid) { opt.read_group_id = args::get(rgid); }

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -26,6 +26,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::ValueFlag<std::string> o(parser, "PATH", "redirect output to file [stdout]", {'o'});
     args::Flag v(parser, "v", "Verbose output", {'v'});
     args::Flag no_progress(parser, "no-progress", "Disable progress report (enabled by default if output is a terminal)", {"no-progress"});
+    args::Flag cigar_m(parser, "cigar-m", "Use CIGAR M instead of =/X", {"m-op"});
     args::Flag x(parser, "x", "Only map reads, no base level alignment (produces PAF file)", {'x'});
     args::Flag U(parser, "U", "Suppress output of unmapped reads", {'U'});
     args::Flag interleaved(parser, "interleaved", "Interleaved input", {"interleaved"});
@@ -88,6 +89,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (o) { opt.output_file_name = args::get(o); opt.write_to_stdout = false; }
     if (v) { opt.verbose = true; }
     if (no_progress) { opt.show_progress = false; }
+    if (cigar_m) { opt.cigar_eqx = false; }
     if (x) { opt.is_sam_out = false; }
     if (U) { opt.output_unmapped = false; }
     if (rgid) { opt.read_group_id = args::get(rgid); }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -14,7 +14,7 @@ struct CommandLineOptions {
     bool write_to_stdout { true };
     bool verbose { false };
     bool show_progress { true };
-    bool cigar_eqx { true };
+    bool cigar_eqx { false };
     std::string read_group_id { "" };
     std::vector<std::string> read_group_fields;
     std::string logfile_name { "" };

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -14,6 +14,7 @@ struct CommandLineOptions {
     bool write_to_stdout { true };
     bool verbose { false };
     bool show_progress { true };
+    bool cigar_eqx { true };
     std::string read_group_id { "" };
     std::vector<std::string> read_group_fields;
     std::string logfile_name { "" };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,6 +172,7 @@ int run_strobealign(int argc, char **argv) {
     map_param.R = opt.R;
     map_param.maxTries = opt.maxTries;
     map_param.is_sam_out = opt.is_sam_out;
+    map_param.cigar_eqx = opt.cigar_eqx;
     map_param.output_unmapped = opt.output_unmapped;
 
     log_parameters(index_parameters, map_param, aln_params);

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -146,7 +146,8 @@ void perform_task(
 
         std::string sam_out;
         sam_out.reserve(7*map_param.r * (records1.size() + records3.size()));
-        Sam sam{sam_out, references, CigarOps::EQX, read_group_id, map_param.output_unmapped};
+        CigarOps cigar_ops = map_param.cigar_eqx ? CigarOps::EQX : CigarOps::M;
+        Sam sam{sam_out, references, cigar_ops, read_group_id, map_param.output_unmapped};
         for (size_t i = 0; i < records1.size(); ++i) {
             auto record1 = records1[i];
             auto record2 = records2[i];

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -146,7 +146,7 @@ void perform_task(
 
         std::string sam_out;
         sam_out.reserve(7*map_param.r * (records1.size() + records3.size()));
-        Sam sam{sam_out, references, read_group_id, map_param.output_unmapped};
+        Sam sam{sam_out, references, CigarOps::EQX, read_group_id, map_param.output_unmapped};
         for (size_t i = 0; i < records1.size(); ++i) {
             auto record1 = records1[i];
             auto record2 = records2[i];

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -42,6 +42,20 @@ void Sam::append_tail() {
     sam_string.append(tail);
 }
 
+std::string Sam::cigar_string(const Cigar& cigar) const {
+    if (cigar.empty()) {
+        // This case should normally not occur because
+        // unmapped reads would be added with add_unmapped,
+        // which hardcodes the "*"
+        return "*";
+    }
+    if (cigar_ops == CigarOps::EQX) {
+        return cigar.to_string();
+    } else {
+        return cigar.to_m().to_string();
+    }
+}
+
 void Sam::add_unmapped(const KSeq& record, int flags) {
     if (!output_unmapped) {
         return;
@@ -124,7 +138,7 @@ void Sam::add_record(
     sam_string.append("\t");
     sam_string.append(std::to_string(mapq));
     sam_string.append("\t");
-    sam_string.append(cigar.to_string());
+    sam_string.append(cigar_string(cigar));
     sam_string.append("\t");
 
     sam_string.append(mate_name);

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -104,7 +104,7 @@ void Sam::add_record(
     const std::string& reference_name,
     int pos,
     int mapq,
-    const std::string& cigar,
+    const Cigar& cigar,
     const std::string& mate_name,
     int mate_ref_start,
     int template_len,
@@ -124,7 +124,7 @@ void Sam::add_record(
     sam_string.append("\t");
     sam_string.append(std::to_string(mapq));
     sam_string.append("\t");
-    sam_string.append(cigar);
+    sam_string.append(cigar.to_string());
     sam_string.append("\t");
 
     sam_string.append(mate_name);

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -1,12 +1,14 @@
-#ifndef SAM_HPP
-#define SAM_HPP
+#ifndef STROBEALIGN_SAM_HPP
+#define STROBEALIGN_SAM_HPP
 
 #include <string>
 #include "kseq++.hpp"
 #include "refs.hpp"
+#include "cigar.hpp"
+
 
 struct alignment {
-    std::string cigar;
+    Cigar cigar;
     int ref_start;
     int ed;
     int global_ed;
@@ -55,7 +57,7 @@ public:
     void add_unmapped_pair(const klibpp::KSeq& r1, const klibpp::KSeq& r2);
     void add_unmapped_mate(const klibpp::KSeq& record, int flags, const std::string& mate_rname, int mate_pos);
 
-    void add_record(const std::string& query_name, int flags, const std::string& reference_name, int pos, int mapq, const std::string& cigar, const std::string& mate_name, int mate_ref_start, int template_len, const std::string& query_sequence, const std::string& query_sequence_rc, const std::string& qual, int ed, int aln_score);
+    void add_record(const std::string& query_name, int flags, const std::string& reference_name, int pos, int mapq, const Cigar& cigar, const std::string& mate_name, int mate_ref_start, int template_len, const std::string& query_sequence, const std::string& query_sequence_rc, const std::string& qual, int ed, int aln_score);
 
 private:
     void append_tail();

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -36,12 +36,24 @@ enum SamFlags {
     SUPPLEMENTARY = 0x800,
 };
 
+enum struct CigarOps {
+    EQX = 0,  // use = and X CIGAR operations
+    M = 1,    // use M CIGAR operations
+};
+
 class Sam {
 
 public:
-    Sam(std::string& sam_string, const References& references, const std::string& read_group_id = "", bool output_unmapped = true)
+    Sam(
+        std::string& sam_string,
+        const References& references,
+        CigarOps cigar_ops = CigarOps::EQX,
+        const std::string& read_group_id = "",
+        bool output_unmapped = true
+    )
         : sam_string(sam_string)
         , references(references)
+        , cigar_ops(cigar_ops)
         , output_unmapped(output_unmapped) {
             if (read_group_id.empty()) {
                 tail = "\n";
@@ -61,8 +73,10 @@ public:
 
 private:
     void append_tail();
+    std::string cigar_string(const Cigar& cigar) const;
     std::string& sam_string;
     const References& references;
+    const CigarOps cigar_ops;
     std::string tail;
     bool output_unmapped;
 };

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -25,6 +25,12 @@ strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library -v tests/phi
 diff tests/phix.se.sam phix.se.sam
 rm phix.se.sam
 
+# Single-end SAM, M CIGAR operators
+strobealign --m-op tests/phix.fasta tests/phix.1.fastq | grep -v '^@PG' > phix.se.m.sam
+if samtools view phix.se.m.sam | cut -f6 | grep -q '[X=]'; then false; fi
+
+rm phix.se.m.sam
+
 # Paired-end SAM
 strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library tests/phix.fasta tests/phix.1.fastq tests/phix.2.fastq | grep -v '^@PG' > phix.pe.sam
 diff tests/phix.pe.sam phix.pe.sam

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -21,18 +21,18 @@ if strobealign -G > /dev/null 2> /dev/null; then false; fi
 strobealign -h > /dev/null
 
 # Single-end SAM
-strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library -v tests/phix.fasta tests/phix.1.fastq | grep -v '^@PG' > phix.se.sam
+strobealign --eqx --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library -v tests/phix.fasta tests/phix.1.fastq | grep -v '^@PG' > phix.se.sam
 diff tests/phix.se.sam phix.se.sam
 rm phix.se.sam
 
 # Single-end SAM, M CIGAR operators
-strobealign --m-op tests/phix.fasta tests/phix.1.fastq | grep -v '^@PG' > phix.se.m.sam
+strobealign tests/phix.fasta tests/phix.1.fastq | grep -v '^@PG' > phix.se.m.sam
 if samtools view phix.se.m.sam | cut -f6 | grep -q '[X=]'; then false; fi
 
 rm phix.se.m.sam
 
 # Paired-end SAM
-strobealign --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library tests/phix.fasta tests/phix.1.fastq tests/phix.2.fastq | grep -v '^@PG' > phix.pe.sam
+strobealign --eqx --chunk-size 3 --rg-id 1 --rg SM:sample --rg LB:library tests/phix.fasta tests/phix.1.fastq tests/phix.2.fastq | grep -v '^@PG' > phix.pe.sam
 diff tests/phix.pe.sam phix.pe.sam
 rm phix.pe.sam
 

--- a/tests/test_aligner.cpp
+++ b/tests/test_aligner.cpp
@@ -7,7 +7,7 @@ TEST_CASE("hamming_align") {
         "", "",
         7, 5, 0
     );
-    CHECK(info.cigar.to_string() == "");
+    CHECK(info.cigar.empty());
     CHECK(info.edit_distance == 0);
     CHECK(info.sw_score == 0);
     CHECK(info.ref_start == 0);

--- a/tests/test_cigar.cpp
+++ b/tests/test_cigar.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Parse CIGAR") {
 
 TEST_CASE("Cigar construction and push") {
     Cigar c1;
-    CHECK(c1.to_string() == "*");
+    CHECK(c1.to_string() == "");
 
     c1.push(CIGAR_MATCH, 1);
     CHECK(c1.to_string() == "1M");
@@ -47,7 +47,7 @@ TEST_CASE("Cigar construction and push") {
     CHECK(c2.to_string() == "3M5X7I13D");
 }
 
-TEST_CASE("Cigar =/X conversion") {
+TEST_CASE("Cigar conversion from M to =/X") {
     Cigar c1{"1M"};
     CHECK(c1.to_eqx("A", "A").to_string() == "1=");
     CHECK(c1.to_eqx("A", "G").to_string() == "1X");
@@ -59,6 +59,12 @@ TEST_CASE("Cigar =/X conversion") {
 
     Cigar c{"2M 1D 4M 1I 3M"};
     CHECK(c.to_eqx("ACTTTGCATT", "ACGTATGAAA").to_string() == "2=1D1=1X2=1I1=2X");
+}
+
+TEST_CASE("Cigar conversion from =/X to M") {
+    CHECK(Cigar("").to_m().empty());
+    CHECK(Cigar("5=").to_m().to_string() == "5M");
+    CHECK(Cigar("5S3=1X2=4S").to_m().to_string() == "5S6M4S");
 }
 
 TEST_CASE("concatenate Cigar") {

--- a/tests/test_cigar.cpp
+++ b/tests/test_cigar.cpp
@@ -12,10 +12,9 @@ TEST_CASE("compress_cigar") {
 }
 
 TEST_CASE("Parse CIGAR") {
-    std::vector<std::string> cigars = {"", "1M", "10M2I1D99=1X4P5S"};
-    for (auto& s : cigars) {
-        CHECK(Cigar(s).to_string() == s);
-    }
+    CHECK(Cigar("").empty());
+    CHECK(Cigar("1M").to_string() == "1M");
+    CHECK(Cigar("10M2I1D99=1X4P5S").to_string() == "10M2I1D99=1X4P5S");
     // Not standard, only for convenience
     CHECK(Cigar("M").to_string() == "1M");
     CHECK(Cigar("M M").to_string() == "2M");
@@ -26,7 +25,7 @@ TEST_CASE("Parse CIGAR") {
 
 TEST_CASE("Cigar construction and push") {
     Cigar c1;
-    CHECK(c1.to_string() == "");
+    CHECK(c1.to_string() == "*");
 
     c1.push(CIGAR_MATCH, 1);
     CHECK(c1.to_string() == "1M");

--- a/tests/test_sam.cpp
+++ b/tests/test_sam.cpp
@@ -24,6 +24,35 @@ TEST_CASE("Formatting unmapped SAM record") {
     }
 }
 
+TEST_CASE("Sam::add") {
+    References references;
+    references.add("contig1", "AACCGGTT");
+    std::string sam_string;
+    Sam sam(sam_string, references);
+
+    klibpp::KSeq record;
+    record.name = "readname";
+    record.seq = "AACGT";
+    record.qual = ">#BB";
+
+    alignment aln;
+    aln.ref_id = 0;
+    aln.is_unaligned = false;
+    aln.is_rc = true;
+    aln.ref_start = 2;
+    aln.ed = 3;
+    aln.aln_score = 9;
+    aln.mapq = 55;
+    aln.cigar = Cigar("2S2=1X3=3S");
+
+    std::string read_rc = reverse_complement(record.seq);
+    bool is_secondary = false;
+    sam.add(aln, record, read_rc, is_secondary);
+    CHECK(sam_string ==
+        "readname\t16\tcontig1\t3\t55\t2S2=1X3=3S\t*\t0\t0\tACGTT\tBB#>\tNM:i:3\tAS:i:9\n"
+    );
+}
+
 TEST_CASE("Pair with one unmapped SAM record") {
     References references;
     references.add("contig1", "ACGT");

--- a/tests/test_sam.cpp
+++ b/tests/test_sam.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Pair with one unmapped SAM record") {
     aln1.is_rc = true;
     aln1.ed = 17;
     aln1.aln_score = 9;
-    aln1.cigar = "2M";
+    aln1.cigar = Cigar("2M");
 
     alignment aln2;
     aln2.is_unaligned = true;
@@ -91,7 +91,7 @@ TEST_CASE("TLEN zero when reads map to different contigs") {
     aln1.is_rc = false;
     aln1.ed = 17;
     aln1.aln_score = 9;
-    aln1.cigar = "2M";
+    aln1.cigar = Cigar("2M");
 
     alignment aln2;
     aln2.is_unaligned = false;
@@ -100,7 +100,7 @@ TEST_CASE("TLEN zero when reads map to different contigs") {
     aln2.is_rc = false;
     aln2.ed = 2;
     aln2.aln_score = 4;
-    aln2.cigar = "3M";
+    aln2.cigar = Cigar("3M");
 
     klibpp::KSeq record1;
     klibpp::KSeq record2;


### PR DESCRIPTION
I needed to do some refactoring so that CIGARs are internally always represented as `Cigar` objects and only converted to their string representation at the very last moment when the alignments are serialized to SAM format. This makes it easy to optionally convert them to use `M` instead of `=`/`X` operations since the logic for that needs to be in only one place.

I chose `--m-op` as the name for the command-line option for now, but I’m not super happy with it. Bowtie2 and minimap2 have an `--eqx` switch and the opposite behavior: `M` by default and `=`/`X` is optional. Perhaps we should change the default as well for better compatibility? Also, that would avoid the spurious variant calling issue as long as htslib is not fixed.
