### PR TITLE
Fix off-by-one error in statistics

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -168,8 +168,8 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.tot_occur_once = 0;
     randstrobe_start_indices.reserve((1u << bits) + 1);
 
-    uint64_t unique_mers = 0;
-    randstrobe_hash_t prev_hash = static_cast<randstrobe_hash_t>(-1);
+    uint64_t unique_mers = randstrobes.empty() ? 0 : 1;
+    randstrobe_hash_t prev_hash = randstrobes.empty() ? 0 : randstrobes[0].hash;
     unsigned int count = 0;
 
     for (bucket_index_t position = 0; position < randstrobes.size(); ++position) {


### PR DESCRIPTION
On the first loop iteration, count is 0, so we would end up in the ++tot_mid_ab case.

Before:
```
Index statistics
  Total strobemers:              1022
  Distinct strobemers:           1022 (100.00%)
    1 occurrence:                1022 (100.00%)
    2..100 occurrences:             1 (  0.10%)
    >100 occurrences:               0 (  0.00%)
```
After:
```
Index statistics
  Total strobemers:              1022
  Distinct strobemers:           1022 (100.00%)
    1 occurrence:                1022 (100.00%)
    2..100 occurrences:             0 (  0.00%)
    >100 occurrences:               0 (  0.00%)
```