### PR TITLE
Log index statistics in a nicer way

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -140,8 +140,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
 
     Timer count_hash;
     auto randstrobe_hashes = count_randstrobe_hashes_parallel(references, parameters, n_threads);
-    stats.elapsed_unique_hashes = count_hash.duration();
-    logger.debug() << "Count number of randstrobe hashes: " << randstrobe_hashes << '\n';
+    stats.elapsed_counting_hashes = count_hash.duration();
 
     Timer randstrobes_timer;
     add_randstrobes_to_vector(randstrobe_hashes);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -104,7 +104,7 @@ int count_randstrobe_hashes(const std::string& seq, const IndexParameters& param
 size_t count_randstrobe_hashes_parallel(const References& references, const IndexParameters& parameters, size_t n_threads) {
     std::vector<std::thread> workers;
     unsigned int total = 0;
-    std::atomic_size_t ref_index = 0;
+    std::atomic_size_t ref_index{0};
 
     std::vector<int> counts;
     for (size_t i = 0; i < n_threads; ++i) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -206,7 +206,6 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.frac_unique = 1.0 * stats.tot_occur_once / unique_mers;
     stats.tot_high_ab = tot_high_ab;
     stats.tot_mid_ab = tot_mid_ab;
-    stats.tot_distinct_strobemer_count = unique_mers;
 
     std::sort(strobemer_counts.begin(), strobemer_counts.end(), std::greater<int>());
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -221,7 +221,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     }
     stats.filter_cutoff = filter_cutoff;
     stats.elapsed_hash_index = hash_index_timer.duration();
-    stats.unique_mers = unique_mers;
+    stats.unique_strobemers = unique_mers;
 }
 
 void StrobemerIndex::add_randstrobes_to_vector(int randstrobe_hashes){

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -26,7 +26,6 @@ struct IndexCreationStatistics {
     float frac_unique = 0;
     unsigned int tot_high_ab = 0;
     unsigned int tot_mid_ab = 0;
-    unsigned int tot_distinct_strobemer_count = 0;
     unsigned int index_cutoff = 0;
     unsigned int filter_cutoff = 0;
     randstrobe_hash_t unique_strobemers = 0;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -33,7 +33,7 @@ struct IndexCreationStatistics {
 
     std::chrono::duration<double> elapsed_hash_index;
     std::chrono::duration<double> elapsed_generating_seeds;
-    std::chrono::duration<double> elapsed_unique_hashes;
+    std::chrono::duration<double> elapsed_counting_hashes;
     std::chrono::duration<double> elapsed_sorting_seeds;
 };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -29,7 +29,7 @@ struct IndexCreationStatistics {
     unsigned int tot_distinct_strobemer_count = 0;
     unsigned int index_cutoff = 0;
     unsigned int filter_cutoff = 0;
-    randstrobe_hash_t unique_mers = 0;
+    randstrobe_hash_t unique_strobemers = 0;
 
     std::chrono::duration<double> elapsed_hash_index;
     std::chrono::duration<double> elapsed_generating_seeds;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,13 +225,12 @@ int run_strobealign(int argc, char **argv) {
         << "Total strobemers occur once: " << index.stats.tot_occur_once << std::endl
         << "Fraction Unique: " << index.stats.frac_unique << std::endl
         << "Total strobemers highly abundant > 100: " << index.stats.tot_high_ab << std::endl
-        << "Total strobemers mid abundance (between 2-100): " << index.stats.tot_mid_ab << std::endl
-        << "Total distinct strobemers stored: " << index.stats.tot_distinct_strobemer_count << std::endl;
+        << "Total strobemers mid abundance (between 2-100): " << index.stats.tot_mid_ab << std::endl;
         if (index.stats.tot_high_ab >= 1) {
-            logger.debug() << "Ratio distinct to highly abundant: " << index.stats.tot_distinct_strobemer_count / index.stats.tot_high_ab << std::endl;
+            logger.debug() << "Ratio distinct to highly abundant: " << index.stats.unique_strobemers / index.stats.tot_high_ab << std::endl;
         }
         if (index.stats.tot_mid_ab >= 1) {
-            logger.debug() << "Ratio distinct to non distinct: " << index.stats.tot_distinct_strobemer_count / (index.stats.tot_high_ab + index.stats.tot_mid_ab) << std::endl;
+            logger.debug() << "Ratio distinct to non distinct: " << index.stats.unique_strobemers / (index.stats.tot_high_ab + index.stats.tot_mid_ab) << std::endl;
         }
         logger.debug() << "Filtered cutoff index: " << index.stats.index_cutoff << std::endl;
         logger.debug() << "Filtered cutoff count: " << index.stats.filter_cutoff << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -222,7 +222,7 @@ int run_strobealign(int argc, char **argv) {
         logger.debug()
             << "Index statistics\n"
             << "  Total strobemers:    " << std::setw(14) << index.stats.tot_strobemer_count << '\n'
-            << "  Unique strobemers:   " << std::setw(14) << index.stats.unique_strobemers << '\n'
+            << "  Distinct strobemers: " << std::setw(14) << index.stats.unique_strobemers << '\n'
             << "    1 occurrence:      " << std::setw(14) << index.stats.tot_occur_once << " (" << std::setw(6) << index.stats.frac_unique*100 << "%)\n"
             << "    2..100 occurrences:" << std::setw(14) << index.stats.tot_mid_ab << " (" << std::setw(6) << (100.0 * index.stats.tot_mid_ab / index.stats.unique_strobemers) << "%)\n"
             << "    >100 occurrences:  " << std::setw(14) << index.stats.tot_high_ab << " (" << std::setw(6) << (100.0 * index.stats.tot_high_ab / index.stats.unique_strobemers) << "%)\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -220,12 +220,13 @@ int run_strobealign(int argc, char **argv) {
         logger.info() << "Total time indexing: " << index_timer.elapsed() << " s\n";
 
         logger.debug()
-        << "Unique strobemers: " << index.stats.unique_strobemers << std::endl
-        << "Total strobemers count: " << index.stats.tot_strobemer_count << std::endl
-        << "Total strobemers occur once: " << index.stats.tot_occur_once << std::endl
-        << "Fraction Unique: " << index.stats.frac_unique << std::endl
-        << "Total strobemers highly abundant > 100: " << index.stats.tot_high_ab << std::endl
-        << "Total strobemers mid abundance (between 2-100): " << index.stats.tot_mid_ab << std::endl;
+            << "Index statistics\n"
+            << "  Total strobemers:    " << std::setw(14) << index.stats.tot_strobemer_count << '\n'
+            << "  Unique strobemers:   " << std::setw(14) << index.stats.unique_strobemers << '\n'
+            << "    1 occurrence:      " << std::setw(14) << index.stats.tot_occur_once << " (" << std::setw(6) << index.stats.frac_unique*100 << "%)\n"
+            << "    2..100 occurrences:" << std::setw(14) << index.stats.tot_mid_ab << " (" << std::setw(6) << (100.0 * index.stats.tot_mid_ab / index.stats.unique_strobemers) << "%)\n"
+            << "    >100 occurrences:  " << std::setw(14) << index.stats.tot_high_ab << " (" << std::setw(6) << (100.0 * index.stats.tot_high_ab / index.stats.unique_strobemers) << "%)\n"
+            ;
         if (index.stats.tot_high_ab >= 1) {
             logger.debug() << "Ratio distinct to highly abundant: " << index.stats.unique_strobemers / index.stats.tot_high_ab << std::endl;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,7 +214,7 @@ int run_strobealign(int argc, char **argv) {
         index.populate(opt.f, opt.n_threads);
         
         logger.info() << "  Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;
-        logger.info() << "  Time estimating number of unique hashes: " << index.stats.elapsed_unique_hashes.count() << " s" <<  std::endl;
+        logger.info() << "  Time counting hashes: " << index.stats.elapsed_counting_hashes.count() << " s" <<  std::endl;
         logger.info() << "  Time sorting non-unique seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
         logger.info() << "  Time generating hash table index: " << index.stats.elapsed_hash_index.count() << " s" <<  std::endl;
         logger.info() << "Total time indexing: " << index_timer.elapsed() << " s\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -220,7 +220,7 @@ int run_strobealign(int argc, char **argv) {
         logger.info() << "Total time indexing: " << index_timer.elapsed() << " s\n";
 
         logger.debug()
-        << "Unique strobemers: " << index.stats.unique_mers << std::endl
+        << "Unique strobemers: " << index.stats.unique_strobemers << std::endl
         << "Total strobemers count: " << index.stats.tot_strobemer_count << std::endl
         << "Total strobemers occur once: " << index.stats.tot_occur_once << std::endl
         << "Fraction Unique: " << index.stats.frac_unique << std::endl

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -222,7 +222,7 @@ int run_strobealign(int argc, char **argv) {
         logger.debug()
             << "Index statistics\n"
             << "  Total strobemers:    " << std::setw(14) << index.stats.tot_strobemer_count << '\n'
-            << "  Distinct strobemers: " << std::setw(14) << index.stats.unique_strobemers << '\n'
+            << "  Distinct strobemers: " << std::setw(14) << index.stats.unique_strobemers << " (100.00%)\n"
             << "    1 occurrence:      " << std::setw(14) << index.stats.tot_occur_once << " (" << std::setw(6) << index.stats.frac_unique*100 << "%)\n"
             << "    2..100 occurrences:" << std::setw(14) << index.stats.tot_mid_ab << " (" << std::setw(6) << (100.0 * index.stats.tot_mid_ab / index.stats.unique_strobemers) << "%)\n"
             << "    >100 occurrences:  " << std::setw(14) << index.stats.tot_high_ab << " (" << std::setw(6) << (100.0 * index.stats.tot_high_ab / index.stats.unique_strobemers) << "%)\n"


### PR DESCRIPTION
This is also part of #298, but I took the opportunity to make the index statistic logging a bit nicer, which I had wanted to do for a while.
Before:
```
Unique strobemers: 23324540
Total strobemers count: 26446802
Total strobemers occur once: 22560298
Fraction Unique: 0.97
Total strobemers highly abundant > 100: 1562
Total strobemers mid abundance (between 2-100): 762681
Total distinct strobemers stored: 23324540
```

After:
```
Index statistics
  Total strobemers:          26446802
  Unique strobemers:         23324540
    1 occurrence:            22560298 ( 96.72%)
    2..100 occurrences:        762681 (  3.27%)
    >100 occurrences:            1562 (  0.01%)
```
