### PR TITLE
Ignore /1/2 suffix when matching interleaved reads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   Added option `--eqx` to use `=` and `X` as before.
 * #265: Fixed overflowing read count statistics when processing $2^{31}$ reads
   or more. Thanks @telmin.
+* #273: Fix handling of interleaved files using /1 or /2 suffixes
 
 ## v0.9.0 (2023-03-16)
 

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -65,4 +65,6 @@ void perform_task(InputBuffer &input_buffer, OutputBuffer &output_buffer,
                   AlignmentStatistics& statistics, int& done, const alignment_params &aln_params,
                   const mapping_params &map_param, const IndexParameters& index_parameters, const References& references, const StrobemerIndex& index, const std::string& read_group_id);
 
+bool same_name(const std::string& n1, const std::string& n2);
+
 #endif

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -104,3 +104,14 @@ TEST_CASE("RewindableFile") {
     rf.read(buf2, 1024);
     CHECK(memcmp(buf1, buf2, 1024) == 0);
 }
+
+TEST_CASE("same_name"){
+    CHECK(same_name("a", "a"));
+    CHECK(same_name("abc", "abc"));
+    CHECK(same_name("abc/1", "abc/2"));
+
+    CHECK(!same_name("a", "b"));
+    CHECK(!same_name("a/1", "b/2"));
+    CHECK(!same_name("abc/", "abx/"));
+    CHECK(!same_name("abc/2", "abc/1"));
+}


### PR DESCRIPTION
A read named `read/1` followed by `read/2` should form a pair in the interleaved format. This matches the behaviour of `bwa mem -p` as well

closes #273

/cc #274 