### PR TITLE
fix overflow n_reads in show_progress_until_done

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -713,7 +713,7 @@ static inline void rescue_mate(
     alignment &sam_aln,
     float mu,
     float sigma,
-    unsigned int &tot_rescued,
+    size_t &tot_rescued,
     int k
 ) {
     int a, b, ref_start,ref_len,ref_end;

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -713,7 +713,7 @@ static inline void rescue_mate(
     alignment &sam_aln,
     float mu,
     float sigma,
-    size_t &tot_rescued,
+    uint64_t &tot_rescued,
     int k
 ) {
     int a, b, ref_start,ref_len,ref_end;

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -19,12 +19,12 @@ struct AlignmentStatistics {
     std::chrono::duration<double> tot_extend{0};
     std::chrono::duration<double> tot_write_file{0};
 
-    unsigned int n_reads = 0;
-    unsigned int tot_aligner_calls = 0;
-    unsigned int tot_rescued = 0;
-    unsigned int tot_all_tried = 0;
-    unsigned int did_not_fit = 0;
-    unsigned int tried_rescue = 0;
+    size_t n_reads = 0;
+    size_t tot_aligner_calls = 0;
+    size_t tot_rescued = 0;
+    size_t tot_all_tried = 0;
+    size_t did_not_fit = 0;
+    size_t tried_rescue = 0;
 
     AlignmentStatistics operator+=(const AlignmentStatistics& other) {
         this->tot_read_file += other.tot_read_file;

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -19,12 +19,12 @@ struct AlignmentStatistics {
     std::chrono::duration<double> tot_extend{0};
     std::chrono::duration<double> tot_write_file{0};
 
-    size_t n_reads = 0;
-    size_t tot_aligner_calls = 0;
-    size_t tot_rescued = 0;
-    size_t tot_all_tried = 0;
-    size_t did_not_fit = 0;
-    size_t tried_rescue = 0;
+    uint64_t n_reads = 0;
+    uint64_t tot_aligner_calls = 0;
+    uint64_t tot_rescued = 0;
+    uint64_t tot_all_tried = 0;
+    uint64_t did_not_fit = 0;
+    uint64_t tried_rescue = 0;
 
     AlignmentStatistics operator+=(const AlignmentStatistics& other) {
         this->tot_read_file += other.tot_read_file;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ void show_progress_until_done(std::vector<int>& worker_done, std::vector<Alignme
                 continue;
             }
         }
-        auto n_reads = 0;
+        auto n_reads = 0ull;
         for (auto& stat : stats) {
             n_reads += stat.n_reads;
         }


### PR DESCRIPTION
Hi.
I was running Strobealign on a large file and noticed that it overflows when the number of reads exceeds the int limit.
n_reads are type inferred as signed int, but here it is better to use size_t.
I fixed this and would appreciate it if you could merge it.
