### PR TITLE
Compute strobemers in parallel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 * #277, #285, PR #306: Support for very large references (exceeding ~20 Gbp) was
   added by switching from 32 bit to 64 bit strobemer indices.
   This was also enabled and made simpler by the memory layout changes.
+* #307: Indexing was further parallelized, cutting the time for index generation
+  in about half for many cases.
 * #289: Fixed missing CIGAR for secondary alignments.
 * #212: SEQ and QUAL are set to `*` for secondary alignments as recommended
   by the SAM specification.

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -101,9 +101,8 @@ uint64_t count_randstrobes(const std::string& seq, const IndexParameters& parame
     return num;
 }
 
-uint64_t count_randstrobes_parallel(const References& references, const IndexParameters& parameters, size_t n_threads) {
+std::vector<uint64_t> count_randstrobes_parallel(const References& references, const IndexParameters& parameters, size_t n_threads) {
     std::vector<std::thread> workers;
-    uint64_t total = 0;
     std::atomic_size_t ref_index{0};
 
     std::vector<uint64_t> counts;
@@ -129,29 +128,31 @@ uint64_t count_randstrobes_parallel(const References& references, const IndexPar
         worker.join();
     }
 
-    for (auto& count : counts) {
-        total += count;
-    }
-    return total;
+    return counts;
 }
 
 void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.tot_strobemer_count = 0;
 
     Timer count_hash;
-    auto randstrobe_hashes = count_randstrobes_parallel(references, parameters, n_threads);
+    auto randstrobe_counts = count_randstrobes_parallel(references, parameters, n_threads);
     stats.elapsed_counting_hashes = count_hash.duration();
 
-    uint64_t memory_bytes = references.total_length() + sizeof(RefRandstrobe) * randstrobe_hashes + sizeof(bucket_index_t) * (1u << bits);
-    logger.debug() << "Total number of randstrobes: " << randstrobe_hashes << '\n';
+    uint64_t total_randstrobes = 0;
+    for (auto& count : randstrobe_counts) {
+        total_randstrobes += count;
+    }
+
+    logger.debug() << "Total number of randstrobes: " << total_randstrobes << '\n';
+    uint64_t memory_bytes = references.total_length() + sizeof(RefRandstrobe) * total_randstrobes + sizeof(bucket_index_t) * (1u << bits);
     logger.debug() << "Estimated total memory usage: " << memory_bytes / 1E9 << " GB\n";
 
-    if (randstrobe_hashes > std::numeric_limits<bucket_index_t>::max()) {
+    if (total_randstrobes > std::numeric_limits<bucket_index_t>::max()) {
         throw std::range_error("Too many randstrobes");
     }
     Timer randstrobes_timer;
-    randstrobes.reserve(randstrobe_hashes);
-    add_randstrobes_to_vector();
+    randstrobes.assign(total_randstrobes, RefRandstrobe{0, 0, 0});
+    assign_all_randstrobes(randstrobe_counts);
     stats.elapsed_generating_seeds = randstrobes_timer.duration();
 
     Timer sorting_timer;
@@ -231,39 +232,49 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.unique_strobemers = unique_mers;
 }
 
-void StrobemerIndex::add_randstrobes_to_vector() {
+void StrobemerIndex::assign_all_randstrobes(const std::vector<uint64_t>& randstrobe_counts) {
+    size_t offset = 0;
     for (size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
-        auto seq = references.sequences[ref_index];
-        if (seq.length() < parameters.randstrobe.w_max) {
-            continue;
-        }
-        RandstrobeGenerator randstrobe_iter{seq, parameters.syncmer, parameters.randstrobe};
-        std::vector<Randstrobe> chunk;
-        // TODO
-        // Chunking makes this function faster, but the speedup is achieved even
-        // with a chunk size of 1.
-        const size_t chunk_size = 4;
-        chunk.reserve(chunk_size);
-        bool end = false;
-        while (!end) {
-            // fill chunk
-            Randstrobe randstrobe;
-            while (chunk.size() < chunk_size) {
-                randstrobe = randstrobe_iter.next();
-                if (randstrobe == randstrobe_iter.end()) {
-                    end = true;
-                    break;
-                }
-                chunk.push_back(randstrobe);
+        assign_randstrobes(ref_index, offset);
+        offset += randstrobe_counts[ref_index];
+    }
+}
+
+/*
+ * Compute randstrobes of one reference and assign them to the randstrobes
+ * vector starting from the given offset
+ */
+void StrobemerIndex::assign_randstrobes(size_t ref_index, size_t offset) {
+    auto seq = references.sequences[ref_index];
+    if (seq.length() < parameters.randstrobe.w_max) {
+        return;
+    }
+    RandstrobeGenerator randstrobe_iter{seq, parameters.syncmer, parameters.randstrobe};
+    std::vector<Randstrobe> chunk;
+    // TODO
+    // Chunking makes this function faster, but the speedup is achieved even
+    // with a chunk size of 1.
+    const size_t chunk_size = 4;
+    chunk.reserve(chunk_size);
+    bool end = false;
+    while (!end) {
+        // fill chunk
+        Randstrobe randstrobe;
+        while (chunk.size() < chunk_size) {
+            randstrobe = randstrobe_iter.next();
+            if (randstrobe == randstrobe_iter.end()) {
+                end = true;
+                break;
             }
-            stats.tot_strobemer_count += chunk.size();
-            for (auto randstrobe : chunk) {
-                RefRandstrobe::packed_t packed = ref_index << 8;
-                packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
-                randstrobes.emplace_back(randstrobe.hash, randstrobe.strobe1_pos, packed);
-            }
-            chunk.clear();
+            chunk.push_back(randstrobe);
         }
+        stats.tot_strobemer_count += chunk.size();
+        for (auto randstrobe : chunk) {
+            RefRandstrobe::packed_t packed = ref_index << 8;
+            packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
+            randstrobes[offset++] = RefRandstrobe{randstrobe.hash, randstrobe.strobe1_pos, packed};
+        }
+        chunk.clear();
     }
 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -91,14 +91,18 @@ int StrobemerIndex::pick_bits(size_t size) const {
 }
 
 uint64_t count_randstrobes(const std::string& seq, const IndexParameters& parameters) {
-    uint64_t num = 0;
-
-    RandstrobeGenerator randstrobe_iter{seq, parameters.syncmer, parameters.randstrobe};
-    Randstrobe randstrobe;
-    while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
-        num++;
+    uint64_t n_syncmers = 0;
+    SyncmerIterator syncmer_iterator(seq, parameters.syncmer);
+    Syncmer syncmer;
+    while (!(syncmer = syncmer_iterator.next()).is_end()) {
+        n_syncmers++;
     }
-    return num;
+    // The last w_min syncmers do not result in a randstrobe
+    if (n_syncmers < parameters.randstrobe.w_min) {
+        return 0;
+    } else {
+        return n_syncmers - parameters.randstrobe.w_min;
+    }
 }
 
 std::vector<uint64_t> count_randstrobes_parallel(const References& references, const IndexParameters& parameters, size_t n_threads) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -145,24 +145,27 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
         total_randstrobes += count;
     }
 
-    logger.debug() << "Total number of randstrobes: " << total_randstrobes << '\n';
+    logger.debug() << "  Total number of randstrobes: " << total_randstrobes << '\n';
     uint64_t memory_bytes = references.total_length() + sizeof(RefRandstrobe) * total_randstrobes + sizeof(bucket_index_t) * (1u << bits);
-    logger.debug() << "Estimated total memory usage: " << memory_bytes / 1E9 << " GB\n";
+    logger.debug() << "  Estimated total memory usage: " << memory_bytes / 1E9 << " GB\n";
 
     if (total_randstrobes > std::numeric_limits<bucket_index_t>::max()) {
         throw std::range_error("Too many randstrobes");
     }
     Timer randstrobes_timer;
+    logger.debug() << "  Generating randstrobes ...\n";
     randstrobes.assign(total_randstrobes, RefRandstrobe{0, 0, 0});
     assign_all_randstrobes_parallel(randstrobe_counts, n_threads);
     stats.elapsed_generating_seeds = randstrobes_timer.duration();
 
     Timer sorting_timer;
+    logger.debug() << "  Sorting ...\n";
     // sort by hash values
     pdqsort_branchless(randstrobes.begin(), randstrobes.end());
     stats.elapsed_sorting_seeds = sorting_timer.duration();
 
     Timer hash_index_timer;
+    logger.debug() << "  Indexing ...\n";
 
     uint64_t tot_high_ab = 0;
     uint64_t tot_mid_ab = 0;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -152,7 +152,8 @@ struct StrobemerIndex {
     }
 
 private:
-    void add_randstrobes_to_vector();
+    void assign_all_randstrobes(const std::vector<uint64_t>& randstrobe_counts);
+    void assign_randstrobes(size_t ref_index, size_t offset);
 
     const IndexParameters& parameters;
     const References& references;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -153,6 +153,7 @@ struct StrobemerIndex {
 
 private:
     void assign_all_randstrobes(const std::vector<uint64_t>& randstrobe_counts);
+    void assign_all_randstrobes_parallel(const std::vector<uint64_t>& randstrobe_counts, size_t n_threads);
     void assign_randstrobes(size_t ref_index, size_t offset);
 
     const IndexParameters& parameters;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -102,6 +102,29 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
     CHECK(iter2.next() == iter2.end());
 }
 
+// This tests an assumption that we need to hold for count_randstrobes()
+TEST_CASE("syncmer and randstrobe iterators return (nearly) same no. of items") {
+    auto references = References::from_fasta("tests/phix.fasta");
+    auto& seq = references.sequences[0];
+    auto parameters = IndexParameters::from_read_length(100);
+
+    uint64_t randstrobe_count = 0;
+    auto randstrobe_iter = RandstrobeGenerator(seq, parameters.syncmer, parameters.randstrobe);
+    Randstrobe randstrobe;
+    while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
+        randstrobe_count++;
+    }
+
+    uint64_t syncmer_count = 0;
+    auto syncmer_iterator = SyncmerIterator(seq, parameters.syncmer);
+    Syncmer syncmer;
+    while (!(syncmer = syncmer_iterator.next()).is_end()) {
+        syncmer_count++;
+    }
+
+    CHECK(randstrobe_count + parameters.randstrobe.w_min == syncmer_count);
+}
+
 TEST_CASE("reverse complement") {
     CHECK(reverse_complement("") == "");
     CHECK(reverse_complement("A") == "T");


### PR DESCRIPTION
This was surprisingly easy to implement with the new memory layout. However, this may not be the way to go and I’m opening this PR mainly to document the experiment.

The approach here still requires two passes over the references: The first pass counts the randstrobes for each reference and then uses that to compute the total needed length of the randstrobes vector (as before) and also at which offset in the vector the randstrobes for a contig need to be stored. Then the vector is filled in parallel from multiple worker threads. They use the offset to write into the correct position in the vector.

This works, but the speedup is only ~2X because the other steps of index generation (mainly sorting) is not parallel. Also, we still need the first randstrobe counting pass, whereas we could maybe get a similar speedup by getting rid of it.

Here are some options for parallelization

1. We could keep this approach and also sort randstrobes for each contig in parallel; then do a $k$-way merge sort afterwards in order to get the final sorted randstrobes vector (needs a heap/`std::priority_queue`).
2. We speed up the counting by counting only syncmers, not randstrobes. In theory, the numbers should be identical and computing syncmers is faster, but there is a slight discrepancy which one would need to investigate. The no. of randstrobes is not higher than the number of syncmers, however, so it already works as an upper bound. One could reserve space using the number of syncmers and then move entries around in the vector so that there are no empty slots ("defragment").
3. We abandon the counting and use an estimate to reserve enough elements (this is #304). Then we let each thread compute randstrobes in chunks and add those chunks to the vector in whichever order they come in. Since the order of randstrobes then is no longer deterministic, we change sorting so that it no longer compares just the hashes, but all members of `RefRandstrobe` (as suggested by @luispedro).