### PR TITLE
Speed up index generation slightly by forcing inlining of XXH64

### DIFF
--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -3,6 +3,8 @@
 #include <bitset>
 #include <algorithm>
 #include <cassert>
+
+#define XXH_INLINE_ALL
 #include <xxhash.h>
 
 #include "randstrobes.hpp"


### PR DESCRIPTION
See https://fastcompression.blogspot.com/2018/03/xxhash-for-small-keys-impressive-power.html

This speeds up index generation by ~3%.