### PR TITLE
Fix secondary alignments not having CIGAR strings

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -119,18 +119,18 @@ static inline void align_SE(
             min_mapq_diff = std::max(0, sam_aln.sw_score - best_align_sw_score); // new distance to next best match
             best_align_sw_score = sam_aln.sw_score;
             best_sam_aln = std::move(sam_aln);
-            if (max_secondary == 1) {
+            if (max_secondary == 0) {
                 best_align_dist = best_sam_aln.global_ed;
             }
         }
 //        sam_aln.ed = 10000; // init
-        if (max_secondary > 1) {
+        if (max_secondary > 0) {
             alignments.emplace_back(sam_aln);
         }
         cnt++;
     }
 
-    if (max_secondary == 1) {
+    if (max_secondary == 0) {
         best_sam_aln.mapq = std::min(min_mapq_diff, 60);
         sam.add(best_sam_aln, record, read.rc);
         return;
@@ -142,7 +142,7 @@ static inline void align_SE(
         }
     );
 
-    auto max_out = std::min(alignments.size(), static_cast<size_t>(max_secondary));
+    auto max_out = std::min(alignments.size(), static_cast<size_t>(max_secondary) + 1);
     bool is_secondary = false;
     for (size_t i = 0; i < max_out; ++i) {
         auto sam_aln = alignments[i];
@@ -1449,7 +1449,7 @@ void align_SE_read(
         align_SE(
             aligner, sam, nams, record, index_parameters.k,
             references, statistics, map_param.dropoff_threshold, map_param.maxTries,
-            map_param.max_secondary + 1
+            map_param.max_secondary
         );
     }
     statistics.tot_extend += extend_timer.duration();

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -870,20 +870,17 @@ void rescue_read(
         auto best_aln_pair = high_scores[0];
         alignment sam_aln1 = std::get<1>(best_aln_pair);
         alignment sam_aln2 = std::get<2>(best_aln_pair);
-//            get_MAPQ(all_nams1, n_max1, mapq1);
-//            mapq2 = 0;
         if (swap_r1r2) {
             sam.add_pair(sam_aln2, sam_aln1, record2, record1, read2.rc, read1.rc, mapq2, mapq1, is_proper_pair(sam_aln2, sam_aln1, mu, sigma), true);
         } else {
             sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc, read2.rc, mapq1, mapq2, is_proper_pair(sam_aln1, sam_aln2, mu, sigma), true);
         }
     } else {
-        int max_out = std::min(high_scores.size(), max_secondary);
+        auto max_out = std::min(high_scores.size(), max_secondary);
         bool is_primary = true;
         auto best_aln_pair = high_scores[0];
         auto s_max = std::get<0>(best_aln_pair);
-//            get_MAPQ(all_nams1, n_max1, mapq1);
-        for (int i = 0; i < max_out; ++i) {
+        for (size_t i = 0; i < max_out; ++i) {
             if (i > 0) {
                 is_primary = false;
                 mapq1 = 0;
@@ -1228,7 +1225,6 @@ inline void align_PE(
     auto sam_aln1 = std::get<1>(best_aln_pair);
     auto sam_aln2 = std::get<2>(best_aln_pair);
     if (max_secondary == 0) {
-//            get_MAPQ_aln(sam_aln1, sam_aln2);
         bool is_proper = is_proper_pair(sam_aln1, sam_aln2, mu, sigma);
         sam.add_pair(sam_aln1, sam_aln2, record1, record2, read1.rc, read2.rc,
                         mapq1, mapq2, is_proper, true);

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -114,6 +114,9 @@ static inline void align_SE(
         int diff_to_best = std::abs(best_align_sw_score - sam_aln.sw_score);
         min_mapq_diff = std::min(min_mapq_diff, diff_to_best);
 
+        if (max_secondary > 0) {
+            alignments.emplace_back(sam_aln);
+        }
         if (sam_aln.sw_score > best_align_sw_score) {
             min_mapq_diff = std::max(0, sam_aln.sw_score - best_align_sw_score); // new distance to next best match
             best_align_sw_score = sam_aln.sw_score;
@@ -121,9 +124,6 @@ static inline void align_SE(
             if (max_secondary == 0) {
                 best_align_dist = best_sam_aln.global_ed;
             }
-        }
-        if (max_secondary > 0) {
-            alignments.emplace_back(sam_aln);
         }
         tries++;
     }

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -68,7 +68,7 @@ bool reverse_nam_if_needed(Nam& n, const Read& read, const References& reference
     return false;
 }
 
-static inline void align_SE_secondary_hits(
+static inline void align_SE(
     const Aligner& aligner,
     Sam& sam,
     std::vector<Nam>& all_nams,
@@ -1450,7 +1450,7 @@ void align_SE_read(
         output_hits_paf(outstring, nams, record.name, references, index_parameters.k,
                         record.seq.length());
     } else {
-        align_SE_secondary_hits(
+        align_SE(
             aligner, sam, nams, record, index_parameters.k,
             references, statistics, map_param.dropoff_threshold, map_param.maxTries,
             map_param.max_secondary + 1

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -146,14 +146,18 @@ void Sam::add_record(
     sam_string.append(std::to_string(template_len));
     sam_string.append("\t");
 
-    if (flags & REVERSE) {
+    if (flags & SECONDARY) {
+        sam_string.append("*");
+    } else if (flags & REVERSE) {
         sam_string.append(query_sequence_rc);
     } else {
         sam_string.append(query_sequence);
     }
 
     if (!(flags & UNMAP)) {
-        if (flags & REVERSE) {
+        if (flags & SECONDARY) {
+            append_qual("");
+        } else if (flags & REVERSE) {
             auto qual_rev = qual;
             std::reverse(qual_rev.begin(), qual_rev.end());
             append_qual(qual_rev);


### PR DESCRIPTION
This was a regression introduced in 51eab56e07dbbb88c67772e7cafa4b777646946f:
After `best_sam_aln = std::move(sam_aln)`, sam_aln should not be used, but we did use it when appending it to the alignments vector.

The  actual bugfix is in 6fb332684574a76569bbd29fcce0f787eb4aae51. This PR also sets SEQ and QUAL to `*` for secondary alignments as recommended by the SAM spec (see #212). (I verified that this is what BWA-MEM does as well.)

Closes #289
Closes #66