### PR TITLE
Using two vectors to represent the hash table when indexing (similar running time and much lower memory usage)

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1366,7 +1366,7 @@ void align_PE_read(
     auto [nonrepetitive_fraction1, nams1] = find_nams(query_randstrobes1, index);
     auto [nonrepetitive_fraction2, nams2] = find_nams(query_randstrobes2, index);
     statistics.tot_find_nams += nam_timer.duration();
-
+ 
     if (map_param.R > 1) {
         Timer rescue_timer;
         if (nams1.empty() || nonrepetitive_fraction1 < 0.7) {

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1366,7 +1366,7 @@ void align_PE_read(
     auto [nonrepetitive_fraction1, nams1] = find_nams(query_randstrobes1, index);
     auto [nonrepetitive_fraction2, nams2] = find_nams(query_randstrobes2, index);
     statistics.tot_find_nams += nam_timer.duration();
- 
+
     if (map_param.R > 1) {
         Timer rescue_timer;
         if (nams1.empty() || nonrepetitive_fraction1 < 0.7) {

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1366,7 +1366,6 @@ void align_PE_read(
     auto [nonrepetitive_fraction1, nams1] = find_nams(query_randstrobes1, index);
     auto [nonrepetitive_fraction2, nams2] = find_nams(query_randstrobes2, index);
     statistics.tot_find_nams += nam_timer.duration();
-
     if (map_param.R > 1) {
         Timer rescue_timer;
         if (nams1.empty() || nonrepetitive_fraction1 < 0.7) {

--- a/src/arguments.hpp
+++ b/src/arguments.hpp
@@ -24,10 +24,11 @@ struct SeedingArguments {
             "It is recommended not to change this parameter unless you have a good "
             "understanding of syncmers as it will drastically change the memory usage and "
             "results with non default values.", {'s'}}
+        , n{parser, "INT", "use top n bits to store hash [28]", {'n'}}
     {
     }
     args::ArgumentParser& parser;
-    args::ValueFlag<int> r, m, k, l, u, c, s;
+    args::ValueFlag<int> r, m, k, l, u, c, s, n;
 };
 
 #endif

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -107,6 +107,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (seeding.u) { opt.u = args::get(seeding.u); opt.u_set = true; }
     if (seeding.s) { opt.s = args::get(seeding.s); opt.s_set = true; }
     if (seeding.c) { opt.c = args::get(seeding.c); opt.c_set = true; }
+    if (seeding.n) { opt.n = args::get(seeding.n); opt.n_set = true;}
 
     // Alignment
     // if (n) { n = args::get(n); }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -26,7 +26,9 @@ struct CommandLineOptions {
 
     // Seeding
     int r { 150 };
+    int n { 28 };
     bool r_set { false };
+    bool n_set { false };
     bool max_seed_len_set { false };
     bool k_set { false };
     bool s_set { false };

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -46,8 +46,10 @@ unsigned int StrobemerIndex::find(uint64_t key) const{
         if (randstrobes_vector[position_start].hash == key){
             return position_start;
         }
+        else{
+            return -1;
+        }
     }
-
     // Binary research to find the hash
     int firstOccur = -1;
     while (position_start <= position_end){

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -24,13 +24,13 @@ static const uint32_t STI_FILE_FORMAT_VERSION = 1;
 
 unsigned int StrobemerIndex::find(uint64_t key) const{
     unsigned int top_N = key >> (64 - N);
-    unsigned int position_start = hash_positions[top_N] - 1;
+    int position_start = hash_positions[top_N] - 1;
 
     if (position_start == -1){
         return position_start;
     }
 
-    unsigned int position_end = -1;
+    int position_end = -1;
     for (unsigned int i = top_N + 1; i < 1 << N; i++){
         if (hash_positions[i] != 0){
             position_end = hash_positions[i] - 2;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -20,7 +20,7 @@
 #include "logger.hpp"
 
 static Logger& logger = Logger::get();
-static const uint32_t STI_FILE_FORMAT_VERSION = 1;
+static const uint32_t STI_FILE_FORMAT_VERSION = 2;
 
 const int MAX_LINEAR_SEARCH = 4;
 unsigned int StrobemerIndex::find(uint64_t key) const{

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -201,10 +201,6 @@ struct StrobemerIndex {
 
     }
 
-    unsigned int get_size() const {
-        return randstrobes_vector.size();
-    }
-
     RandstrobeMap::const_iterator end() const {
         return randstrobe_map.cend();
     }
@@ -219,13 +215,13 @@ struct StrobemerIndex {
 
 private:
     // std::vector<RefRandstrobeWithHash> add_randstrobes_to_hash_table();
-    void add_randstrobes_to_vector();
+    void add_randstrobes_to_vector(int randstrobe_hashes);
     const IndexParameters& parameters;
     const References& references;
     const unsigned int N = 28;  // store N bits in the 
+    std::vector<RefRandstrobeWithHash> randstrobes_vector;
     unsigned int* hash_positions = new unsigned int[1 << N](); // the position array used to store the position of the hash in the hash vector;
     RandstrobeMap randstrobe_map; // k-mer -> (offset in flat_vector, occurence count )
-    std::vector<RefRandstrobeWithHash> randstrobes_vector;
     static const int bit_alloc = 8;
     static const int mask = (1 << bit_alloc) - 1;
 };

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -170,7 +170,7 @@ struct StrobemerIndex {
         }else{
             return -1;
         }
-    }
+    } 
 
     unsigned int get_strob1_position(unsigned int position) const {
         return randstrobes_vector[position].position;
@@ -185,14 +185,24 @@ struct StrobemerIndex {
     }
 
     unsigned int get_next_pos(unsigned int position) const {
+        if (position == randstrobes_vector.size() - 1){
+                return position;
+            } 
+
+        uint64_t hash_value = randstrobes_vector[position].hash;
         for(unsigned int i = position + 1; i < randstrobes_vector.size(); i++){
-            if (randstrobes_vector[i].hash != randstrobes_vector[position].hash){
+            if (randstrobes_vector[i].hash != hash_value){
                 return i - 1;
             }
             if (i == randstrobes_vector.size() - 1){
                 return i;
             } 
         }
+
+    }
+
+    unsigned int get_size() const {
+        return randstrobes_vector.size();
     }
 
     RandstrobeMap::const_iterator end() const {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -218,7 +218,7 @@ private:
     void add_randstrobes_to_vector(int randstrobe_hashes);
     const IndexParameters& parameters;
     const References& references;
-    const unsigned int N = 27;  // store N bits in the 
+    const unsigned int N = 28;  // store N bits in the 
     std::vector<RefRandstrobeWithHash> randstrobes_vector;
     unsigned int* hash_positions = new unsigned int[1 << N](); // the position array used to store the position of the hash in the hash vector;
     RandstrobeMap randstrobe_map; // k-mer -> (offset in flat_vector, occurence count )

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -152,7 +152,6 @@ struct StrobemerIndex {
         , references(references) {}
     unsigned int filter_cutoff; //This also exists in mapping_params, but is calculated during index generation,
                                 //therefore stored here since it needs to be saved with the index.
-    RefRandstrobeVector flat_vector;
     mutable IndexCreationStatistics stats;
 
     void write(const std::string& filename) const;
@@ -160,11 +159,6 @@ struct StrobemerIndex {
     void populate(float f, size_t n_threads);
     void print_diagnostics(const std::string& logfile_name, int k) const;
     unsigned int find(uint64_t key) const;
-    static const unsigned int N = 28;  // store N bits in the 
-    static const uint64_t hash_mask = (((uint64_t)1 << (64 - N)) - 1);
-    // RandstrobeMap::const_iterator find(uint64_t key) const {
-    //     return randstrobe_map.find(key);
-    // }
 
     uint64_t get_hash(unsigned int position) const {
         if (position < randstrobes_vector.size()){
@@ -172,7 +166,15 @@ struct StrobemerIndex {
         }else{
             return -1;
         }
-    } 
+    }
+
+    // uint64_t get_hash_mask() const{
+    //     return hash_mask;
+    // }
+
+    // unsigned int get_N() const{
+    //     return N;
+    // }
 
     unsigned int get_strob1_position(unsigned int position) const {
         return randstrobes_vector[position].position;
@@ -191,28 +193,20 @@ struct StrobemerIndex {
         return count;
     }
 
-    RandstrobeMap::const_iterator end() const {
-        return randstrobe_map.cend();
-    }
-
-    void add_entry(uint64_t key, unsigned int offset, unsigned int count) {
-        randstrobe_map[key] = RandstrobeMapEntry{offset, count};
-    }
-
     int k() const {
         return parameters.k;
     }
-    
+
 private:
-    // std::vector<RefRandstrobeWithHash> add_randstrobes_to_hash_table();
     void add_randstrobes_to_vector(int randstrobe_hashes);
     const IndexParameters& parameters;
     const References& references;
     std::vector<RefRandstrobeWithHash> randstrobes_vector;
-    unsigned int* hash_positions = new unsigned int[1 << N](); // the position array used to store the position of the hash in the hash vector;
-    RandstrobeMap randstrobe_map; // k-mer -> (offset in flat_vector, occurence count )
+    std::vector<unsigned int> hash_positions;
     static const int bit_alloc = 8;
     static const int mask = (1 << bit_alloc) - 1;
+    const unsigned int N = parameters.n;
+    const uint64_t hash_mask = (((uint64_t)1 << (64 - N)) - 1);
 };
 
 #endif

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -160,6 +160,7 @@ struct StrobemerIndex {
     void populate(float f, size_t n_threads);
     void print_diagnostics(const std::string& logfile_name, int k) const;
     unsigned int find(uint64_t key) const;
+    static const unsigned int N = 28;  // store N bits in the 
     // RandstrobeMap::const_iterator find(uint64_t key) const {
     //     return randstrobe_map.find(key);
     // }
@@ -212,13 +213,12 @@ struct StrobemerIndex {
     int k() const {
         return parameters.k;
     }
-
+    
 private:
     // std::vector<RefRandstrobeWithHash> add_randstrobes_to_hash_table();
     void add_randstrobes_to_vector(int randstrobe_hashes);
     const IndexParameters& parameters;
     const References& references;
-    const unsigned int N = 28;  // store N bits in the 
     std::vector<RefRandstrobeWithHash> randstrobes_vector;
     unsigned int* hash_positions = new unsigned int[1 << N](); // the position array used to store the position of the hash in the hash vector;
     RandstrobeMap randstrobe_map; // k-mer -> (offset in flat_vector, occurence count )

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -93,7 +93,24 @@ public:
         }
     }
 
+<<<<<<< HEAD
 private:
+=======
+    unsigned int offset() const{
+        assert(!is_direct());
+        return m_offset;
+    }
+
+    bool is_direct() const {
+        return m_count & 0x8000'0000;
+    }
+
+    RefRandstrobe as_ref_randstrobe() const {  // 将m_count 首位置为0
+        assert(is_direct());
+        return RefRandstrobe{m_offset, m_count & 0x7fff'ffff};
+    }
+
+>>>>>>> a8f67916634c393db08b8a2e6c8305da4eec5838
     void set_count(unsigned int count) {
         m_count = count;
     }

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -93,24 +93,6 @@ public:
         }
     }
 
-<<<<<<< HEAD
-private:
-=======
-    unsigned int offset() const{
-        assert(!is_direct());
-        return m_offset;
-    }
-
-    bool is_direct() const {
-        return m_count & 0x8000'0000;
-    }
-
-    RefRandstrobe as_ref_randstrobe() const {  // 将m_count 首位置为0
-        assert(is_direct());
-        return RefRandstrobe{m_offset, m_count & 0x7fff'ffff};
-    }
-
->>>>>>> a8f67916634c393db08b8a2e6c8305da4eec5838
     void set_count(unsigned int count) {
         m_count = count;
     }
@@ -184,14 +166,6 @@ struct StrobemerIndex {
             return -1;
         }
     }
-
-    // uint64_t get_hash_mask() const{
-    //     return hash_mask;
-    // }
-
-    // unsigned int get_N() const{
-    //     return N;
-    // }
 
     unsigned int get_strob1_position(unsigned int position) const {
         return randstrobes_vector[position].position;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -218,7 +218,7 @@ private:
     void add_randstrobes_to_vector(int randstrobe_hashes);
     const IndexParameters& parameters;
     const References& references;
-    const unsigned int N = 28;  // store N bits in the 
+    const unsigned int N = 27;  // store N bits in the 
     std::vector<RefRandstrobeWithHash> randstrobes_vector;
     unsigned int* hash_positions = new unsigned int[1 << N](); // the position array used to store the position of the hash in the hash vector;
     RandstrobeMap randstrobe_map; // k-mer -> (offset in flat_vector, occurence count )

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -52,80 +52,8 @@ private:
 
 using RefRandstrobeVector = std::vector<RefRandstrobe>;
 
-struct StrobemerIndex;
-
-/*
- * An entry in the randstrobe map that allows retrieval of randstrobe
- * occurrences. To save memory, the entry is either a "direct" or an
- * "indirect" one.
- *
- * - A direct entry is used if the randstrobe occurs only once in the reference.
- *   Then that single occurrence itself is stored and can be retrieved by the
- *   as_ref_randstrobe() method.
- * - An indirect entry is used if the randstrobe has multiple occurrences.
- *   In that case, offset() and count() point to an interval within a second
- *   table (RandstrobeVector).
- */
-class RandstrobeMapEntry {
-public:
-    RandstrobeMapEntry() { }
-    RandstrobeMapEntry(unsigned int offset, unsigned int count) : m_offset(offset), m_count(count) { }
-
-    template <class F>
-    void for_each(const RefRandstrobeVector& flat_vector, F func) const {
-        // Determine whether the hash table’s value directly represents a
-        // ReferenceMer (this is the case if count==1) or an offset/count
-        // pair that refers to entries in the flat_vector.
-        if (is_direct()) {
-            func(as_ref_randstrobe());
-        } else {
-            for (size_t j = offset(); j < offset() + count(); ++j) {
-                func(flat_vector[j]);
-            }
-        }
-    }
-
-    unsigned int count() const {
-        if (is_direct()) {
-            return 1;
-        } else {
-            return m_count;
-        }
-    }
-
-    void set_count(unsigned int count) {
-        m_count = count;
-    }
-
-    void set_offset(unsigned int offset) {
-        assert(!is_direct());
-        m_offset = offset;
-    }
-
-    unsigned int offset() const {
-        assert(!is_direct());
-        return m_offset;
-    }
-
-    bool is_direct() const {
-        return m_count & 0x8000'0000;
-    }
-
-    RefRandstrobe as_ref_randstrobe() const {  // 将m_count 首位置为0
-        assert(is_direct());
-        return RefRandstrobe{m_offset, m_count & 0x7fff'ffff};
-    }
-
-    unsigned int m_offset;
-    unsigned int m_count;
-
-    friend StrobemerIndex;
-};
-
-using RandstrobeMap = robin_hood::unordered_map<randstrobe_hash_t, RandstrobeMapEntry>;
 
 typedef std::vector<uint64_t> hash_vector; //only used during index generation
-
 struct IndexCreationStatistics {
     unsigned int flat_vector_size = 0;
     unsigned int tot_strobemer_count = 0;
@@ -157,7 +85,31 @@ struct StrobemerIndex {
     void read(const std::string& filename);
     void populate(float f, size_t n_threads);
     void print_diagnostics(const std::string& logfile_name, int k) const;
-    unsigned int find(uint64_t key) const;
+    unsigned int find(uint64_t key) const {
+        constexpr int MAX_LINEAR_SEARCH = 4;
+        const unsigned int top_N = key >> (64 - parameters.n);
+        int position_start = hash_positions[top_N];
+        int position_end = hash_positions[top_N + 1];
+        if (position_start == position_end) {
+            return -1;
+        }
+
+        if (position_end - position_start < MAX_LINEAR_SEARCH) {
+            for ( ; position_start < position_end; ++position_start) {
+                if (randstrobes_vector[position_start].hash == key) return position_start;
+                if (randstrobes_vector[position_start].hash > key) return -1;
+            }
+            return -1;
+        }
+        auto cmp = [this](const RefRandstrobeWithHash lhs, const RefRandstrobeWithHash rhs) {return lhs.hash < rhs.hash; };
+
+        auto pos = std::lower_bound(randstrobes_vector.begin() + position_start,
+                                               randstrobes_vector.begin() + position_end,
+                                               RefRandstrobeWithHash{key, 0, 0},
+                                               cmp);
+        if (pos->hash == key) return pos - randstrobes_vector.begin();
+        return -1;
+    }
 
     uint64_t get_hash(unsigned int position) const {
         if (position < randstrobes_vector.size()){
@@ -167,7 +119,7 @@ struct StrobemerIndex {
         }
     }
 
-    unsigned int get_strob1_position(unsigned int position) const {
+    unsigned int get_strobe1_position(unsigned int position) const {
         return randstrobes_vector[position].position;
     }
 
@@ -179,9 +131,24 @@ struct StrobemerIndex {
         return randstrobes_vector[position].packed >> bit_alloc;
     }
 
-    unsigned int get_count(unsigned int position) const {
-        unsigned int count = randstrobes_vector[position].hash >> (64 - N);
-        return count;
+    unsigned int get_count(const unsigned int position) const {
+        constexpr unsigned int MAX_LINEAR_SEARCH = 8;
+        const auto hash = randstrobes_vector[position].hash;
+
+        // For 95% of cases, the result will be small and a brute force search
+        // is the best option. Once, we go over MAX_LINEAR_SEARCH, though, we
+        // call get_count_line_search which performs a line search with
+        // expanding step in O(log N) comparisons
+        //
+        unsigned int count = 1;
+        while (get_hash(position + count) == hash
+                && count < MAX_LINEAR_SEARCH) {
+            ++count;
+        }
+        if (get_hash(position + count) != hash) {
+            return count;
+        }
+        return count + get_count_line_search(position + count);
     }
 
     int k() const {
@@ -190,14 +157,14 @@ struct StrobemerIndex {
 
 private:
     void add_randstrobes_to_vector(int randstrobe_hashes);
+    unsigned int get_count_line_search(unsigned int) const;
+
     const IndexParameters& parameters;
     const References& references;
     std::vector<RefRandstrobeWithHash> randstrobes_vector;
     std::vector<unsigned int> hash_positions;
-    static const int bit_alloc = 8;
-    static const int mask = (1 << bit_alloc) - 1;
-    const unsigned int N = parameters.n;
-    const uint64_t hash_mask = (((uint64_t)1 << (64 - N)) - 1);
+    static constexpr int bit_alloc = 8;
+    static constexpr int mask = (1 << bit_alloc) - 1;
 };
 
 #endif

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -161,6 +161,7 @@ struct StrobemerIndex {
     void print_diagnostics(const std::string& logfile_name, int k) const;
     unsigned int find(uint64_t key) const;
     static const unsigned int N = 28;  // store N bits in the 
+    static const uint64_t hash_mask = (((uint64_t)1 << (64 - N)) - 1);
     // RandstrobeMap::const_iterator find(uint64_t key) const {
     //     return randstrobe_map.find(key);
     // }
@@ -185,21 +186,9 @@ struct StrobemerIndex {
         return randstrobes_vector[position].packed >> bit_alloc;
     }
 
-    unsigned int get_next_pos(unsigned int position) const {
-        if (position == randstrobes_vector.size() - 1){
-                return position;
-            } 
-
-        uint64_t hash_value = randstrobes_vector[position].hash;
-        for(unsigned int i = position + 1; i < randstrobes_vector.size(); i++){
-            if (randstrobes_vector[i].hash != hash_value){
-                return i - 1;
-            }
-            if (i == randstrobes_vector.size() - 1){
-                return i;
-            } 
-        }
-
+    unsigned int get_count(unsigned int position) const {
+        unsigned int count = randstrobes_vector[position].hash >> (64 - N);
+        return count;
     }
 
     RandstrobeMap::const_iterator end() const {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -24,6 +24,7 @@
  * - position of the first strobe
  * - offset of the second strobe
 */
+
 class RefRandstrobe {
 public:
     RefRandstrobe() { }  // TODO should not be needed
@@ -111,7 +112,7 @@ private:
         return m_count & 0x8000'0000;
     }
 
-    RefRandstrobe as_ref_randstrobe() const {
+    RefRandstrobe as_ref_randstrobe() const {  // 将m_count 首位置为0
         assert(is_direct());
         return RefRandstrobe{m_offset, m_count & 0x7fff'ffff};
     }
@@ -158,9 +159,40 @@ struct StrobemerIndex {
     void read(const std::string& filename);
     void populate(float f, size_t n_threads);
     void print_diagnostics(const std::string& logfile_name, int k) const;
+    unsigned int find(uint64_t key) const;
+    // RandstrobeMap::const_iterator find(uint64_t key) const {
+    //     return randstrobe_map.find(key);
+    // }
 
-    RandstrobeMap::const_iterator find(uint64_t key) const {
-        return randstrobe_map.find(key);
+    uint64_t get_hash(unsigned int position) const {
+        if (position < randstrobes_vector.size()){
+            return randstrobes_vector[position].hash;
+        }else{
+            return -1;
+        }
+    }
+
+    unsigned int get_strob1_position(unsigned int position) const {
+        return randstrobes_vector[position].position;
+    }
+
+    int strobe2_offset(unsigned int position) const {
+        return randstrobes_vector[position].packed & mask;
+    }
+
+    int reference_index(unsigned int position) const {
+        return randstrobes_vector[position].packed >> bit_alloc;
+    }
+
+    unsigned int get_next_pos(unsigned int position) const {
+        for(unsigned int i = position + 1; i < randstrobes_vector.size(); i++){
+            if (randstrobes_vector[i].hash != randstrobes_vector[position].hash){
+                return i - 1;
+            }
+            if (i == randstrobes_vector.size() - 1){
+                return i;
+            } 
+        }
     }
 
     RandstrobeMap::const_iterator end() const {
@@ -176,11 +208,16 @@ struct StrobemerIndex {
     }
 
 private:
-    std::vector<RefRandstrobeWithHash> add_randstrobes_to_hash_table();
-
+    // std::vector<RefRandstrobeWithHash> add_randstrobes_to_hash_table();
+    void add_randstrobes_to_vector();
     const IndexParameters& parameters;
     const References& references;
+    const unsigned int N = 28;  // store N bits in the 
+    unsigned int* hash_positions = new unsigned int[1 << N](); // the position array used to store the position of the hash in the hash vector;
     RandstrobeMap randstrobe_map; // k-mer -> (offset in flat_vector, occurence count )
+    std::vector<RefRandstrobeWithHash> randstrobes_vector;
+    static const int bit_alloc = 8;
+    static const int mask = (1 << bit_alloc) - 1;
 };
 
 #endif

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -33,7 +33,7 @@ static std::vector<Profile> profiles = {
  * k, s, l, u, c and max_seed_len can be used to override determined parameters
  * by setting them to a value other than IndexParameters::DEFAULT.
  */
-IndexParameters IndexParameters::from_read_length(int read_length, int k, int s, int l, int u, int c, int max_seed_len) {
+IndexParameters IndexParameters::from_read_length(int read_length, int c, int k, int s, int l, int u, int max_seed_len, int n) {
     const int default_c = 8;
     size_t canonical_read_length = 50;
     for (const auto& p : profiles) {
@@ -63,7 +63,7 @@ IndexParameters IndexParameters::from_read_length(int read_length, int k, int s,
         max_dist = max_seed_len - k; // convert to distance in start positions
     }
     int q = std::pow(2, c == DEFAULT ? default_c : c) - 1;
-    return IndexParameters(canonical_read_length, k, s, l, u, q, max_dist);
+    return IndexParameters(canonical_read_length, k, s, l, u, q, max_dist, n);
 }
 
 void IndexParameters::write(std::ostream& os) const {
@@ -74,6 +74,7 @@ void IndexParameters::write(std::ostream& os) const {
     write_int_to_ostream(os, u);
     write_int_to_ostream(os, q);
     write_int_to_ostream(os, max_dist);
+    write_int_to_ostream(os, n);
 }
 
 IndexParameters IndexParameters::read(std::istream& is) {
@@ -84,7 +85,8 @@ IndexParameters IndexParameters::read(std::istream& is) {
     int u = read_int_from_istream(is);
     int q = read_int_from_istream(is);
     int max_dist = read_int_from_istream(is);
-    return IndexParameters(canonical_read_length, k, s, l, u, q, max_dist);
+    int n = read_int_from_istream(is);
+    return IndexParameters(canonical_read_length, k, s, l, u, q, max_dist, n);
 }
 
 bool IndexParameters::operator==(const IndexParameters& other) const {
@@ -98,7 +100,8 @@ bool IndexParameters::operator==(const IndexParameters& other) const {
         && this->max_dist == other.max_dist
         && this->t_syncmer == other.t_syncmer
         && this->w_min == other.w_min
-        && this->w_max == other.w_max;
+        && this->w_max == other.w_max
+        && this->n == other.n;
 }
 
 /*
@@ -128,6 +131,7 @@ std::ostream& operator<<(std::ostream& os, const IndexParameters& parameters) {
         << ", t_syncmer=" << parameters.t_syncmer
         << ", w_min=" << parameters.w_min
         << ", w_max=" << parameters.w_max
+        << ", n=" << parameters.n
         << ")";
     return os;
 }

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -33,7 +33,7 @@ static std::vector<Profile> profiles = {
  * k, s, l, u, c and max_seed_len can be used to override determined parameters
  * by setting them to a value other than IndexParameters::DEFAULT.
  */
-IndexParameters IndexParameters::from_read_length(int read_length, int c, int k, int s, int l, int u, int max_seed_len, int n) {
+IndexParameters IndexParameters::from_read_length(int read_length, int k, int s, int l, int u, int c, int max_seed_len, int n) {
     const int default_c = 8;
     size_t canonical_read_length = 50;
     for (const auto& p : profiles) {

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -20,9 +20,10 @@ public:
     const int t_syncmer;
     const unsigned w_min;
     const unsigned w_max;
+    const int n;
 
     static const int DEFAULT = std::numeric_limits<int>::min();
-    IndexParameters(size_t canonical_read_length, int k, int s, int l, int u, int q, int max_dist)
+    IndexParameters(size_t canonical_read_length, int k, int s, int l, int u, int q, int max_dist, int n)
         : canonical_read_length(canonical_read_length)
         , k(k)
         , s(s)
@@ -33,11 +34,12 @@ public:
         , t_syncmer((k - s) / 2 + 1)
         , w_min(std::max(1, k / (k - s + 1) + l))
         , w_max(k / (k - s + 1) + u)
+        , n(n)
     {
         verify();
     }
 
-    static IndexParameters from_read_length(int read_length, int k = DEFAULT, int s = DEFAULT, int l = DEFAULT, int u = DEFAULT, int c = DEFAULT, int max_seed_len = DEFAULT);
+    static IndexParameters from_read_length(int read_length, int c = DEFAULT, int k = DEFAULT, int s = DEFAULT, int l = DEFAULT, int u = DEFAULT, int max_seed_len = DEFAULT, int n = 28);
     static IndexParameters read(std::istream& os);
     std::string filename_extension() const;
     void write(std::ostream& os) const;

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -39,7 +39,7 @@ public:
         verify();
     }
 
-    static IndexParameters from_read_length(int read_length, int c = DEFAULT, int k = DEFAULT, int s = DEFAULT, int l = DEFAULT, int u = DEFAULT, int max_seed_len = DEFAULT, int n = 28);
+    static IndexParameters from_read_length(int read_length, int k = DEFAULT, int s = DEFAULT, int l = DEFAULT, int u = DEFAULT, int c = DEFAULT, int max_seed_len = DEFAULT, int n = 28);
     static IndexParameters read(std::istream& os);
     std::string filename_extension() const;
     void write(std::ostream& os) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,6 @@ int run_strobealign(int argc, char **argv) {
     if (opt.c >= 64 || opt.c <= 0) {
         throw BadParameter("c must be greater than 0 and less than 64");
     }
-
     InputBuffer input_buffer = get_input_buffer(opt);
     if (!opt.r_set && !opt.reads_filename1.empty()) {
         opt.r = estimate_read_length(input_buffer);
@@ -154,6 +153,7 @@ int run_strobealign(int argc, char **argv) {
         opt.s_set ? opt.s : IndexParameters::DEFAULT,
         opt.l_set ? opt.l : IndexParameters::DEFAULT,
         opt.u_set ? opt.u : IndexParameters::DEFAULT,
+        opt.c_set ? opt.c : IndexParameters::DEFAULT,
         opt.max_seed_len_set ? opt.max_seed_len : IndexParameters::DEFAULT,
         opt.n_set ? opt.n : 28
     );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,8 +154,8 @@ int run_strobealign(int argc, char **argv) {
         opt.s_set ? opt.s : IndexParameters::DEFAULT,
         opt.l_set ? opt.l : IndexParameters::DEFAULT,
         opt.u_set ? opt.u : IndexParameters::DEFAULT,
-        opt.c_set ? opt.c : IndexParameters::DEFAULT,
-        opt.max_seed_len_set ? opt.max_seed_len : IndexParameters::DEFAULT
+        opt.max_seed_len_set ? opt.max_seed_len : IndexParameters::DEFAULT,
+        opt.n_set ? opt.n : 28
     );
     logger.debug() << index_parameters << '\n';
     alignment_params aln_params;

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -169,12 +169,19 @@ std::pair<float, std::vector<Nam>> find_nams(
     robin_hood::unordered_map<unsigned int, std::vector<Hit>> hits_per_ref;
     hits_per_ref.reserve(100);
 
+<<<<<<< HEAD
+=======
+    /*
+    1. Find the hash in the vector
+    2. the occur times of the hash value, use a flag 
+    3. need to know reference index, strobe1 position, storbe2 - strobe1
+    */
+>>>>>>> 4740246 (Fix bug when finding hash)
     int nr_good_hits = 0, total_hits = 0;
     for (const auto &q : query_randstrobes) {
         unsigned int position = index.find(q.hash);
         if (position != -1){
             total_hits++;
-
             uint64_t new_hash = index.get_hash(position + index.filter_cutoff);
             if ((new_hash == q.hash)){
                 continue;

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -1,5 +1,7 @@
 #include "nam.hpp"
+#include "logger.hpp"
 
+static Logger& logger = Logger::get();
 namespace {
 
 struct Hit {
@@ -34,11 +36,11 @@ void add_to_hits_per_ref(
             hits_per_ref[index.reference_index(position)].push_back(Hit{query_s, query_e, ref_s, ref_e, is_rc});
             min_diff = diff;
         }
-    } else {
-        for (unsigned int j = position + 1; j <= next_position; ++j) {
+    } 
+    else {
+        for (unsigned int j = position; j <= next_position; ++j) {
             int ref_s = index.get_strob1_position(j);
             int ref_e = ref_s + index.strobe2_offset(j) + index.k();
-
             int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
             if (diff <= min_diff) {
                 hits_per_ref[index.reference_index(j)].push_back(Hit{query_s, query_e, ref_s, ref_e, is_rc});
@@ -173,11 +175,13 @@ std::pair<float, std::vector<Nam>> find_nams(
     int nr_good_hits = 0, total_hits = 0;
     for (const auto &q : query_randstrobes) {
         // auto ref_hit = index.find(q.hash);
+
         unsigned int position = index.find(q.hash);
         if (position != -1){
             total_hits++;
+
             uint64_t new_hash = index.get_hash(position + index.filter_cutoff);
-            if ((new_hash != -1) && (new_hash == q.hash)){
+            if ((new_hash == q.hash)){
                 continue;
             }
             nr_good_hits++;
@@ -185,8 +189,8 @@ std::pair<float, std::vector<Nam>> find_nams(
         }
     }
     float nonrepetitive_fraction = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
-
     auto nams = merge_hits_into_nams(hits_per_ref, index.k(), false);
+    // return make_pair(hits_per_ref[0].size() + hits_per_ref[1].size() + hits_per_ref[2].size(), nams);
     return make_pair(nonrepetitive_fraction, nams);
 }
 

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -21,28 +21,13 @@ void add_to_hits_per_ref(
     unsigned int position,
     int min_diff
 ) {
-    // Determine whether the hash table’s value directly represents a
-    // ReferenceMer (this is the case if count==1) or an offset/count
-    // pair that refers to entries in the flat_vector.
-
-    unsigned int count = index.get_count(position);
-    if (count == 1) {
-        int ref_s = index.get_strob1_position(position);
+    for (const auto hash = index.get_hash(position); index.get_hash(position) == hash; ++position) {
+        int ref_s = index.get_strobe1_position(position);
         int ref_e = ref_s + index.strobe2_offset(position) + index.k();
         int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
         if (diff <= min_diff) {
             hits_per_ref[index.reference_index(position)].push_back(Hit{query_s, query_e, ref_s, ref_e, is_rc});
             min_diff = diff;
-        }
-    } else {
-        for (unsigned int j = position; j < position + count; ++j) {
-            int ref_s = index.get_strob1_position(j);
-            int ref_e = ref_s + index.strobe2_offset(j) + index.k();
-            int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
-            if (diff <= min_diff) {
-                hits_per_ref[index.reference_index(j)].push_back(Hit{query_s, query_e, ref_s, ref_e, is_rc});
-                min_diff = diff;
-            }
         }
     }
 }
@@ -177,13 +162,10 @@ std::pair<float, std::vector<Nam>> find_nams(
 
     int nr_good_hits = 0, total_hits = 0;
     for (const auto &q : query_randstrobes) {
-        unsigned int position = index.find(q.hash);
+        int position = index.find(q.hash);
         if (position != -1){
             total_hits++;
-            unsigned int count = index.get_count(position);
-            if (count > index.filter_cutoff){
-                continue;
-            } 
+            if (index.get_hash(position + index.filter_cutoff) == q.hash) { continue; }
             nr_good_hits++;
             add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, position, 100'000);
         }
@@ -204,7 +186,6 @@ std::vector<Nam> find_nams_rescue(
 ) {
     struct RescueHit {
         unsigned int count;
-        // RandstrobeMapEntry randstrobe_map_entry;
         unsigned int position;
         unsigned int query_s;
         unsigned int query_e;
@@ -224,7 +205,6 @@ std::vector<Nam> find_nams_rescue(
     hits_rc.reserve(5000);
 
     for (auto &qr : query_randstrobes) {
-        // auto ref_hit = index.find(qr.hash);
         unsigned int position = index.find(qr.hash);
         if (position != -1){
             unsigned int count = index.get_count(position);
@@ -235,14 +215,6 @@ std::vector<Nam> find_nams_rescue(
                 hits_fw.push_back(rh);
             }
         }
-        // if (ref_hit != index.end()) {
-        //     RescueHit rh{ref_hit->second.count(), ref_hit->second, qr.start, qr.end, qr.is_reverse};
-        //     if (qr.is_reverse){
-        //         hits_rc.push_back(rh);
-        //     } else {
-        //         hits_fw.push_back(rh);
-        //     }
-        // }
     }
 
     std::sort(hits_fw.begin(), hits_fw.end());

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -1,7 +1,5 @@
 #include "nam.hpp"
-#include "logger.hpp"
 
-static Logger& logger = Logger::get();
 namespace {
 
 struct Hit {
@@ -36,8 +34,7 @@ void add_to_hits_per_ref(
             hits_per_ref[index.reference_index(position)].push_back(Hit{query_s, query_e, ref_s, ref_e, is_rc});
             min_diff = diff;
         }
-    } 
-    else {
+    } else {
         for (unsigned int j = position; j <= next_position; ++j) {
             int ref_s = index.get_strob1_position(j);
             int ref_e = ref_s + index.strobe2_offset(j) + index.k();
@@ -174,8 +171,6 @@ std::pair<float, std::vector<Nam>> find_nams(
 
     int nr_good_hits = 0, total_hits = 0;
     for (const auto &q : query_randstrobes) {
-        // auto ref_hit = index.find(q.hash);
-
         unsigned int position = index.find(q.hash);
         if (position != -1){
             total_hits++;
@@ -190,7 +185,6 @@ std::pair<float, std::vector<Nam>> find_nams(
     }
     float nonrepetitive_fraction = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
     auto nams = merge_hits_into_nams(hits_per_ref, index.k(), false);
-    // return make_pair(hits_per_ref[0].size() + hits_per_ref[1].size() + hits_per_ref[2].size(), nams);
     return make_pair(nonrepetitive_fraction, nams);
 }
 

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -18,7 +18,6 @@ void add_to_hits_per_ref(
     int query_e,
     bool is_rc,
     const StrobemerIndex& index,
-    // RandstrobeMapEntry randstrobe_map_entry,
     unsigned int position,
     int min_diff
 ) {
@@ -26,21 +25,8 @@ void add_to_hits_per_ref(
     // ReferenceMer (this is the case if count==1) or an offset/count
     // pair that refers to entries in the flat_vector.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    unsigned int next_position = index.get_next_pos(position);
-
-    if (next_position == position) {
-=======
     unsigned int count = index.get_count(position);
     if (count == 1) {
-        // auto r = randstrobe_map_entry.as_ref_randstrobe();
->>>>>>> 8f7cebc (Add count to topN bits)
-=======
-    unsigned int count = index.get_count(position);
-    if (count == 1) {
-        // auto r = randstrobe_map_entry.as_ref_randstrobe();
->>>>>>> a8f67916634c393db08b8a2e6c8305da4eec5838
         int ref_s = index.get_strob1_position(position);
         int ref_e = ref_s + index.strobe2_offset(position) + index.k();
         int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
@@ -183,20 +169,12 @@ std::pair<float, std::vector<Nam>> find_nams(
     robin_hood::unordered_map<unsigned int, std::vector<Hit>> hits_per_ref;
     hits_per_ref.reserve(100);
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> a8f67916634c393db08b8a2e6c8305da4eec5838
     /*
     1. Find the hash in the vector
     2. the occur times of the hash value, use a flag 
     3. need to know reference index, strobe1 position, storbe2 - strobe1
     */
-<<<<<<< HEAD
->>>>>>> 4740246 (Fix bug when finding hash)
-=======
->>>>>>> a8f67916634c393db08b8a2e6c8305da4eec5838
+
     int nr_good_hits = 0, total_hits = 0;
     for (const auto &q : query_randstrobes) {
         unsigned int position = index.find(q.hash);

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -27,6 +27,7 @@ void add_to_hits_per_ref(
     // pair that refers to entries in the flat_vector.
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     unsigned int next_position = index.get_next_pos(position);
 
     if (next_position == position) {
@@ -35,6 +36,11 @@ void add_to_hits_per_ref(
     if (count == 1) {
         // auto r = randstrobe_map_entry.as_ref_randstrobe();
 >>>>>>> 8f7cebc (Add count to topN bits)
+=======
+    unsigned int count = index.get_count(position);
+    if (count == 1) {
+        // auto r = randstrobe_map_entry.as_ref_randstrobe();
+>>>>>>> a8f67916634c393db08b8a2e6c8305da4eec5838
         int ref_s = index.get_strob1_position(position);
         int ref_e = ref_s + index.strobe2_offset(position) + index.k();
         int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
@@ -178,13 +184,19 @@ std::pair<float, std::vector<Nam>> find_nams(
     hits_per_ref.reserve(100);
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+>>>>>>> a8f67916634c393db08b8a2e6c8305da4eec5838
     /*
     1. Find the hash in the vector
     2. the occur times of the hash value, use a flag 
     3. need to know reference index, strobe1 position, storbe2 - strobe1
     */
+<<<<<<< HEAD
 >>>>>>> 4740246 (Fix bug when finding hash)
+=======
+>>>>>>> a8f67916634c393db08b8a2e6c8305da4eec5838
     int nr_good_hits = 0, total_hits = 0;
     for (const auto &q : query_randstrobes) {
         unsigned int position = index.find(q.hash);
@@ -245,6 +257,14 @@ std::vector<Nam> find_nams_rescue(
                 hits_fw.push_back(rh);
             }
         }
+        // if (ref_hit != index.end()) {
+        //     RescueHit rh{ref_hit->second.count(), ref_hit->second, qr.start, qr.end, qr.is_reverse};
+        //     if (qr.is_reverse){
+        //         hits_rc.push_back(rh);
+        //     } else {
+        //         hits_fw.push_back(rh);
+        //     }
+        // }
     }
 
     std::sort(hits_fw.begin(), hits_fw.end());

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -76,7 +76,7 @@ std::vector<Nam> merge_hits_into_nams(
                         o.ref_e = h.ref_e;
 //                        o.previous_query_start = h.query_s;
 //                        o.previous_ref_start = h.ref_s; // keeping track so that we don't . Can be caused by interleaved repeats.
-                        o.query_prev_hit_startpos = h.query_s; // log the last strobemer hit in case of outputting paf
+                        o.query_prev_hit_startpos = h.query_s; // ` the last strobemer hit in case of outputting paf
                         o.ref_prev_hit_startpos = h.ref_s; // log the last strobemer hit in case of outputting paf
                         o.n_hits ++;
 //                        o.score += (float)1/ (float)h.count;

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -1,5 +1,7 @@
 #include "nam.hpp"
+#include "logger.hpp"
 
+static Logger& logger = Logger::get();
 namespace {
 
 struct Hit {
@@ -24,9 +26,15 @@ void add_to_hits_per_ref(
     // ReferenceMer (this is the case if count==1) or an offset/count
     // pair that refers to entries in the flat_vector.
 
+<<<<<<< HEAD
     unsigned int next_position = index.get_next_pos(position);
 
     if (next_position == position) {
+=======
+    unsigned int count = index.get_count(position);
+    if (count == 1) {
+        // auto r = randstrobe_map_entry.as_ref_randstrobe();
+>>>>>>> 8f7cebc (Add count to topN bits)
         int ref_s = index.get_strob1_position(position);
         int ref_e = ref_s + index.strobe2_offset(position) + index.k();
         int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
@@ -35,7 +43,7 @@ void add_to_hits_per_ref(
             min_diff = diff;
         }
     } else {
-        for (unsigned int j = position; j <= next_position; ++j) {
+        for (unsigned int j = position; j < position + count; ++j) {
             int ref_s = index.get_strob1_position(j);
             int ref_e = ref_s + index.strobe2_offset(j) + index.k();
             int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
@@ -182,10 +190,10 @@ std::pair<float, std::vector<Nam>> find_nams(
         unsigned int position = index.find(q.hash);
         if (position != -1){
             total_hits++;
-            uint64_t new_hash = index.get_hash(position + index.filter_cutoff);
-            if ((new_hash == q.hash)){
+            unsigned int count = index.get_count(position);
+            if (count > index.filter_cutoff){
                 continue;
-            }
+            } 
             nr_good_hits++;
             add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, position, 100'000);
         }
@@ -229,7 +237,7 @@ std::vector<Nam> find_nams_rescue(
         // auto ref_hit = index.find(qr.hash);
         unsigned int position = index.find(qr.hash);
         if (position != -1){
-            unsigned int count = index.get_next_pos(position) - position + 1;
+            unsigned int count = index.get_count(position);
             RescueHit rh{count, position, qr.start, qr.end, qr.is_reverse};
             if (qr.is_reverse){
                 hits_rc.push_back(rh);

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -157,7 +157,6 @@ void perform_task(
                 && input_buffer.finished_reading){
             break;
         }
-
         std::string sam_out;
         sam_out.reserve(7*map_param.r * (records1.size() + records3.size()));
         CigarOps cigar_ops = map_param.cigar_eqx ? CigarOps::EQX : CigarOps::M;

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -16,7 +16,6 @@
 #include "kseq++.hpp"
 #include "sam.hpp"
 
-
 // checks if two read names are the same ignoring /1 suffix on the first one
 // and /2 on the second one (if present)
 bool same_name(const std::string& n1, const std::string& n2) {
@@ -29,9 +28,11 @@ bool same_name(const std::string& n1, const std::string& n2) {
     if (n1[i - 1] == '/' && n1[i] == '1' && n2[i] == '2') return true;
     return n1[i] == n2[i];
 }
+
 // distribute_interleaved implements the 'interleaved' format:
 // If two consequent reads have the same name, they are considered to be a pair.
 // Otherwise, they are considered to be single-end reads.
+
 void distribute_interleaved(
     std::vector<klibpp::KSeq>& records,
     std::vector<klibpp::KSeq>& records1,

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -16,8 +16,6 @@
 #include "kseq++.hpp"
 #include "sam.hpp"
 
-// checks if two read names are the same ignoring /1 suffix on the first one
-// and /2 on the second one (if present)
 bool same_name(const std::string& n1, const std::string& n2) {
     if (n1.length() != n2.length()) return false;
     if (n1.length() <= 2) return n1 == n2;

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -143,7 +143,9 @@ void perform_task(
 ) {
     bool eof = false;
     Aligner aligner{aln_params};
+    int temp_index = 0;
     while (!eof) {
+        temp_index += 1;
         std::vector<klibpp::KSeq> records1;
         std::vector<klibpp::KSeq> records2;
         std::vector<klibpp::KSeq> records3;
@@ -155,6 +157,7 @@ void perform_task(
                 && input_buffer.finished_reading){
             break;
         }
+
         std::string sam_out;
         sam_out.reserve(7*map_param.r * (records1.size() + records3.size()));
         CigarOps cigar_ops = map_param.cigar_eqx ? CigarOps::EQX : CigarOps::M;

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -13,6 +13,86 @@
 int main() {
 }
 
+namespace {
+
+struct StrobemerIndex;
+
+/*
+ * An entry in the randstrobe map that allows retrieval of randstrobe
+ * occurrences. To save memory, the entry is either a "direct" or an
+ * "indirect" one.
+ *
+ * - A direct entry is used if the randstrobe occurs only once in the reference.
+ *   Then that single occurrence itself is stored and can be retrieved by the
+ *   as_ref_randstrobe() method.
+ * - An indirect entry is used if the randstrobe has multiple occurrences.
+ *   In that case, offset() and count() point to an interval within a second
+ *   table (RandstrobeVector).
+ */
+class RandstrobeMapEntry {
+public:
+    RandstrobeMapEntry() { }
+    RandstrobeMapEntry(unsigned int offset, unsigned int count) : m_offset(offset), m_count(count) { }
+
+    template <class F>
+    void for_each(const RefRandstrobeVector& flat_vector, F func) const {
+        // Determine whether the hash table’s value directly represents a
+        // ReferenceMer (this is the case if count==1) or an offset/count
+        // pair that refers to entries in the flat_vector.
+        if (is_direct()) {
+            func(as_ref_randstrobe());
+        } else {
+            for (size_t j = offset(); j < offset() + count(); ++j) {
+                func(flat_vector[j]);
+            }
+        }
+    }
+
+    unsigned int count() const {
+        if (is_direct()) {
+            return 1;
+        } else {
+            return m_count;
+        }
+    }
+
+    void set_count(unsigned int count) {
+        m_count = count;
+    }
+
+    void set_offset(unsigned int offset) {
+        assert(!is_direct());
+        m_offset = offset;
+    }
+
+    unsigned int offset() const {
+        assert(!is_direct());
+        return m_offset;
+    }
+
+    bool is_direct() const {
+        return m_count & 0x8000'0000;
+    }
+
+    RefRandstrobe as_ref_randstrobe() const {  // 将m_count 首位置为0
+        assert(is_direct());
+        return RefRandstrobe{m_offset, m_count & 0x7fff'ffff};
+    }
+
+    unsigned int m_offset;
+    unsigned int m_count;
+
+    friend StrobemerIndex;
+};
+
+using RandstrobeMap = robin_hood::unordered_map<randstrobe_hash_t, RandstrobeMapEntry>;
+ 
+
+
+
+}
+
+
 struct hit {
     int query_s;
     int query_e;


### PR DESCRIPTION
We do not add the count in the top N bits.  We searched the count with O(log N). In my benchmarking, it can achieve similar running time. 

It means that we can get even smaller indices later by removing the top of the hash. 

Sincerely
Shaojun