### PR TITLE
Fix: Allocated buffer was not correctly deleted

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -108,7 +108,7 @@ void StrobemerIndex::read(const std::string& filename) {
     // read in big chunks
     const uint64_t chunk_size = pow(2,20);//4 M => chunks of ~10 MB - The chunk size seem not to be that important
     auto buf_size = std::min(sz, chunk_size) * (sizeof(RandstrobeMap::key_type) + sizeof(RandstrobeMap::mapped_type));
-    std::unique_ptr<char> buf_ptr(new char[buf_size]);
+    std::unique_ptr<char[]> buf_ptr(new char[buf_size]);
     char* buf2 = buf_ptr.get();
     auto left_to_read = sz;
     while (left_to_read > 0) {


### PR DESCRIPTION
GCC 13 has a new warning that caught this:
```
warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
```

Background: Memory allocated with the `new[]` operator (distinct from just `new`) must be deallocated with the `delete[]` operator (distinct from just `delete`). The `unique_ptr` hides the `delete`, but the principle still applies.