### PR TITLE
Make strobealign work with large references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,10 @@
 
 * #278: Memory usage was reduced drastically thanks to a redesigned strobemer
   index memory layout. For the human genome, for example, strobealign now needs
-  13 GiB of RAM instead of 23 GiB. Contributed by @psj1997 and @luispedro.
+  14 GiB of RAM instead of 23 GiB. Contributed by @psj1997 and @luispedro.
+* #277, #285, PR #306: Support for very large references (exceeding ~20 Gbp) was
+  added by switching from 32 bit to 64 bit strobemer indices.
+  This was also enabled and made simpler by the memory layout changes.
 * #289: Fixed missing CIGAR for secondary alignments.
 * #212: SEQ and QUAL are set to `*` for secondary alignments as recommended
   by the SAM specification.

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -208,7 +208,6 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     while (randstrobe_start_indices.size() < ((1u << bits) + 1)) {
         randstrobe_start_indices.push_back(randstrobes.size());
     }
-    stats.frac_unique = 1.0 * stats.tot_occur_once / unique_mers;
     stats.tot_high_ab = tot_high_ab;
     stats.tot_mid_ab = tot_mid_ab;
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -142,6 +142,9 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     auto randstrobe_hashes = count_randstrobes_parallel(references, parameters, n_threads);
     stats.elapsed_counting_hashes = count_hash.duration();
 
+    uint64_t memory_bytes = references.total_length() + sizeof(RefRandstrobe) * randstrobe_hashes + sizeof(bucket_index_t) * (1u << bits);
+    logger.debug() << "Estimated total memory usage: " << memory_bytes / 1E9 << " GB\n";
+
     if (randstrobe_hashes > std::numeric_limits<bucket_index_t>::max()) {
         throw std::range_error("Too many randstrobes");
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -157,9 +157,9 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
 
     Timer hash_index_timer;
 
-    unsigned int tot_high_ab = 0;
-    unsigned int tot_mid_ab = 0;
-    std::vector<unsigned int> strobemer_counts;
+    uint64_t tot_high_ab = 0;
+    uint64_t tot_mid_ab = 0;
+    std::vector<uint64_t> strobemer_counts;
 
     stats.tot_occur_once = 0;
     randstrobe_start_indices.reserve((1u << bits) + 1);
@@ -213,7 +213,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
 
     std::sort(strobemer_counts.begin(), strobemer_counts.end(), std::greater<int>());
 
-    unsigned int index_cutoff = unique_mers * f;
+    uint64_t index_cutoff = unique_mers * f;
     stats.index_cutoff = index_cutoff;
     if (!strobemer_counts.empty()){
         filter_cutoff = index_cutoff < strobemer_counts.size() ?  strobemer_counts[index_cutoff] : strobemer_counts.back();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -257,10 +257,10 @@ void StrobemerIndex::add_randstrobes_to_vector() {
                 RefRandstrobe::packed_t packed = ref_index << 8;
                 packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
                 randstrobes.push_back(RefRandstrobe{randstrobe.hash, randstrobe.strobe1_pos, packed});
-                }
-            chunk.clear();
             }
+            chunk.clear();
         }
+    }
 }
 
 void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) const {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -143,6 +143,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.elapsed_counting_hashes = count_hash.duration();
 
     uint64_t memory_bytes = references.total_length() + sizeof(RefRandstrobe) * randstrobe_hashes + sizeof(bucket_index_t) * (1u << bits);
+    logger.debug() << "Total number of randstrobes: " << randstrobe_hashes << '\n';
     logger.debug() << "Estimated total memory usage: " << memory_bytes / 1E9 << " GB\n";
 
     if (randstrobe_hashes > std::numeric_limits<bucket_index_t>::max()) {

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -20,13 +20,13 @@
 
 
 struct IndexCreationStatistics {
-    unsigned int tot_strobemer_count = 0;
-    unsigned int tot_occur_once = 0;
-    unsigned int tot_high_ab = 0;
-    unsigned int tot_mid_ab = 0;
-    unsigned int index_cutoff = 0;
-    unsigned int filter_cutoff = 0;
-    randstrobe_hash_t unique_strobemers = 0;
+    uint64_t tot_strobemer_count = 0;
+    uint64_t tot_occur_once = 0;
+    uint64_t tot_high_ab = 0;
+    uint64_t tot_mid_ab = 0;
+    uint64_t index_cutoff = 0;
+    uint64_t filter_cutoff = 0;
+    uint64_t unique_strobemers = 0;
 
     std::chrono::duration<double> elapsed_hash_index;
     std::chrono::duration<double> elapsed_generating_seeds;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -139,7 +139,7 @@ struct StrobemerIndex {
         return (pos - randstrobes.begin() - 1) - position + 1;
     }
 
-    int end() const {
+    size_t end() const {
         return -1;
     }
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -61,15 +61,15 @@ struct StrobemerIndex {
         bucket_index_t position_start = randstrobe_start_indices[top_N];
         bucket_index_t position_end = randstrobe_start_indices[top_N + 1];
         if (position_start == position_end) {
-            return -1;
+            return end();
         }
 
         if (position_end - position_start < MAX_LINEAR_SEARCH) {
             for ( ; position_start < position_end; ++position_start) {
                 if (randstrobes[position_start].hash == key) return position_start;
-                if (randstrobes[position_start].hash > key) return -1;
+                if (randstrobes[position_start].hash > key) return end();
             }
-            return -1;
+            return end();
         }
         auto cmp = [](const RefRandstrobe lhs, const RefRandstrobe rhs) {return lhs.hash < rhs.hash; };
 
@@ -78,14 +78,14 @@ struct StrobemerIndex {
                                                RefRandstrobe{key, 0, 0},
                                                cmp);
         if (pos->hash == key) return pos - randstrobes.begin();
-        return -1;
+        return end();
     }
 
     randstrobe_hash_t get_hash(bucket_index_t position) const {
         if (position < randstrobes.size()) {
             return randstrobes[position].hash;
         } else {
-            return -1;
+            return end();
         }
     }
     

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -22,7 +22,6 @@
 struct IndexCreationStatistics {
     unsigned int tot_strobemer_count = 0;
     unsigned int tot_occur_once = 0;
-    float frac_unique = 0;
     unsigned int tot_high_ab = 0;
     unsigned int tot_mid_ab = 0;
     unsigned int index_cutoff = 0;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -35,7 +35,7 @@ struct IndexCreationStatistics {
 };
 
 struct StrobemerIndex {
-    using bucket_index_t = uint32_t;
+    using bucket_index_t = uint64_t;
     StrobemerIndex(const References& references, const IndexParameters& parameters, int bits=-1)
         : filter_cutoff(0)
         , parameters(parameters)
@@ -170,7 +170,7 @@ private:
      */
 
     std::vector<RefRandstrobe> randstrobes;
-    std::vector<unsigned int> randstrobe_start_indices;
+    std::vector<bucket_index_t> randstrobe_start_indices;
     int bits; // no. of bits of the hash to use when indexing a randstrobe bucket
 };
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -20,7 +20,6 @@
 
 
 struct IndexCreationStatistics {
-    unsigned int flat_vector_size = 0;
     unsigned int tot_strobemer_count = 0;
     unsigned int tot_occur_once = 0;
     float frac_unique = 0;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -55,7 +55,7 @@ struct StrobemerIndex {
     void populate(float f, size_t n_threads);
     void print_diagnostics(const std::string& logfile_name, int k) const;
     int pick_bits(size_t size) const;
-    int find(randstrobe_hash_t key) const {
+    size_t find(randstrobe_hash_t key) const {
         constexpr int MAX_LINEAR_SEARCH = 4;
         const unsigned int top_N = key >> (64 - bits);
         bucket_index_t position_start = randstrobe_start_indices[top_N];
@@ -89,7 +89,7 @@ struct StrobemerIndex {
         }
     }
     
-    randstrobe_hash_t is_filtered(bucket_index_t position) const {
+    bool is_filtered(bucket_index_t position) const {
         return get_hash(position) == get_hash(position + filter_cutoff);
     }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -1,13 +1,13 @@
 #include "io.hpp"
 
-void write_int_to_ostream(std::ostream& os, int value) {
-    int val;
+void write_int_to_ostream(std::ostream& os, int32_t value) {
+    int32_t val;
     val = value;
     os.write(reinterpret_cast<const char*>(&val), sizeof(val));
 }
 
-int read_int_from_istream(std::istream& is) {
-    int val;
+int32_t read_int_from_istream(std::istream& is) {
+    int32_t val;
     is.read(reinterpret_cast<char*>(&val), sizeof(val));
     return val;
 }

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -5,13 +5,13 @@
 #include <vector>
 #include <cstdint>
 
-void write_int_to_ostream(std::ostream& os, int value);
-int read_int_from_istream(std::istream& is);
+void write_int_to_ostream(std::ostream& os, int32_t value);
+int32_t read_int_from_istream(std::istream& is);
 
 /* Write a vector to an output stream, preceded by its length */
 template <typename T>
 void write_vector(std::ostream& os, const std::vector<T>& v) {
-    auto size = uint64_t(v.size());
+    uint64_t size = v.size();
     os.write(reinterpret_cast<char*>(&size), sizeof(size));
     os.write(reinterpret_cast<const char*>(v.data()), v.size() * sizeof(T));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,9 +223,12 @@ int run_strobealign(int argc, char **argv) {
             << "Index statistics\n"
             << "  Total strobemers:    " << std::setw(14) << index.stats.tot_strobemer_count << '\n'
             << "  Distinct strobemers: " << std::setw(14) << index.stats.unique_strobemers << " (100.00%)\n"
-            << "    1 occurrence:      " << std::setw(14) << index.stats.tot_occur_once << " (" << std::setw(6) << index.stats.frac_unique*100 << "%)\n"
-            << "    2..100 occurrences:" << std::setw(14) << index.stats.tot_mid_ab << " (" << std::setw(6) << (100.0 * index.stats.tot_mid_ab / index.stats.unique_strobemers) << "%)\n"
-            << "    >100 occurrences:  " << std::setw(14) << index.stats.tot_high_ab << " (" << std::setw(6) << (100.0 * index.stats.tot_high_ab / index.stats.unique_strobemers) << "%)\n"
+            << "    1 occurrence:      " << std::setw(14) << index.stats.tot_occur_once
+                << " (" << std::setw(6) << (100.0 * index.stats.tot_occur_once / index.stats.unique_strobemers) << "%)\n"
+            << "    2..100 occurrences:" << std::setw(14) << index.stats.tot_mid_ab
+                << " (" << std::setw(6) << (100.0 * index.stats.tot_mid_ab / index.stats.unique_strobemers) << "%)\n"
+            << "    >100 occurrences:  " << std::setw(14) << index.stats.tot_high_ab
+                << " (" << std::setw(6) << (100.0 * index.stats.tot_high_ab / index.stats.unique_strobemers) << "%)\n"
             ;
         if (index.stats.tot_high_ab >= 1) {
             logger.debug() << "Ratio distinct to highly abundant: " << index.stats.unique_strobemers / index.stats.tot_high_ab << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,9 +213,9 @@ int run_strobealign(int argc, char **argv) {
         Timer index_timer;
         index.populate(opt.f, opt.n_threads);
         
+        logger.info() << "  Time counting seeds: " << index.stats.elapsed_counting_hashes.count() << " s" <<  std::endl;
         logger.info() << "  Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;
-        logger.info() << "  Time counting hashes: " << index.stats.elapsed_counting_hashes.count() << " s" <<  std::endl;
-        logger.info() << "  Time sorting non-unique seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
+        logger.info() << "  Time sorting seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
         logger.info() << "  Time generating hash table index: " << index.stats.elapsed_hash_index.count() << " s" <<  std::endl;
         logger.info() << "Total time indexing: " << index_timer.elapsed() << " s\n";
 

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -16,7 +16,7 @@ void add_to_hits_per_ref(
     int query_e,
     bool is_rc,
     const StrobemerIndex& index,
-    unsigned int position,
+    size_t position,
     int min_diff
 ) {
     for (const auto hash = index.get_hash(position); index.get_hash(position) == hash; ++position) {
@@ -153,7 +153,7 @@ std::pair<float, std::vector<Nam>> find_nams(
     hits_per_ref.reserve(100);
     int nr_good_hits = 0, total_hits = 0;
     for (const auto &q : query_randstrobes) {
-        int position = index.find(q.hash);
+        size_t position = index.find(q.hash);
         if (position != index.end()){
             total_hits++;
             if (index.is_filtered(position)) {
@@ -179,7 +179,7 @@ std::vector<Nam> find_nams_rescue(
 ) {
     struct RescueHit {
         unsigned int count;
-        unsigned int position;
+        size_t position;
         unsigned int query_s;
         unsigned int query_e;
         bool is_rc;
@@ -198,10 +198,10 @@ std::vector<Nam> find_nams_rescue(
     hits_rc.reserve(5000);
 
     for (auto &qr : query_randstrobes) {
-        int position = index.find(qr.hash);
-        if (position != index.end()){
+        size_t position = index.find(qr.hash);
+        if (position != index.end()) {
             unsigned int count = index.get_count(position);
-            RescueHit rh{count, static_cast<unsigned int>(position), qr.start, qr.end, qr.is_reverse};
+            RescueHit rh{count, position, qr.start, qr.end, qr.is_reverse};
             if (qr.is_reverse){
                 hits_rc.push_back(rh);
             } else {


### PR DESCRIPTION
(Marking as draft because this is untested.)

This unconditionally switches the bucket start indices from 32 to 64 bit. This makes strobealign work with more than $2^{32}$ strobemers, but also doubles memory usage of the index vector.

Closes #277
Closes #285