### PR TITLE
Make include guards consistent

### DIFF
--- a/src/arguments.hpp
+++ b/src/arguments.hpp
@@ -1,5 +1,5 @@
-#ifndef ARGUMENTS_HPP
-#define ARGUMENTS_HPP
+#ifndef STROBEALIGN_ARGUMENTS_HPP
+#define STROBEALIGN_ARGUMENTS_HPP
 
 #include <args.hxx>
 

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -1,5 +1,5 @@
-#ifndef CMDLINE_HPP
-#define CMDLINE_HPP
+#ifndef STROBEALIGN_CMDLINE_HPP
+#define STROBEALIGN_CMDLINE_HPP
 
 #include <vector>
 #include <string>

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -1,5 +1,5 @@
-#ifndef exceptions_hpp
-#define exceptions_hpp
+#ifndef STROBEALIGN_EXCEPTIONS_HPP
+#define STROBEALIGN_EXCEPTIONS_HPP
 
 #include <stdexcept>
 #include <string>

--- a/src/fastq.hpp
+++ b/src/fastq.hpp
@@ -1,5 +1,5 @@
-#ifndef FASTQ_HPP
-#define FASTQ_HPP
+#ifndef STROBEALIGN_FASTQ_HPP
+#define STROBEALIGN_FASTQ_HPP
 
 #include <zlib.h>
 #include <string>

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -1,11 +1,7 @@
-//
-//  index.hpp
-//  cpp_course
-//
 //  Created by Kristoffer Sahlin on 4/21/21.
-//
-#ifndef index_hpp
-#define index_hpp
+
+#ifndef STROBEALIGN_INDEX_HPP
+#define STROBEALIGN_INDEX_HPP
 
 #include <chrono>
 #include <stdio.h>

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -1,5 +1,5 @@
-#ifndef INDEXPARAMETERS_HPP
-#define INDEXPARAMETERS_HPP
+#ifndef STROBEALIGN_INDEXPARAMETERS_HPP
+#define STROBEALIGN_INDEXPARAMETERS_HPP
 
 #include <cstdint>
 #include <algorithm>

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -1,5 +1,5 @@
-#ifndef IO_HPP
-#define IO_HPP
+#ifndef STROBEALIGN_IO_HPP
+#define STROBEALIGN_IO_HPP
 
 #include <iostream>
 #include <vector>

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -1,5 +1,5 @@
-#ifndef LOGGER_HPP
-#define LOGGER_HPP
+#ifndef STROBEALIGN_LOGGER_HPP
+#define STROBEALIGN_LOGGER_HPP
 
 #include <ostream>
 #include <iostream>

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -1,5 +1,5 @@
-#ifndef pc_hpp
-#define pc_hpp
+#ifndef STROBEALIGN_PC_HPP
+#define STROBEALIGN_PC_HPP
 
 #include <thread>
 #include <condition_variable>

--- a/src/readlen.hpp
+++ b/src/readlen.hpp
@@ -1,5 +1,5 @@
-#ifndef READLEN_HPP
-#define READLEN_HPP
+#ifndef STROBEALIGN_READLEN_HPP
+#define STROBEALIGN_READLEN_HPP
 
 #include "kseq++.hpp"
 #include <zlib.h>

--- a/src/refs.hpp
+++ b/src/refs.hpp
@@ -1,5 +1,5 @@
-#ifndef REFS_HPP
-#define REFS_HPP
+#ifndef STROBEALIGN_REFS_HPP
+#define STROBEALIGN_REFS_HPP
 
 #include <cstdint>
 #include <string>

--- a/src/revcomp.hpp
+++ b/src/revcomp.hpp
@@ -1,5 +1,5 @@
-#ifndef REVCOMP_HPP
-#define REVCOMP_HPP
+#ifndef STROBEALIGN_REVCOMP_HPP
+#define STROBEALIGN_REVCOMP_HPP
 
 #include <string>
 #include <algorithm>

--- a/src/timer.hpp
+++ b/src/timer.hpp
@@ -1,5 +1,5 @@
-#ifndef TIMER_HPP
-#define TIMER_HPP
+#ifndef STROBEALIGN_TIMER_HPP
+#define STROBEALIGN_TIMER_HPP
 
 #include <chrono>
 

--- a/src/tmpdir.hpp
+++ b/src/tmpdir.hpp
@@ -1,5 +1,5 @@
-#ifndef TMPDIR_HPP
-#define TMPDIR_HPP
+#ifndef STROBEALIGN_TMPDIR_HPP
+#define STROBEALIGN_TMPDIR_HPP
 
 #include <filesystem>
 #include <sstream>


### PR DESCRIPTION
This changes all include guards so that they consistently use `STROBEALIGN_xyz_HPP` for a file named `xyz.hpp`.