### PR TITLE
Ensure syncmer and randstrobe iterators yield same no. of items

### DIFF
--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -185,7 +185,7 @@ Randstrobe RandstrobeIterator2::next() {
         }
         syncmers.push_back(syncmer);
     }
-    if (syncmers.size() <= w_min) {
+    if (syncmers.empty()) {
         return RandstrobeIterator2::end();
     }
     auto strobe1 = syncmers[0];

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -102,7 +102,7 @@ public:
     }
 
     bool has_next() {
-        return strobe1_start + w_min < string_hashes.size();
+        return strobe1_start < string_hashes.size();
     }
 
 private:

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=7985847aacd9e75b3ec3f8298c767dd2a4a47350
+baseline_commit=a7d097202fdd8d9d11eebc82e72eea2c1a13b123

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -101,6 +101,31 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
         CHECK(randstrobe2 != iter2.end());
         CHECK(randstrobe1 == randstrobe2);
     }
+    CHECK(iter2.next() == iter2.end());
+}
+
+TEST_CASE("syncmer and randstrobe iterators return same no. of items") {
+    auto references = References::from_fasta("tests/phix.fasta");
+    auto& seq = references.sequences[0];
+    auto parameters = IndexParameters::from_read_length(100);
+
+    uint64_t randstrobe_count = 0;
+    auto randstrobe_iter = RandstrobeIterator2(
+        seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist
+    );
+    Randstrobe randstrobe;
+    while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
+        randstrobe_count++;
+    }
+
+    uint64_t syncmer_count = 0;
+    auto syncmer_iterator = SyncmerIterator(seq, parameters.k, parameters.s, parameters.t_syncmer);
+    Syncmer syncmer;
+    while (!(syncmer = syncmer_iterator.next()).is_end()) {
+        syncmer_count++;
+    }
+
+    CHECK(randstrobe_count == syncmer_count);
 }
 
 TEST_CASE("reverse complement") {


### PR DESCRIPTION
See #307

I measured mapping runtime only on drosophila 50 and 100, where it increased by ~2%, which I understand because more strobemers are generated per read. ~~But it also increases accuracy, which is nice, but I don’t understand quite why.

The extra randstrobes are just the hash of one syncmer. I would expect that they are only found in the reference if the syncmer in the reference also does not have a partner. Is there some other reason why the accuracy increases or does this (that a syncmer in the reference does not have a partner) just happen often enough?~~

Edit: I measured mapping rate, not accuracy.

# Single-end ~~accuracy~~ mapping rate

dataset | before (e0764b6) | this PR (a7d0972)
-|-|-
drosophila-50 | 94.4233 | 94.453 (+0.0297)
drosophila-100 | 99.4656 | 99.4696 (+0.0040)
drosophila-200 | 99.7226 | 99.7225 (-0.0001)
drosophila-300 | 99.6863 | 99.6863 (+0.0000)
maize-50 | 95.3226 | 95.6045 (+0.2819)
maize-100 | 99.4867 | 99.5624 (+0.0757)
maize-200 | 99.7433 | 99.7444 (+0.0011)
maize-300 | 99.6957 | 99.6957 (+0.0000)
CHM13-50 | 94.2214 | 94.5568 (+0.3354)
CHM13-100 | 99.4495 | 99.4839 (+0.0344)
CHM13-200 | 99.732 | 99.7357 (+0.0037)
CHM13-300 | 99.693 | 99.6931 (+0.0001)
rye-50 | 94.4464 | 96.2626 (+1.8162)
rye-100 | 99.2582 | 99.6555 (+0.3973)

# Paired-end ~~accuracy~~ mapping rate

dataset | e0764b6 | a7d0972
-|-|-
drosophila-50 | 99.4863 | 99.48805 (+0.0018)
drosophila-100 | 99.80925 | 99.80935 (+0.0001)
drosophila-200 | 99.73955 | 99.73925 (-0.0003)
drosophila-300 | 99.6903 | 99.6903 (+0.0000)
maize-50 | 99.4366 | 99.4832 (+0.0466)
maize-100 | 99.8021 | 99.8055 (+0.0034)
maize-200 | 99.7529 | 99.7529 (+0.0000)
maize-300 | 99.6946 | 99.6946 (+0.0000)
CHM13-50 | 99.3389 | 99.3783 (+0.0394)
CHM13-100 | 99.80495 | 99.806 (+0.0011)
CHM13-200 | 99.74855 | 99.74865 (+0.0001)
CHM13-300 | 99.69325 | 99.69325 (+0.0000)
rye-50 | 99.2548 | 99.5159 (+0.2611)
rye-100 | 99.80015 | 99.8126 (+0.0125)
