### PR TITLE
Use string views instead of strings when extracting query randstrobes

### DIFF
--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -1,5 +1,6 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/string_view.h>
 #include <nanobind/stl/bind_vector.h>
 #include <nanobind/make_iterator.h>
 #include <iostream>

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -111,7 +111,7 @@ Syncmer SyncmerIterator::next() {
 }
 
 std::pair<std::vector<syncmer_hash_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
-    const std::string &seq,
+    const std::string_view seq,
     const size_t k,
     const size_t s,
     const size_t t
@@ -210,7 +210,7 @@ Randstrobe RandstrobeIterator2::next() {
 /*
  * Generate randstrobes for a query sequence and its reverse complement.
  */
-QueryRandstrobeVector randstrobes_query(const std::string& seq, const IndexParameters& parameters) {
+QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexParameters& parameters) {
     QueryRandstrobeVector randstrobes;
     if (seq.length() < parameters.w_max) {
         return randstrobes;

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -39,7 +39,7 @@ std::ostream& operator<<(std::ostream& os, const QueryRandstrobe& randstrobe);
 
 using QueryRandstrobeVector = std::vector<QueryRandstrobe>;
 
-QueryRandstrobeVector randstrobes_query(const std::string &seq, const IndexParameters& parameters);
+QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexParameters& parameters);
 
 struct Randstrobe {
     randstrobe_hash_t hash;
@@ -109,13 +109,13 @@ std::ostream& operator<<(std::ostream& os, const Syncmer& syncmer);
 
 class SyncmerIterator {
 public:
-    SyncmerIterator(const std::string& seq, size_t k, size_t s, size_t t)
+    SyncmerIterator(const std::string_view seq, size_t k, size_t s, size_t t)
         : seq(seq), k(k), s(s), t(t) { }
 
     Syncmer next();
 
 private:
-    const std::string& seq;
+    const std::string_view seq;
     const size_t k;
     const size_t s;
     const size_t t;
@@ -162,7 +162,7 @@ private:
 
 
 std::pair<std::vector<syncmer_hash_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
-    const std::string &seq,
+    const std::string_view seq,
     const size_t k,
     const size_t s,
     const size_t t


### PR DESCRIPTION
Hi!

I am wrapping `strobealign` and using it with another C library for processing reads, and my reads are stored in raw C-strings for ABI compatibility with the rest of the code. However, this means that I need to copy the reads to a `std::string` at every query, which can become expensive.

This PR updates `query_randstrobes` so that it uses a `std::string_view` rather than a `std::string`, avoiding unneeded copies. `std::string_view` was added in C++17, which is the minimum required version anyway. `std::string_view` can be obtained cheaply (without copy) from both a C++ `std::string` and an raw `const char*` pointer.
