### PR TITLE
Update io.hpp to fix MinGW build

### DIFF
--- a/src/io.hpp
+++ b/src/io.hpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <vector>
+#include <cstdint>
 
 void write_int_to_ostream(std::ostream& os, int value);
 int read_int_from_istream(std::istream& is);


### PR DESCRIPTION
Building on MinGW gets the following error without this fix.

`io.hpp:21:5: error: 'uint64_t' was not declared in this scope`