### PR TITLE
Fail somewhat gracefully for too large references

### DIFF
--- a/src/arguments.hpp
+++ b/src/arguments.hpp
@@ -24,7 +24,7 @@ struct SeedingArguments {
             "It is recommended not to change this parameter unless you have a good "
             "understanding of syncmers as it will drastically change the memory usage and "
             "results with non default values.", {'s'}}
-        , bits{parser, "INT", "No. of top bits of hash to use as bucket indices "
+        , bits{parser, "INT", "No. of top bits of hash to use as bucket indices (8-31)"
             "[determined from reference size]", {'b'}}
     {
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -90,7 +90,7 @@ int StrobemerIndex::pick_bits(size_t size) const {
     return std::max(8, static_cast<int>(log2(estimated_number_of_randstrobes)) - 1);
 }
 
-uint64_t count_randstrobe_hashes(const std::string& seq, const IndexParameters& parameters) {
+uint64_t count_randstrobes(const std::string& seq, const IndexParameters& parameters) {
     uint64_t num = 0;
 
     auto randstrobe_iter = RandstrobeIterator2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
@@ -101,7 +101,7 @@ uint64_t count_randstrobe_hashes(const std::string& seq, const IndexParameters& 
     return num;
 }
 
-uint64_t count_randstrobe_hashes_parallel(const References& references, const IndexParameters& parameters, size_t n_threads) {
+uint64_t count_randstrobes_parallel(const References& references, const IndexParameters& parameters, size_t n_threads) {
     std::vector<std::thread> workers;
     uint64_t total = 0;
     std::atomic_size_t ref_index{0};
@@ -120,7 +120,7 @@ uint64_t count_randstrobe_hashes_parallel(const References& references, const In
                         if (j >= references.size()) {
                             break;
                         }
-                        count += count_randstrobe_hashes(references.sequences[j], parameters);
+                        count += count_randstrobes(references.sequences[j], parameters);
                     }
                 }, std::ref(references), std::ref(parameters), std::ref(counts[i]))
         );
@@ -139,7 +139,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.tot_strobemer_count = 0;
 
     Timer count_hash;
-    auto randstrobe_hashes = count_randstrobe_hashes_parallel(references, parameters, n_threads);
+    auto randstrobe_hashes = count_randstrobes_parallel(references, parameters, n_threads);
     stats.elapsed_counting_hashes = count_hash.duration();
 
     Timer randstrobes_timer;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -161,10 +161,11 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.tot_occur_once = 0;
     randstrobe_start_indices.reserve((1 << bits) + 1);
 
-    unsigned int unique_mers = 0;
+    uint64_t unique_mers = 0;
     randstrobe_hash_t prev_hash = static_cast<randstrobe_hash_t>(-1);
     unsigned int count = 0;
-    for (unsigned int position = 0; position < randstrobes.size(); ++position) {
+
+    for (bucket_index_t position = 0; position < randstrobes.size(); ++position) {
         const randstrobe_hash_t cur_hash = randstrobes[position].hash;
         if (cur_hash == prev_hash) {
             ++count;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -142,6 +142,9 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     auto randstrobe_hashes = count_randstrobes_parallel(references, parameters, n_threads);
     stats.elapsed_counting_hashes = count_hash.duration();
 
+    if (randstrobe_hashes > std::numeric_limits<bucket_index_t>::max()) {
+        throw std::range_error("Too many randstrobes");
+    }
     Timer randstrobes_timer;
     randstrobes.reserve(randstrobe_hashes);
     add_randstrobes_to_vector();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -90,8 +90,8 @@ int StrobemerIndex::pick_bits(size_t size) const {
     return std::max(8, static_cast<int>(log2(estimated_number_of_randstrobes)) - 1);
 }
 
-int count_randstrobe_hashes(const std::string& seq, const IndexParameters& parameters) {
-    int num = 0;
+uint64_t count_randstrobe_hashes(const std::string& seq, const IndexParameters& parameters) {
+    uint64_t num = 0;
 
     auto randstrobe_iter = RandstrobeIterator2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
     Randstrobe randstrobe;
@@ -101,12 +101,12 @@ int count_randstrobe_hashes(const std::string& seq, const IndexParameters& param
     return num;
 }
 
-size_t count_randstrobe_hashes_parallel(const References& references, const IndexParameters& parameters, size_t n_threads) {
+uint64_t count_randstrobe_hashes_parallel(const References& references, const IndexParameters& parameters, size_t n_threads) {
     std::vector<std::thread> workers;
-    unsigned int total = 0;
+    uint64_t total = 0;
     std::atomic_size_t ref_index{0};
 
-    std::vector<int> counts;
+    std::vector<uint64_t> counts;
     for (size_t i = 0; i < n_threads; ++i) {
         counts.push_back(0);
     }
@@ -114,7 +114,7 @@ size_t count_randstrobe_hashes_parallel(const References& references, const Inde
     for (size_t i = 0; i < n_threads; ++i) {
         workers.push_back(
             std::thread(
-                [&ref_index](const References& references, const IndexParameters& parameters, int& count) {
+                [&ref_index](const References& references, const IndexParameters& parameters, uint64_t& count) {
                     while (true) {
                         size_t j = ref_index.fetch_add(1);
                         if (j >= references.size()) {
@@ -223,7 +223,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.unique_strobemers = unique_mers;
 }
 
-void StrobemerIndex::add_randstrobes_to_vector(int randstrobe_hashes){
+void StrobemerIndex::add_randstrobes_to_vector(size_t randstrobe_hashes){
     randstrobes.reserve(randstrobe_hashes);
     for (size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
         auto seq = references.sequences[ref_index];

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -78,7 +78,7 @@ void StrobemerIndex::read(const std::string& filename) {
 
     read_vector(ifs, randstrobes);
     read_vector(ifs, randstrobe_start_indices);
-    if (randstrobe_start_indices.size() != (1 << bits) + 1) {
+    if (randstrobe_start_indices.size() != (1u << bits) + 1) {
         throw InvalidIndexFile("randstrobe_start_indices vector is of the wrong size");
     }
 }
@@ -87,7 +87,7 @@ void StrobemerIndex::read(const std::string& filename) {
 int StrobemerIndex::pick_bits(size_t size) const {
     size_t estimated_number_of_randstrobes = size / (parameters.k - parameters.s + 1);
     // Two randstrobes per bucket on average
-    return std::max(8, static_cast<int>(log2(estimated_number_of_randstrobes)) - 1);
+    return std::clamp(static_cast<int>(log2(estimated_number_of_randstrobes)) - 1, 8, 31);
 }
 
 uint64_t count_randstrobes(const std::string& seq, const IndexParameters& parameters) {
@@ -162,7 +162,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     std::vector<unsigned int> strobemer_counts;
 
     stats.tot_occur_once = 0;
-    randstrobe_start_indices.reserve((1 << bits) + 1);
+    randstrobe_start_indices.reserve((1u << bits) + 1);
 
     uint64_t unique_mers = 0;
     randstrobe_hash_t prev_hash = static_cast<randstrobe_hash_t>(-1);
@@ -205,7 +205,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
         }
         strobemer_counts.push_back(count);
     }
-    while (randstrobe_start_indices.size() < ((1 << bits) + 1)) {
+    while (randstrobe_start_indices.size() < ((1u << bits) + 1)) {
         randstrobe_start_indices.push_back(randstrobes.size());
     }
     stats.frac_unique = 1.0 * stats.tot_occur_once / unique_mers;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -143,7 +143,8 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.elapsed_counting_hashes = count_hash.duration();
 
     Timer randstrobes_timer;
-    add_randstrobes_to_vector(randstrobe_hashes);
+    randstrobes.reserve(randstrobe_hashes);
+    add_randstrobes_to_vector();
     stats.elapsed_generating_seeds = randstrobes_timer.duration();
 
     Timer sorting_timer;
@@ -223,8 +224,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.unique_strobemers = unique_mers;
 }
 
-void StrobemerIndex::add_randstrobes_to_vector(size_t randstrobe_hashes){
-    randstrobes.reserve(randstrobe_hashes);
+void StrobemerIndex::add_randstrobes_to_vector() {
     for (size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
         auto seq = references.sequences[ref_index];
         if (seq.length() < parameters.w_max) {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -148,7 +148,7 @@ struct StrobemerIndex {
     }
 
 private:
-    void add_randstrobes_to_vector(size_t randstrobe_hashes);
+    void add_randstrobes_to_vector();
 
     const IndexParameters& parameters;
     const References& references;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -37,6 +37,7 @@ struct IndexCreationStatistics {
 };
 
 struct StrobemerIndex {
+    using bucket_index_t = uint32_t;
     StrobemerIndex(const References& references, const IndexParameters& parameters, int bits=-1)
         : filter_cutoff(0)
         , parameters(parameters)
@@ -54,8 +55,8 @@ struct StrobemerIndex {
     int find(randstrobe_hash_t key) const {
         constexpr int MAX_LINEAR_SEARCH = 4;
         const unsigned int top_N = key >> (64 - bits);
-        int position_start = randstrobe_start_indices[top_N];
-        int position_end = randstrobe_start_indices[top_N + 1];
+        bucket_index_t position_start = randstrobe_start_indices[top_N];
+        bucket_index_t position_end = randstrobe_start_indices[top_N + 1];
         if (position_start == position_end) {
             return -1;
         }
@@ -77,31 +78,31 @@ struct StrobemerIndex {
         return -1;
     }
 
-    randstrobe_hash_t get_hash(unsigned int position) const {
-        if (position < randstrobes.size()){
+    randstrobe_hash_t get_hash(bucket_index_t position) const {
+        if (position < randstrobes.size()) {
             return randstrobes[position].hash;
-        }else{
+        } else {
             return -1;
         }
     }
     
-    randstrobe_hash_t is_filtered(int position) const {
+    randstrobe_hash_t is_filtered(bucket_index_t position) const {
         return get_hash(position) == get_hash(position + filter_cutoff);
     }
 
-    unsigned int get_strobe1_position(unsigned int position) const {
+    unsigned int get_strobe1_position(bucket_index_t position) const {
         return randstrobes[position].position;
     }
 
-    int strobe2_offset(unsigned int position) const {
+    int strobe2_offset(bucket_index_t position) const {
         return randstrobes[position].strobe2_offset();
     }
 
-    int reference_index(unsigned int position) const {
+    int reference_index(bucket_index_t position) const {
         return randstrobes[position].reference_index();
     }
 
-    unsigned int get_count(const unsigned int position) const {
+    unsigned int get_count(bucket_index_t position) const {
         // For 95% of cases, the result will be small and a brute force search
         // is the best option. Once, we go over MAX_LINEAR_SEARCH, though, we
         // use a binary search to get the next position
@@ -112,11 +113,11 @@ struct StrobemerIndex {
         constexpr unsigned int MAX_LINEAR_SEARCH = 8;
         const auto key = randstrobes[position].hash;
         const unsigned int top_N = key >> (64 - bits);
-        int position_end = randstrobe_start_indices[top_N + 1];
-        unsigned int count = 1;
+        bucket_index_t position_end = randstrobe_start_indices[top_N + 1];
+        uint64_t count = 1;
 
         if (position_end - position < MAX_LINEAR_SEARCH) {
-            for (int position_start = position + 1; position_start < position_end; ++position_start) {
+            for (bucket_index_t position_start = position + 1; position_start < position_end; ++position_start) {
                 if (randstrobes[position_start].hash == key){
                     count += 1;
                 }

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -42,7 +42,12 @@ struct StrobemerIndex {
         : filter_cutoff(0)
         , parameters(parameters)
         , references(references)
-        , bits(bits == -1 ? pick_bits(references.total_length()) : bits) { }
+        , bits(bits == -1 ? pick_bits(references.total_length()) : bits)
+    {
+        if (this->bits < 8 || this->bits > 31) {
+            throw BadParameter("Bits must be between 8 and 31");
+        }
+    }
     unsigned int filter_cutoff; //This also exists in mapping_params, but is calculated during index generation,
                                 //therefore stored here since it needs to be saved with the index.
     mutable IndexCreationStatistics stats;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -148,7 +148,7 @@ struct StrobemerIndex {
     }
 
 private:
-    void add_randstrobes_to_vector(int randstrobe_hashes);
+    void add_randstrobes_to_vector(size_t randstrobe_hashes);
 
     const IndexParameters& parameters;
     const References& references;


### PR DESCRIPTION
This improves handling of large references by hopefully crashing with a somewhat helpful error message (instead of just `std::length_error` or so).

Also, this limits the bits (`-b`) to the range 8..31. It may work up to 32, but this needs some further checking.

* Fix counting of randstrobes (this was just a 32 bit unsigned int and would therefore overflow on large references).
* Introduce a `bucket_index_t` type alias. The intention is for this to become a template parameter at a later stage, which can then be instantiated to be either a `uint32_t` or `uint64_t`.