### PR TITLE
Backport SSW fix

### DIFF
--- a/ext/ssw/ssw.c
+++ b/ext/ssw/ssw.c
@@ -674,7 +674,7 @@ static cigar* banded_sw (const int8_t* ref,
 	l = 0;	// record length of current cigar
 	op = prev_op = 'M';
 	temp2 = 2;	// h
-	while (LIKELY(i > 0)) {
+	while (LIKELY(i >= 0 && j > 0)) {
 		set_d(temp1, band_width, i, j, temp2);
 		switch (direction_line[temp1]) {
 			case 1:


### PR DESCRIPTION
SSW sometimes computes wrong alignments. This has been reported and fixed in https://github.com/mengyao/Complete-Striped-Smith-Waterman-Library/pull/78

This PR backports just makes the same change that was made in that PR.

Our copy of SSW still has some other bugs that have been fixed in more recent versions of SSW. I’ll look into updating SSW.

Closes #294