### PR TITLE
Use --eqx option when doing baseline comparison

### DIFF
--- a/tests/compare-baseline.sh
+++ b/tests/compare-baseline.sh
@@ -62,7 +62,7 @@ builddir=$(mktemp -p . -d build.XXXXXXX)
 cmake . -B ${builddir} ${cmake_options}
 make -j 4 -C ${builddir} strobealign
 set -x
-${builddir}/strobealign -t 4 ${ref} ${reads[@]} | samtools view -o head.bam
+${builddir}/strobealign --eqx -t 4 ${ref} ${reads[@]} | samtools view -o head.bam
 rm -rf ${builddir}
 
 # Do the actual comparison


### PR DESCRIPTION
Otherwise, we compare non-M with M CIGAR strings when there are any other differences (different CIGAR strings alone do not cause two alignments to be considered different, which is why the tests still run fine even after switching the default to M CIGAR).