### PR TITLE
Use ISA-L to speed up gzip decompression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install nasm
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install nasm
       - name: Build
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install nasm
+        run: sudo apt-get install libisal-dev
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
-        run: brew install nasm
+        run: brew install isa-l
       - name: Build
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -56,10 +56,10 @@ jobs:
           python-version: "3.10"
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install nasm
+        run: sudo apt-get install libisal-dev
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
-        run: brew install nasm
+        run: brew install isa-l
       - name: Install Python dependencies
         run: pip install pytest
       - name: Install Python bindings
@@ -109,10 +109,10 @@ jobs:
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install nasm
+        run: sudo apt-get install libisal-dev
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
-        run: brew install nasm
+        run: brew install isa-l
       - name: Build HEAD version
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,12 @@ jobs:
           make -j3 -C baseline/build
           baseline/build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view -o baseline.bam
 
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install nasm
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install nasm
       - name: Build HEAD version
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install nasm
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install nasm
       - name: Install Python dependencies
         run: pip install pytest
       - name: Install Python bindings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,20 @@ FetchContent_Declare(ZStrGitRepo
 )
 FetchContent_MakeAvailable(ZStrGitRepo)
 
+### add isal
+include(ExternalProject)
+ExternalProject_Add(
+  ISAL
+  GIT_REPOSITORY https://github.com/intel/isa-l
+  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ISAL
+  BUILD_IN_SOURCE 1
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND make -f Makefile.unx
+  INSTALL_COMMAND ""
+)
+set(ISAL_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/ISAL/src/ISAL/include")
+set(ISAL_LIB "${CMAKE_CURRENT_BINARY_DIR}/ISAL/src/ISAL/bin/isa-l.a")
+
 # Obtain version from Git or fall back to PROJECT_VERSION if not building
 # from a Git repository
 add_custom_target(version
@@ -67,8 +81,9 @@ add_library(salib STATIC ${SOURCES}
   ext/ssw/ssw_cpp.cpp
   ext/ssw/ssw.c
 )
-target_include_directories(salib PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
-target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr)
+target_include_directories(salib PUBLIC src/ ext/ ${PROJECT_BINARY_DIR} ${ISAL_INCLUDE_DIR})
+target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr ${ISAL_LIB})
+add_dependencies(salib ISAL)
 IF(ENABLE_AVX)
   target_compile_options(salib PUBLIC "-mavx2")
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(PYTHON_BINDINGS "Build Python bindings" OFF)
 find_package(ZLIB)
 find_package(Threads)
 find_package(OpenMP)
+find_package(PkgConfig REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -68,7 +69,6 @@ add_library(salib STATIC ${SOURCES}
   ext/ssw/ssw_cpp.cpp
   ext/ssw/ssw.c
 )
-find_package(PkgConfig REQUIRED)
 pkg_check_modules(ISAL REQUIRED IMPORTED_TARGET GLOBAL libisal>=2.30.0)
 target_include_directories(salib PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
 target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr PkgConfig::ISAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,21 +31,6 @@ FetchContent_Declare(ZStrGitRepo
 )
 FetchContent_MakeAvailable(ZStrGitRepo)
 
-### add isal
-include(ExternalProject)
-ExternalProject_Add(
-  ISAL
-  GIT_REPOSITORY https://github.com/intel/isa-l
-  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ISAL
-  BUILD_IN_SOURCE 1
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND make -f Makefile.unx
-  INSTALL_COMMAND ""
-)
-ExternalProject_Get_property(ISAL SOURCE_DIR)
-set(ISAL_INCLUDE_DIR "${SOURCE_DIR}/include")
-set(ISAL_LIB "${SOURCE_DIR}/bin/isa-l.a")
-
 # Obtain version from Git or fall back to PROJECT_VERSION if not building
 # from a Git repository
 add_custom_target(version
@@ -83,9 +68,10 @@ add_library(salib STATIC ${SOURCES}
   ext/ssw/ssw_cpp.cpp
   ext/ssw/ssw.c
 )
-target_include_directories(salib PUBLIC src/ ext/ ${PROJECT_BINARY_DIR} ${ISAL_INCLUDE_DIR})
-target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr ${ISAL_LIB})
-add_dependencies(salib ISAL)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(ISAL REQUIRED IMPORTED_TARGET GLOBAL libisal>=2.30.0)
+target_include_directories(salib PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
+target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr PkgConfig::ISAL)
 IF(ENABLE_AVX)
   target_compile_options(salib PUBLIC "-mavx2")
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(salib STATIC ${SOURCES}
   src/readlen.cpp
   src/version.cpp
   src/io.cpp
+  src/iowrap.cpp
   ext/xxhash.c
   ext/ssw/ssw_cpp.cpp
   ext/ssw/ssw.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,9 @@ ExternalProject_Add(
   BUILD_COMMAND make -f Makefile.unx
   INSTALL_COMMAND ""
 )
-set(ISAL_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/ISAL/src/ISAL/include")
-set(ISAL_LIB "${CMAKE_CURRENT_BINARY_DIR}/ISAL/src/ISAL/bin/isa-l.a")
+ExternalProject_Get_property(ISAL SOURCE_DIR)
+set(ISAL_INCLUDE_DIR "${SOURCE_DIR}/include")
+set(ISAL_LIB "${SOURCE_DIR}/bin/isa-l.a")
 
 # Obtain version from Git or fall back to PROJECT_VERSION if not building
 # from a Git repository

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -1,7 +1,7 @@
 #include "fastq.hpp"
 
 namespace {
-    bool checkExt(const std::string& filename, const std::string& target_ext)
+    bool check_ext(const std::string& filename, const std::string& target_ext)
     {
         auto ext_pos = filename.find_last_of(".");
         if(ext_pos == std::string::npos) {
@@ -15,22 +15,22 @@ namespace {
         return false;
     }
 
-    inline bool isGzip(const std::string& filename)
+    inline bool is_gzip(const std::string& filename)
     {
-        return checkExt(filename, ".gz");
+        return check_ext(filename, ".gz");
     }
 
-    inline bool isRaw(const std::string& filename)
+    inline bool is_raw(const std::string& filename)
     {
-        return checkExt(filename, ".fq") || checkExt(filename, ".fastq");
+        return check_ext(filename, ".fq") || check_ext(filename, ".fastq");
     }
 
-    std::unique_ptr<AbstructIO> CreateIO(const std::string& filename)
+    std::unique_ptr<AbstructIO> create_io(const std::string& filename)
     {
         std::unique_ptr<AbstructIO> io;
-        if(isGzip(filename)) {
+        if(is_gzip(filename)) {
             io = std::make_unique<IsalIO>(filename);
-        } else if(isRaw(filename)) {
+        } else if(is_raw(filename)) {
             io = std::make_unique<RawIO>(filename);
         } else {
             io = std::make_unique<GeneralIO>(filename);
@@ -44,7 +44,7 @@ RewindableFile::RewindableFile(const std::string& filename)
     rewindable(true),
     stream_(klibpp::make_ikstream(this, rewind_read, 16384)) {
 
-    file = CreateIO(filename);
+    file = create_io(filename);
 
     stream_ = klibpp::make_ikstream(this, rewind_read, 16384);
 }

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -4,6 +4,9 @@ namespace {
     inline bool checkExt(const std::string& filename, const std::string& target_ext)
     {
         auto ext_pos = filename.find_last_of(".");
+        if(ext_pos == std::string::npos) {
+            return false;
+        }
         auto ext = filename.substr(ext_pos, filename.size() - ext_pos);
         if(ext == target_ext) {
             return true;

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -1,11 +1,36 @@
 #include "fastq.hpp"
 
+namespace {
+    inline bool isGzip(const std::string& filename)
+    {
+        auto ext_pos = filename.find_last_of(".");
+        auto ext = filename.substr(ext_pos, filename.size() - ext_pos);
+        if(ext == ".gz") {
+            return true;
+        }
+
+        return false;
+    }
+
+    std::unique_ptr<AbstructIO> CreateIO(const std::string& filename)
+    {
+        std::unique_ptr<AbstructIO> io;
+        if(isGzip(filename)) {
+            io = std::make_unique<IsalIO>(filename);
+        } else {
+            io = std::make_unique<GeneralIO>(filename);
+        }
+        return io;
+    }
+};
+
 RewindableFile::RewindableFile(const std::string& filename)
     : file(nullptr),
     rewindable(true),
     stream_(klibpp::make_ikstream(this, rewind_read, 16384)) {
 
-    file = std::make_unique<GeneralIO>(filename);
+    file = CreateIO(filename);
+
     stream_ = klibpp::make_ikstream(this, rewind_read, 16384);
 }
 

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -25,9 +25,9 @@ namespace {
         return check_ext(filename, ".fq") || check_ext(filename, ".fastq");
     }
 
-    std::unique_ptr<AbstructIO> create_io(const std::string& filename)
+    std::unique_ptr<AbstractIO> create_io(const std::string& filename)
     {
-        std::unique_ptr<AbstructIO> io;
+        std::unique_ptr<AbstractIO> io;
         if(is_gzip(filename)) {
             io = std::make_unique<IsalIO>(filename);
         } else if(is_raw(filename)) {

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -1,15 +1,25 @@
 #include "fastq.hpp"
 
 namespace {
-    inline bool isGzip(const std::string& filename)
+    inline bool checkExt(const std::string& filename, const std::string& target_ext)
     {
         auto ext_pos = filename.find_last_of(".");
         auto ext = filename.substr(ext_pos, filename.size() - ext_pos);
-        if(ext == ".gz") {
+        if(ext == target_ext) {
             return true;
         }
 
         return false;
+    }
+
+    inline bool isGzip(const std::string& filename)
+    {
+        return checkExt(filename, ".gz");
+    }
+
+    inline bool isRaw(const std::string& filename)
+    {
+        return checkExt(filename, ".fq") || checkExt(filename, ".fastq");
     }
 
     std::unique_ptr<AbstructIO> CreateIO(const std::string& filename)
@@ -17,6 +27,8 @@ namespace {
         std::unique_ptr<AbstructIO> io;
         if(isGzip(filename)) {
             io = std::make_unique<IsalIO>(filename);
+        } else if(isRaw(filename)) {
+            io = std::make_unique<RawIO>(filename);
         } else {
             io = std::make_unique<GeneralIO>(filename);
         }

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -1,7 +1,7 @@
 #include "fastq.hpp"
 
 namespace {
-    inline bool checkExt(const std::string& filename, const std::string& target_ext)
+    bool checkExt(const std::string& filename, const std::string& target_ext)
     {
         auto ext_pos = filename.find_last_of(".");
         if(ext_pos == std::string::npos) {

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -25,15 +25,15 @@ namespace {
         return check_ext(filename, ".fq") || check_ext(filename, ".fastq");
     }
 
-    std::unique_ptr<AbstractIO> create_io(const std::string& filename)
+    std::unique_ptr<Reader> create_io(const std::string& filename)
     {
-        std::unique_ptr<AbstractIO> io;
+        std::unique_ptr<Reader> io;
         if(is_gzip(filename)) {
-            io = std::make_unique<IsalIO>(filename);
+            io = std::make_unique<IsalGzipReader>(filename);
         } else if(is_raw(filename)) {
-            io = std::make_unique<RawIO>(filename);
+            io = std::make_unique<UncompressReader>(filename);
         } else {
-            io = std::make_unique<GeneralIO>(filename);
+            io = std::make_unique<GzipReader>(filename);
         }
         return io;
     }

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -4,17 +4,12 @@ RewindableFile::RewindableFile(const std::string& filename)
     : file(nullptr),
     rewindable(true),
     stream_(klibpp::make_ikstream(this, rewind_read, 16384)) {
-    if (filename != "") {
-        file = gzopen(filename.c_str(), "r");
-        if (file == nullptr) {
-            throw InvalidFile("Could not open FASTQ file: " + filename);
-        }
-    }
+
+    file = std::make_unique<GeneralIO>(filename);
     stream_ = klibpp::make_ikstream(this, rewind_read, 16384);
 }
 
 RewindableFile::~RewindableFile() {
-    if (file) gzclose(file);
 }
 
 void RewindableFile::rewind() {
@@ -41,7 +36,7 @@ int RewindableFile::read(void* buffer, const int length) {
         return can_read +
             this->read(static_cast<char*>(buffer) + can_read, length - can_read);
     }
-    const int bytes_read = gzread(file, buffer, length);
+    const auto bytes_read = file->read(buffer, length);
     if (bytes_read < 0) {
         throw std::runtime_error("Error reading FASTQ file");
     }

--- a/src/fastq.hpp
+++ b/src/fastq.hpp
@@ -7,6 +7,8 @@
 #include "exceptions.hpp"
 #include "kseq++.hpp"
 
+#include "iowrap.hpp"
+
 // File that can be rewound (once only!)
 class RewindableFile {
 
@@ -23,7 +25,7 @@ public:
     void rewind();
 
 protected:
-    gzFile file;
+    std::unique_ptr<AbstructIO> file;
     std::vector<std::vector<unsigned char>> saved_buffer;
     // if rewindable is false, the file cannot be rewound anymore and is consuming from saved_buffer (if it is not empty)
     bool rewindable;

--- a/src/fastq.hpp
+++ b/src/fastq.hpp
@@ -25,7 +25,7 @@ public:
     void rewind();
 
 protected:
-    std::unique_ptr<AbstractIO> file;
+    std::unique_ptr<Reader> file;
     std::vector<std::vector<unsigned char>> saved_buffer;
     // if rewindable is false, the file cannot be rewound anymore and is consuming from saved_buffer (if it is not empty)
     bool rewindable;

--- a/src/fastq.hpp
+++ b/src/fastq.hpp
@@ -25,7 +25,7 @@ public:
     void rewind();
 
 protected:
-    std::unique_ptr<AbstructIO> file;
+    std::unique_ptr<AbstractIO> file;
     std::vector<std::vector<unsigned char>> saved_buffer;
     // if rewindable is false, the file cannot be rewound anymore and is consuming from saved_buffer (if it is not empty)
     bool rewindable;

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -22,6 +22,28 @@ int64_t GeneralIO::read(void* buffer, size_t length)
     return gzread(file, buffer, length);
 }
 
+void RawIO::open(const std::string& filename)
+{
+    fd = ::open(filename.c_str(), 0);
+    if(fd < 0) {
+        throw InvalidFile("Could not open FASTQ file: " + filename);
+    }
+}
+
+void RawIO::close()
+{
+    if(fd != -1) {
+        ::close(fd);
+    }
+    fd = -1;
+}
+
+int64_t RawIO::read(void* buffer, size_t length)
+{
+    ssize_t ret = ::read(fd, buffer, length);
+    return ret;
+}
+
 void IsalIO::initialize()
 {
     isal_inflate_init(&state);

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -1,5 +1,11 @@
 #include "iowrap.hpp"
 #include "exceptions.hpp"
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <system_error>
+#include <cstring>
 
 void GeneralIO::open(const std::string& filename)
 {
@@ -14,4 +20,132 @@ void GeneralIO::open(const std::string& filename)
 int64_t GeneralIO::read(void* buffer, size_t length)
 {
     return gzread(file, buffer, length);
+}
+
+void IsalIO::initialize()
+{
+    isal_inflate_init(&state);
+    state.crc_flag = ISAL_GZIP_NO_HDR_VER;
+
+    isal_gzip_header_init(&gz_hdr);
+}
+
+void IsalIO::open(const std::string& filename)
+{
+    fd = ::open(filename.c_str(), 0);
+    if(fd < 0) {
+        throw InvalidFile("Could not open FASTQ file: " + filename);
+    }
+
+    struct stat _stat;
+    if(fstat(fd, &_stat) < 0) {
+        throw std::system_error(errno, std::generic_category(), filename);
+    }
+    filesize = _stat.st_size;
+
+    mmap_mem = mmap(NULL, filesize, PROT_READ, MAP_SHARED, fd, 0);
+    if(mmap_mem == MAP_FAILED) {
+        mmap_mem = NULL;
+        if(errno == ENODEV) {
+            throw std::system_error(errno, std::generic_category(), "mmap is not supported on this file: " + filename);
+        }
+        if(errno == ENOMEM) {
+            throw std::system_error(errno, std::generic_category(), "There not enough memory to open file: " + filename);
+        } else {
+            throw std::system_error(errno, std::generic_category(), "mmap failed to open file: " + filename);
+        }
+    }
+    mmap_size       = filesize;
+    compressed_data = reinterpret_cast<uint8_t*>(mmap_mem);
+    compressed_size = mmap_size;
+
+    // decompress gz header
+    state.next_in  = compressed_data;
+    state.avail_in = std::min(decompress_chunk_size, compressed_size);
+    auto pre       = state.avail_in;
+
+    int ret = isal_read_gzip_header(&state, &gz_hdr);
+    if(ret != ISAL_DECOMP_OK) {
+        throw std::runtime_error("Invalid gzip header found");
+    }
+    size_t processed_size = pre - state.avail_in;
+    compressed_data += processed_size;
+    compressed_size -= processed_size;
+
+    thread_reader = std::thread(&IsalIO::decompress, this, std::min(decompress_chunk_size, compressed_size));
+}
+
+void IsalIO::close()
+{
+    if(thread_reader.joinable()) thread_reader.join();
+
+    if(mmap_mem != nullptr) {
+        munmap(mmap_mem, mmap_size);
+    }
+    mmap_mem  = nullptr;
+    mmap_size = 0;
+
+    if(fd != -1)
+        ::close(fd);
+    fd = -1;
+}
+
+int64_t IsalIO::read(void* buffer, size_t length)
+{
+    size_t actual_count = 0;
+    while(length > 0) {
+        size_t size_from_data = std::min(length, uncompressed_data.size() - uncompressed_data_copied);
+        memcpy(buffer, uncompressed_data.data() + uncompressed_data_copied, size_from_data);
+        buffer = (uint8_t*)buffer + size_from_data;
+        length -= size_from_data;
+        uncompressed_data_copied += size_from_data;
+        actual_count += size_from_data;
+
+        if(uncompressed_data_copied == uncompressed_data.size()) {
+            if(thread_reader.joinable()) {
+                thread_reader.join();
+                std::swap(uncompressed_data, uncompressed_data_work);
+                uncompressed_data_copied = 0;
+                if(uncompressed_data.size() == 0) {
+                    break;
+                }
+            }
+            thread_reader = std::thread(&IsalIO::decompress, this, std::min(decompress_chunk_size, compressed_size));
+        }
+    }
+    return actual_count;
+}
+
+void IsalIO::decompress(size_t count)
+{
+    uncompressed_data_work.resize(std::max(count, previous_member_size));
+    uint8_t* ptr = uncompressed_data_work.data();
+
+    while(ptr - uncompressed_data_work.data() < count) {
+        if(compressed_size == 0) break;
+
+        size_t actual_input_size     = std::min(decompress_chunk_size, compressed_size);
+        size_t output_size_available = uncompressed_data_work.data() + uncompressed_data_work.size() - ptr;
+
+        state.next_in  = compressed_data;
+        state.avail_in = actual_input_size;
+
+        state.next_out  = ptr;
+        state.avail_out = output_size_available;
+
+        auto ret = isal_inflate(&state);
+        if(ret != ISAL_DECOMP_OK) {
+            throw std::runtime_error("Error encountered whikle decompressing");
+            exit(-1);
+        }
+
+        size_t processed = actual_input_size - state.avail_in;
+        size_t decomp    = (size_t)(uintptr_t)(state.next_out - ptr);
+
+        compressed_data += processed;
+        compressed_size -= processed;
+        ptr += decomp;
+    }
+    uncompressed_data_work.resize(ptr - uncompressed_data_work.data());
+    previous_member_size = uncompressed_data_work.size();
 }

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -190,7 +190,7 @@ void IsalIO::decompress(size_t count)
 
         auto ret = isal_inflate(&state);
         if(ret != ISAL_DECOMP_OK) {
-            throw std::runtime_error("Error encountered whikle decompressing");
+            throw std::runtime_error("Error encountered while decompressing");
             exit(-1);
         }
 

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -1,0 +1,17 @@
+#include "iowrap.hpp"
+#include "exceptions.hpp"
+
+void GeneralIO::open(const std::string& filename)
+{
+    if(filename != "") {
+        file = gzopen(filename.c_str(), "r");
+        if(file == nullptr) {
+            throw InvalidFile("Could not open FASTQ file: " + filename);
+        }
+    }
+}
+
+int64_t GeneralIO::read(void* buffer, size_t length)
+{
+    return gzread(file, buffer, length);
+}

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -188,7 +188,6 @@ void IsalIO::decompress(size_t count) {
         auto ret = isal_inflate(&state);
         if (ret != ISAL_DECOMP_OK) {
             throw std::runtime_error("Error encountered while decompressing");
-            exit(-1);
         }
 
         size_t processed = actual_input_size - state.avail_in;

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -72,7 +72,7 @@ void RawIO::preload(size_t size)
 {
     read_buffer_work.resize(preload_size);
     auto actual_size = ::read(fd, read_buffer_work.data(), size);
-    if(actual_size != size) {
+    if(actual_size != (decltype(actual_size))size) {
         read_buffer_work.resize(actual_size);
     }
 }
@@ -176,7 +176,7 @@ void IsalIO::decompress(size_t count)
     uncompressed_data_work.resize(std::max(count, previous_member_size));
     uint8_t* ptr = uncompressed_data_work.data();
 
-    while(ptr - uncompressed_data_work.data() < count) {
+    while((uintptr_t)(ptr - uncompressed_data_work.data()) < (uintptr_t)count) {
         if(compressed_size == 0) break;
 
         size_t actual_input_size     = std::min(decompress_chunk_size, compressed_size);

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -93,8 +93,8 @@ class IsalGzipReader : public Reader {
         , uncompressed_data_copied(0)
         , compressed_data(nullptr)
         , compressed_size(0)
-        , decompress_chunk_size(8ull * 1024 * 1024)
-        , previous_member_size(32ull * 1024 * 1024)
+        , decompress_chunk_size(2ull * 1024 * 1024)
+        , previous_member_size(8ull * 1024 * 1024)
         , thread_reader() {
         initialize();
         open(filename);

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -10,13 +10,13 @@
 
 #include <thread>
 
-class AbstructIO
+class AbstractIO
 {
 public:
-    AbstructIO(const std::string&)
+    AbstractIO(const std::string&)
     {}
 
-    virtual ~AbstructIO() {}
+    virtual ~AbstractIO() {}
 
     virtual int64_t read(void* buffer, size_t length) = 0;
     virtual std::string ReaderName() const = 0;
@@ -26,11 +26,11 @@ protected:
 };
 
 
-class GeneralIO : public AbstructIO
+class GeneralIO : public AbstractIO
 {
 public:
     GeneralIO(const std::string& filename)
-        : AbstructIO(filename)
+        : AbstractIO(filename)
     {
         open(filename);
     }
@@ -52,11 +52,11 @@ private:
     void open(const std::string& filename) override;
 };
 
-class RawIO : public AbstructIO
+class RawIO : public AbstractIO
 {
 public:
     RawIO(const std::string& filename)
-        : AbstructIO(filename),
+        : AbstractIO(filename),
           fd(-1),
           preload_size(256ull * 1024 * 1024),
           read_buffer(),
@@ -96,11 +96,11 @@ private:
     void close();
 };
 
-class IsalIO : public AbstructIO
+class IsalIO : public AbstractIO
 {
 public:
     IsalIO(const std::string& filename)
-        : AbstructIO(filename),
+        : AbstractIO(filename),
           fd(-1),
           mmap_mem(nullptr),
           filesize(-1),

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -1,85 +1,69 @@
 #ifndef IO_WRAP_HPP
 #define IO_WRAP_HPP
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 #include <zlib.h>
-#include "isa-l/igzip_lib.h"
 #include <vector>
+#include "isa-l/igzip_lib.h"
 
 #include <thread>
 
-class AbstractIO
-{
-public:
-    AbstractIO(const std::string&)
-    {}
+class AbstractIO {
+   public:
+    AbstractIO(const std::string&) { }
 
-    virtual ~AbstractIO() {}
+    virtual ~AbstractIO() { }
 
     virtual int64_t read(void* buffer, size_t length) = 0;
     virtual std::string ReaderName() const = 0;
 
-protected:
+   protected:
     virtual void open(const std::string& filename) = 0;
 };
 
+class GeneralIO : public AbstractIO {
+   public:
+    GeneralIO(const std::string& filename) : AbstractIO(filename) { open(filename); }
 
-class GeneralIO : public AbstractIO
-{
-public:
-    GeneralIO(const std::string& filename)
-        : AbstractIO(filename)
-    {
-        open(filename);
-    }
-
-    virtual ~GeneralIO()
-    {
-        if(file) {
+    virtual ~GeneralIO() {
+        if (file) {
             gzclose(file);
         }
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const override {
-        return "GeneralIO";
-    }
+    std::string ReaderName() const override { return "GeneralIO"; }
 
-private:
+   private:
     gzFile file;
     void open(const std::string& filename) override;
 };
 
-class RawIO : public AbstractIO
-{
-public:
+class RawIO : public AbstractIO {
+   public:
     RawIO(const std::string& filename)
-        : AbstractIO(filename),
-          fd(-1),
-          preload_size(256ull * 1024 * 1024),
-          read_buffer(),
-          read_buffer_work(),
-          read_buffer_copied(0),
-          thread_reader()
-    {
+        : AbstractIO(filename)
+        , fd(-1)
+        , preload_size(256ull * 1024 * 1024)
+        , read_buffer()
+        , read_buffer_work()
+        , read_buffer_copied(0)
+        , thread_reader() {
         open(filename);
     }
 
-    virtual ~RawIO()
-    {
-        if(fd != -1) {
+    virtual ~RawIO() {
+        if (fd != -1) {
             close();
         }
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const {
-        return "RawIO";
-    }
+    std::string ReaderName() const { return "RawIO"; }
 
-private:
+   private:
     int fd;
 
     void preload(size_t size);
@@ -96,41 +80,36 @@ private:
     void close();
 };
 
-class IsalIO : public AbstractIO
-{
-public:
+class IsalIO : public AbstractIO {
+   public:
     IsalIO(const std::string& filename)
-        : AbstractIO(filename),
-          fd(-1),
-          mmap_mem(nullptr),
-          filesize(-1),
-          mmap_size(-1),
-          uncompressed_data(),
-          uncompressed_data_work(),
-          uncompressed_data_copied(0),
-          compressed_data(nullptr),
-          compressed_size(0),
-          decompress_chunk_size(2567ull * 1024 * 1024),
-          previous_member_size(1024ull * 1024 * 1024),
-          thread_reader()
-    {
+        : AbstractIO(filename)
+        , fd(-1)
+        , mmap_mem(nullptr)
+        , filesize(-1)
+        , mmap_size(-1)
+        , uncompressed_data()
+        , uncompressed_data_work()
+        , uncompressed_data_copied(0)
+        , compressed_data(nullptr)
+        , compressed_size(0)
+        , decompress_chunk_size(2567ull * 1024 * 1024)
+        , previous_member_size(1024ull * 1024 * 1024)
+        , thread_reader() {
         initialize();
         open(filename);
     }
 
-    virtual ~IsalIO()
-    {
-        if(fd != -1) {
+    virtual ~IsalIO() {
+        if (fd != -1) {
             close();
         }
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const override {
-        return "IsalIO";
-    }
+    std::string ReaderName() const override { return "IsalIO"; }
 
-private:
+   private:
     int fd;
     void* mmap_mem;
     ssize_t filesize;

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -61,7 +61,7 @@ class RawIO : public AbstractIO {
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const { return "RawIO"; }
+    std::string ReaderName() const override { return "RawIO"; }
 
    private:
     int fd;

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -4,9 +4,9 @@
 #include <cstdint>
 #include <string>
 
+#include <isa-l/igzip_lib.h>
 #include <zlib.h>
 #include <vector>
-#include <isa-l/igzip_lib.h>
 
 #include <thread>
 
@@ -46,7 +46,7 @@ class UncompressReader : public Reader {
     UncompressReader(const std::string& filename)
         : Reader(filename)
         , fd(-1)
-        , preload_size(256ull * 1024 * 1024)
+        , preload_size(64ull * 1024 * 1024)
         , read_buffer()
         , read_buffer_work()
         , read_buffer_copied(0)
@@ -93,8 +93,8 @@ class IsalGzipReader : public Reader {
         , uncompressed_data_copied(0)
         , compressed_data(nullptr)
         , compressed_size(0)
-        , decompress_chunk_size(2567ull * 1024 * 1024)
-        , previous_member_size(1024ull * 1024 * 1024)
+        , decompress_chunk_size(8ull * 1024 * 1024)
+        , previous_member_size(32ull * 1024 * 1024)
         , thread_reader() {
         initialize();
         open(filename);

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -1,5 +1,5 @@
-#ifndef IO_WRAP_HPP
-#define IO_WRAP_HPP
+#ifndef STROBEALIGN_IOWRAP_HPP
+#define STROBEALIGN_IOWRAP_HPP
 
 #include <cstdint>
 #include <string>

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -17,7 +17,7 @@ class Reader {
     virtual ~Reader() { }
 
     virtual int64_t read(void* buffer, size_t length) = 0;
-    virtual std::string ReaderName() const = 0;
+    [[maybe_unused]] virtual std::string name() const = 0;
 
    protected:
     virtual void open(const std::string& filename) = 0;
@@ -34,7 +34,7 @@ class GzipReader : public Reader {
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const override { return "GzipReader"; }
+    std::string name() const override { return "GzipReader"; }
 
    private:
     gzFile file;
@@ -61,7 +61,7 @@ class UncompressReader : public Reader {
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const override { return "UncompressReader"; }
+    [[maybe_unused]] std::string name() const override { return "UncompressReader"; }
 
    private:
     int fd;
@@ -107,7 +107,7 @@ class IsalGzipReader : public Reader {
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const override { return "IsalGzipReader"; }
+    [[maybe_unused]] std::string name() const override { return "IsalGzipReader"; }
 
    private:
     int fd;

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -34,7 +34,7 @@ class GzipReader : public Reader {
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string name() const override { return "GzipReader"; }
+    [[maybe_unused]] std::string name() const override { return "GzipReader"; }
 
    private:
     gzFile file;

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -5,6 +5,10 @@
 #include <cstdint>
 
 #include <zlib.h>
+#include "igzip_lib.h"
+#include <vector>
+
+#include <thread>
 
 class AbstructIO
 {
@@ -15,6 +19,7 @@ public:
     virtual ~AbstructIO() {}
 
     virtual int64_t read(void* buffer, size_t length) = 0;
+    virtual std::string ReaderName() const = 0;
 
 protected:
     virtual void open(const std::string& filename) = 0;
@@ -38,10 +43,74 @@ public:
     }
 
     int64_t read(void* buffer, size_t length) override;
+    std::string ReaderName() const override {
+        return "GeneralIO";
+    }
 
 private:
     gzFile file;
     void open(const std::string& filename) override;
+};
+
+class IsalIO : public AbstructIO
+{
+public:
+    IsalIO(const std::string& filename)
+        : AbstructIO(filename),
+          fd(-1),
+          mmap_mem(nullptr),
+          filesize(-1),
+          mmap_size(-1),
+          uncompressed_data(),
+          uncompressed_data_work(),
+          uncompressed_data_copied(0),
+          compressed_data(nullptr),
+          compressed_size(0),
+          decompress_chunk_size(2567ull * 1024 * 1024),
+          previous_member_size(1024ull * 1024 * 1024),
+          thread_reader()
+    {
+        initialize();
+        open(filename);
+    }
+
+    virtual ~IsalIO()
+    {
+        if(fd != -1) {
+            close();
+        }
+    }
+
+    int64_t read(void* buffer, size_t length) override;
+    std::string ReaderName() const override {
+        return "IsalIO";
+    }
+
+private:
+    int fd;
+    void* mmap_mem;
+    ssize_t filesize;
+    ssize_t mmap_size;
+    std::vector<uint8_t> uncompressed_data;
+    std::vector<uint8_t> uncompressed_data_work;
+    size_t uncompressed_data_copied;
+
+    uint8_t* compressed_data;
+    size_t compressed_size;
+
+    size_t decompress_chunk_size;
+    size_t previous_member_size;
+
+    std::thread thread_reader;
+
+    inflate_state state;
+    isal_gzip_header gz_hdr;
+
+    void initialize();
+    void open(const std::string& filename) override;
+    void close();
+
+    void decompress(size_t count);
 };
 
 #endif

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -10,11 +10,11 @@
 
 #include <thread>
 
-class AbstractIO {
+class Reader {
    public:
-    AbstractIO(const std::string&) { }
+    Reader(const std::string&) { }
 
-    virtual ~AbstractIO() { }
+    virtual ~Reader() { }
 
     virtual int64_t read(void* buffer, size_t length) = 0;
     virtual std::string ReaderName() const = 0;
@@ -23,28 +23,28 @@ class AbstractIO {
     virtual void open(const std::string& filename) = 0;
 };
 
-class GeneralIO : public AbstractIO {
+class GzipReader : public Reader {
    public:
-    GeneralIO(const std::string& filename) : AbstractIO(filename) { open(filename); }
+    GzipReader(const std::string& filename) : Reader(filename) { open(filename); }
 
-    virtual ~GeneralIO() {
+    virtual ~GzipReader() {
         if (file) {
             gzclose(file);
         }
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const override { return "GeneralIO"; }
+    std::string ReaderName() const override { return "GzipReader"; }
 
    private:
     gzFile file;
     void open(const std::string& filename) override;
 };
 
-class RawIO : public AbstractIO {
+class UncompressReader : public Reader {
    public:
-    RawIO(const std::string& filename)
-        : AbstractIO(filename)
+    UncompressReader(const std::string& filename)
+        : Reader(filename)
         , fd(-1)
         , preload_size(256ull * 1024 * 1024)
         , read_buffer()
@@ -54,14 +54,14 @@ class RawIO : public AbstractIO {
         open(filename);
     }
 
-    virtual ~RawIO() {
+    virtual ~UncompressReader() {
         if (fd != -1) {
             close();
         }
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const override { return "RawIO"; }
+    std::string ReaderName() const override { return "UncompressReader"; }
 
    private:
     int fd;
@@ -80,10 +80,10 @@ class RawIO : public AbstractIO {
     void close();
 };
 
-class IsalIO : public AbstractIO {
+class IsalGzipReader : public Reader {
    public:
-    IsalIO(const std::string& filename)
-        : AbstractIO(filename)
+    IsalGzipReader(const std::string& filename)
+        : Reader(filename)
         , fd(-1)
         , mmap_mem(nullptr)
         , filesize(-1)
@@ -100,14 +100,14 @@ class IsalIO : public AbstractIO {
         open(filename);
     }
 
-    virtual ~IsalIO() {
+    virtual ~IsalGzipReader() {
         if (fd != -1) {
             close();
         }
     }
 
     int64_t read(void* buffer, size_t length) override;
-    std::string ReaderName() const override { return "IsalIO"; }
+    std::string ReaderName() const override { return "IsalGzipReader"; }
 
    private:
     int fd;

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -56,7 +56,13 @@ class RawIO : public AbstructIO
 {
 public:
     RawIO(const std::string& filename)
-        : AbstructIO(filename)
+        : AbstructIO(filename),
+          fd(-1),
+          preload_size(256ull * 1024 * 1024),
+          read_buffer(),
+          read_buffer_work(),
+          read_buffer_copied(0),
+          thread_reader()
     {
         open(filename);
     }
@@ -75,6 +81,17 @@ public:
 
 private:
     int fd;
+
+    void preload(size_t size);
+
+    size_t preload_size;
+
+    std::vector<uint8_t> read_buffer;
+    std::vector<uint8_t> read_buffer_work;
+    size_t read_buffer_copied;
+
+    std::thread thread_reader;
+
     void open(const std::string& filename) override;
     void close();
 };

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -1,0 +1,47 @@
+#ifndef IO_WRAP_HPP
+#define IO_WRAP_HPP
+
+#include <string>
+#include <cstdint>
+
+#include <zlib.h>
+
+class AbstructIO
+{
+public:
+    AbstructIO(const std::string&)
+    {}
+
+    virtual ~AbstructIO() {}
+
+    virtual int64_t read(void* buffer, size_t length) = 0;
+
+protected:
+    virtual void open(const std::string& filename) = 0;
+};
+
+
+class GeneralIO : public AbstructIO
+{
+public:
+    GeneralIO(const std::string& filename)
+        : AbstructIO(filename)
+    {
+        open(filename);
+    }
+
+    virtual ~GeneralIO()
+    {
+        if(file) {
+            gzclose(file);
+        }
+    }
+
+    int64_t read(void* buffer, size_t length) override;
+
+private:
+    gzFile file;
+    void open(const std::string& filename) override;
+};
+
+#endif

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -6,7 +6,7 @@
 
 #include <zlib.h>
 #include <vector>
-#include "isa-l/igzip_lib.h"
+#include <isa-l/igzip_lib.h>
 
 #include <thread>
 

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -52,6 +52,33 @@ private:
     void open(const std::string& filename) override;
 };
 
+class RawIO : public AbstructIO
+{
+public:
+    RawIO(const std::string& filename)
+        : AbstructIO(filename)
+    {
+        open(filename);
+    }
+
+    virtual ~RawIO()
+    {
+        if(fd != -1) {
+            close();
+        }
+    }
+
+    int64_t read(void* buffer, size_t length) override;
+    std::string ReaderName() const {
+        return "RawIO";
+    }
+
+private:
+    int fd;
+    void open(const std::string& filename) override;
+    void close();
+};
+
 class IsalIO : public AbstructIO
 {
 public:

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -25,7 +25,7 @@ class Reader {
 
 class GzipReader : public Reader {
    public:
-    GzipReader(const std::string& filename) : Reader(filename) { open(filename); }
+    GzipReader(const std::string& filename) : Reader(filename), file() { open(filename); }
 
     virtual ~GzipReader() {
         if (file) {

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 
 #include <zlib.h>
-#include "igzip_lib.h"
+#include "isa-l/igzip_lib.h"
 #include <vector>
 
 #include <thread>


### PR DESCRIPTION
Hi.

I speeded up the loading part of Strobealign in this PR.
In this PR, I replaced the use of zlib's gzread for gzip decompression with a class that performs gzip decompression and double buffering using ISA-L.
As a side effect, double buffering is used to read raw fastq, which also speeds up.

The benchmark for gzip decompression with gzopen is shown below.

```
Total time mapping: 2610.28 s.
Total time reading read-file(s): 2284.26 s.
Total time creating strobemers: 25.25 s.
Total time finding NAMs (non-rescue mode): 42.51 s.
Total time finding NAMs (rescue mode): 72.65 s.
Total time sorting NAMs (candidate sites): 121.26 s.
Total time base level alignment (ssw): 167.53 s.
Total time writing alignment to files: 0.00 s.
```

On the other hand, this PR will speed up

```
Total time mapping: 727.12 s.
Total time reading read-file(s): 110.86 s.
Total time creating strobemers: 47.43 s.
Total time finding NAMs (non-rescue mode): 70.84 s.
Total time finding NAMs (rescue mode): 151.78 s.
Total time sorting NAMs (candidate sites): 232.37 s.
Total time base level alignment (ssw): 324.62 s.
Total time writing alignment to files: 0.00 s.
```

This PR improves scalability in systems with a very large number of cores.

Could you please review it?
