### PR TITLE
Support passing a raw C string to `Aligner::align`

### DIFF
--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -35,7 +35,10 @@ public:
         , ssw_aligner(StripedSmithWaterman::Aligner(parameters.match, parameters.mismatch, parameters.gap_open, parameters.gap_extend))
     { }
 
-    aln_info align(const std::string &query, const std::string &ref) const;
+    aln_info align(const char* query, size_t qlen, const char* ref, size_t rlen) const;
+    aln_info align(const std::string &query, const std::string &ref) const {
+        return align(query.c_str(), query.length(), ref.c_str(), ref.length());
+    }
 
     alignment_params parameters;
 


### PR DESCRIPTION
Hi!

I am wrapping `strobealign` and using it with another C library for processing reads, and my reads are stored in raw C-strings for ABI compatibility with the rest of the libraries. However, this means that I need to copy the reads to a `std::string` every time I want to align them, only for the SSW aligner to use the raw C strings anyway. 

If you're okay with it, this PR overloads `Aligner::align` so that it can be given raw C strings instead of C++ strings to avoid unneeded copies.