### PR TITLE
Various refactorings

### DIFF
--- a/GitVersion.cmake
+++ b/GitVersion.cmake
@@ -5,7 +5,9 @@ execute_process(
   ERROR_QUIET
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+
 if (NOT GIT_ERROR)
+  string(SUBSTRING "${GIT_VERSION}" 1 -1 GIT_VERSION)  # Remove "v" prefix
   set(PROJECT_VERSION "${GIT_VERSION}")
 else()
   set(PROJECT_VERSION "${DEFAULT_VERSION}")

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1388,16 +1388,16 @@ void align_PE_read(
                               nam_read2);
         output_hits_paf_PE(outstring, nam_read1, record1.name,
                            references,
-                           index_parameters.k,
+                           index_parameters.syncmer.k,
                            record1.seq.length());
         output_hits_paf_PE(outstring, nam_read2, record2.name,
                            references,
-                           index_parameters.k,
+                           index_parameters.syncmer.k,
                            record2.seq.length());
     } else {
         align_PE(aligner, sam, nams1, nams2, record1,
                  record2,
-                 index_parameters.k,
+                 index_parameters.syncmer.k,
                  references, statistics,
                  map_param.dropoff_threshold, isize_est, map_param.maxTries, map_param.max_secondary);
     }
@@ -1440,11 +1440,11 @@ void align_SE_read(
 
     Timer extend_timer;
     if (!map_param.is_sam_out) {
-        output_hits_paf(outstring, nams, record.name, references, index_parameters.k,
+        output_hits_paf(outstring, nams, record.name, references, index_parameters.syncmer.k,
                         record.seq.length());
     } else {
         align_SE(
-            aligner, sam, nams, record, index_parameters.k,
+            aligner, sam, nams, record, index_parameters.syncmer.k,
             references, statistics, map_param.dropoff_threshold, map_param.maxTries,
             map_param.max_secondary
         );

--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -23,7 +23,7 @@ std::ostream& operator<<(std::ostream& os, const BedRecord& record) {
 }
 
 void dump_randstrobes(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
-    auto syncmers = make_string_to_hashvalues_open_syncmers_canonical(
+    auto syncmers = canonical_syncmers(
         sequence, parameters.k, parameters.s, parameters.t_syncmer);
 
     RandstrobeIterator randstrobe_iter{syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };

--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -34,7 +34,7 @@ void dump_randstrobes(std::ostream& os, const std::string& name, const std::stri
 }
 
 void dump_randstrobes2(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
-    auto randstrobe_iter = RandstrobeIterator2(
+    auto randstrobe_iter = RandstrobeGenerator(
         sequence, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
     Randstrobe randstrobe;
     while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {

--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -23,10 +23,9 @@ std::ostream& operator<<(std::ostream& os, const BedRecord& record) {
 }
 
 void dump_randstrobes(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
-    auto syncmers = canonical_syncmers(
-        sequence, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer);
+    auto syncmers = canonical_syncmers(sequence, parameters.syncmer);
 
-    RandstrobeIterator randstrobe_iter{syncmers, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist };
+    RandstrobeIterator randstrobe_iter{syncmers, parameters.randstrobe};
     while (randstrobe_iter.has_next()) {
         auto randstrobe = randstrobe_iter.next();
         os << BedRecord{name, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.syncmer.k};
@@ -34,8 +33,7 @@ void dump_randstrobes(std::ostream& os, const std::string& name, const std::stri
 }
 
 void dump_randstrobes2(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
-    auto randstrobe_iter = RandstrobeGenerator(
-        sequence, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist);
+    auto randstrobe_iter = RandstrobeGenerator(sequence, parameters.syncmer, parameters.randstrobe);
     Randstrobe randstrobe;
     while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
         os << BedRecord{name, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.syncmer.k};
@@ -43,7 +41,7 @@ void dump_randstrobes2(std::ostream& os, const std::string& name, const std::str
 }
 
 void dump_syncmers(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
-    SyncmerIterator syncmer_iterator(sequence, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer);
+    SyncmerIterator syncmer_iterator(sequence, parameters.syncmer);
     Syncmer syncmer;
     while (!(syncmer = syncmer_iterator.next()).is_end()) {
         os << BedRecord{name, syncmer.position, syncmer.position + parameters.syncmer.k};

--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -23,17 +23,10 @@ std::ostream& operator<<(std::ostream& os, const BedRecord& record) {
 }
 
 void dump_randstrobes(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
-    std::vector<uint64_t> string_hashes;
-    std::vector<unsigned int> pos_to_seq_coordinate;
-    std::tie(string_hashes, pos_to_seq_coordinate) = make_string_to_hashvalues_open_syncmers_canonical(
+    auto syncmers = make_string_to_hashvalues_open_syncmers_canonical(
         sequence, parameters.k, parameters.s, parameters.t_syncmer);
 
-    unsigned int nr_hashes = string_hashes.size();
-    if (nr_hashes == 0) {
-        return;
-    }
-
-    RandstrobeIterator randstrobe_iter { string_hashes, pos_to_seq_coordinate, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
+    RandstrobeIterator randstrobe_iter{syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
     while (randstrobe_iter.has_next()) {
         auto randstrobe = randstrobe_iter.next();
         os << BedRecord{name, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.k};

--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -24,29 +24,29 @@ std::ostream& operator<<(std::ostream& os, const BedRecord& record) {
 
 void dump_randstrobes(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
     auto syncmers = canonical_syncmers(
-        sequence, parameters.k, parameters.s, parameters.t_syncmer);
+        sequence, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer);
 
     RandstrobeIterator randstrobe_iter{syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
     while (randstrobe_iter.has_next()) {
         auto randstrobe = randstrobe_iter.next();
-        os << BedRecord{name, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.k};
+        os << BedRecord{name, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.syncmer.k};
     }
 }
 
 void dump_randstrobes2(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
     auto randstrobe_iter = RandstrobeGenerator(
-        sequence, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+        sequence, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
     Randstrobe randstrobe;
     while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
-        os << BedRecord{name, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.k};
+        os << BedRecord{name, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.syncmer.k};
     }
 }
 
 void dump_syncmers(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
-    SyncmerIterator syncmer_iterator(sequence, parameters.k, parameters.s, parameters.t_syncmer);
+    SyncmerIterator syncmer_iterator(sequence, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer);
     Syncmer syncmer;
     while (!(syncmer = syncmer_iterator.next()).is_end()) {
-        os << BedRecord{name, syncmer.position, syncmer.position + parameters.k};
+        os << BedRecord{name, syncmer.position, syncmer.position + parameters.syncmer.k};
     }
 }
 

--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -26,7 +26,7 @@ void dump_randstrobes(std::ostream& os, const std::string& name, const std::stri
     auto syncmers = canonical_syncmers(
         sequence, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer);
 
-    RandstrobeIterator randstrobe_iter{syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
+    RandstrobeIterator randstrobe_iter{syncmers, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist };
     while (randstrobe_iter.has_next()) {
         auto randstrobe = randstrobe_iter.next();
         os << BedRecord{name, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.syncmer.k};
@@ -35,7 +35,7 @@ void dump_randstrobes(std::ostream& os, const std::string& name, const std::stri
 
 void dump_randstrobes2(std::ostream& os, const std::string& name, const std::string& sequence, const IndexParameters& parameters) {
     auto randstrobe_iter = RandstrobeGenerator(
-        sequence, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+        sequence, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist);
     Randstrobe randstrobe;
     while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
         os << BedRecord{name, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.syncmer.k};

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -93,7 +93,7 @@ int StrobemerIndex::pick_bits(size_t size) const {
 uint64_t count_randstrobes(const std::string& seq, const IndexParameters& parameters) {
     uint64_t num = 0;
 
-    auto randstrobe_iter = RandstrobeIterator2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+    auto randstrobe_iter = RandstrobeGenerator(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
     Randstrobe randstrobe;
     while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
         num++;
@@ -237,7 +237,7 @@ void StrobemerIndex::add_randstrobes_to_vector() {
         if (seq.length() < parameters.w_max) {
             continue;
         }
-        auto randstrobe_iter = RandstrobeIterator2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+        auto randstrobe_iter = RandstrobeGenerator(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
         std::vector<Randstrobe> chunk;
         // TODO
         // Chunking makes this function faster, but the speedup is achieved even

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -93,7 +93,7 @@ int StrobemerIndex::pick_bits(size_t size) const {
 uint64_t count_randstrobes(const std::string& seq, const IndexParameters& parameters) {
     uint64_t num = 0;
 
-    auto randstrobe_iter = RandstrobeGenerator(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+    auto randstrobe_iter = RandstrobeGenerator(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist);
     Randstrobe randstrobe;
     while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
         num++;
@@ -234,10 +234,10 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
 void StrobemerIndex::add_randstrobes_to_vector() {
     for (size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
         auto seq = references.sequences[ref_index];
-        if (seq.length() < parameters.w_max) {
+        if (seq.length() < parameters.randstrobe.w_max) {
             continue;
         }
-        auto randstrobe_iter = RandstrobeGenerator(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+        auto randstrobe_iter = RandstrobeGenerator(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist);
         std::vector<Randstrobe> chunk;
         // TODO
         // Chunking makes this function faster, but the speedup is achieved even

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -93,7 +93,7 @@ int StrobemerIndex::pick_bits(size_t size) const {
 uint64_t count_randstrobes(const std::string& seq, const IndexParameters& parameters) {
     uint64_t num = 0;
 
-    auto randstrobe_iter = RandstrobeGenerator(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist);
+    RandstrobeGenerator randstrobe_iter{seq, parameters.syncmer, parameters.randstrobe};
     Randstrobe randstrobe;
     while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
         num++;
@@ -237,7 +237,7 @@ void StrobemerIndex::add_randstrobes_to_vector() {
         if (seq.length() < parameters.randstrobe.w_max) {
             continue;
         }
-        auto randstrobe_iter = RandstrobeGenerator(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist);
+        RandstrobeGenerator randstrobe_iter{seq, parameters.syncmer, parameters.randstrobe};
         std::vector<Randstrobe> chunk;
         // TODO
         // Chunking makes this function faster, but the speedup is achieved even

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -85,7 +85,7 @@ void StrobemerIndex::read(const std::string& filename) {
 
 /* Pick a suitable number of bits for indexing randstrobe start indices */
 int StrobemerIndex::pick_bits(size_t size) const {
-    size_t estimated_number_of_randstrobes = size / (parameters.k - parameters.s + 1);
+    size_t estimated_number_of_randstrobes = size / (parameters.syncmer.k - parameters.syncmer.s + 1);
     // Two randstrobes per bucket on average
     return std::clamp(static_cast<int>(log2(estimated_number_of_randstrobes)) - 1, 8, 31);
 }
@@ -93,7 +93,7 @@ int StrobemerIndex::pick_bits(size_t size) const {
 uint64_t count_randstrobes(const std::string& seq, const IndexParameters& parameters) {
     uint64_t num = 0;
 
-    auto randstrobe_iter = RandstrobeGenerator(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+    auto randstrobe_iter = RandstrobeGenerator(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
     Randstrobe randstrobe;
     while ((randstrobe = randstrobe_iter.next()) != randstrobe_iter.end()) {
         num++;
@@ -237,7 +237,7 @@ void StrobemerIndex::add_randstrobes_to_vector() {
         if (seq.length() < parameters.w_max) {
             continue;
         }
-        auto randstrobe_iter = RandstrobeGenerator(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+        auto randstrobe_iter = RandstrobeGenerator(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
         std::vector<Randstrobe> chunk;
         // TODO
         // Chunking makes this function faster, but the speedup is achieved even

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -144,7 +144,7 @@ struct StrobemerIndex {
     }
 
     int k() const {
-        return parameters.k;
+        return parameters.syncmer.k;
     }
 
     int get_bits() const {

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -12,6 +12,15 @@ bool SyncmerParameters::operator==(const SyncmerParameters& other) const {
         && this->t_syncmer == other.t_syncmer;
 }
 
+bool RandstrobeParameters::operator==(const RandstrobeParameters& other) const {
+    return this->l == other.l
+        && this->u == other.u
+        && this->q == other.q
+        && this->max_dist == other.max_dist
+        && this->w_min == other.w_min
+        && this->w_max == other.w_max;
+}
+
 /* Pre-defined index parameters that work well for a certain
  * "canonical" read length (and similar read lengths)  */
 struct Profile {
@@ -77,10 +86,10 @@ void IndexParameters::write(std::ostream& os) const {
     write_int_to_ostream(os, canonical_read_length);
     write_int_to_ostream(os, syncmer.k);
     write_int_to_ostream(os, syncmer.s);
-    write_int_to_ostream(os, l);
-    write_int_to_ostream(os, u);
-    write_int_to_ostream(os, q);
-    write_int_to_ostream(os, max_dist);
+    write_int_to_ostream(os, randstrobe.l);
+    write_int_to_ostream(os, randstrobe.u);
+    write_int_to_ostream(os, randstrobe.q);
+    write_int_to_ostream(os, randstrobe.max_dist);
 }
 
 IndexParameters IndexParameters::read(std::istream& is) {
@@ -95,15 +104,9 @@ IndexParameters IndexParameters::read(std::istream& is) {
 }
 
 bool IndexParameters::operator==(const IndexParameters& other) const {
-    return
-        this->canonical_read_length == other.canonical_read_length
+    return this->canonical_read_length == other.canonical_read_length
         && this->syncmer == other.syncmer
-        && this->l == other.l
-        && this->u == other.u
-        && this->q == other.q
-        && this->max_dist == other.max_dist
-        && this->w_min == other.w_min
-        && this->w_max == other.w_max;
+        && this->randstrobe == other.randstrobe;
 }
 
 /*
@@ -127,12 +130,12 @@ std::ostream& operator<<(std::ostream& os, const IndexParameters& parameters) {
         << ", k=" << parameters.syncmer.k
         << ", s=" << parameters.syncmer.s
         << ", t_syncmer=" << parameters.syncmer.t_syncmer
-        << ", l=" << parameters.l
-        << ", u=" << parameters.u
-        << ", q=" << parameters.q
-        << ", max_dist=" << parameters.max_dist
-        << ", w_min=" << parameters.w_min
-        << ", w_max=" << parameters.w_max
+        << ", l=" << parameters.randstrobe.l
+        << ", u=" << parameters.randstrobe.u
+        << ", q=" << parameters.randstrobe.q
+        << ", max_dist=" << parameters.randstrobe.max_dist
+        << ", w_min=" << parameters.randstrobe.w_min
+        << ", w_max=" << parameters.randstrobe.w_max
         << ")";
     return os;
 }

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -6,6 +6,12 @@
 #include "io.hpp"
 
 
+bool SyncmerParameters::operator==(const SyncmerParameters& other) const {
+    return this->s == other.s
+        && this->k == other.k
+        && this->t_syncmer == other.t_syncmer;
+}
+
 /* Pre-defined index parameters that work well for a certain
  * "canonical" read length (and similar read lengths)  */
 struct Profile {
@@ -69,8 +75,8 @@ IndexParameters IndexParameters::from_read_length(int read_length, int k, int s,
 
 void IndexParameters::write(std::ostream& os) const {
     write_int_to_ostream(os, canonical_read_length);
-    write_int_to_ostream(os, k);
-    write_int_to_ostream(os, s);
+    write_int_to_ostream(os, syncmer.k);
+    write_int_to_ostream(os, syncmer.s);
     write_int_to_ostream(os, l);
     write_int_to_ostream(os, u);
     write_int_to_ostream(os, q);
@@ -91,13 +97,11 @@ IndexParameters IndexParameters::read(std::istream& is) {
 bool IndexParameters::operator==(const IndexParameters& other) const {
     return
         this->canonical_read_length == other.canonical_read_length
-        && this->k == other.k
-        && this->s == other.s
+        && this->syncmer == other.syncmer
         && this->l == other.l
         && this->u == other.u
         && this->q == other.q
         && this->max_dist == other.max_dist
-        && this->t_syncmer == other.t_syncmer
         && this->w_min == other.w_min
         && this->w_max == other.w_max;
 }
@@ -120,13 +124,13 @@ std::string IndexParameters::filename_extension() const {
 std::ostream& operator<<(std::ostream& os, const IndexParameters& parameters) {
     os << "IndexParameters("
         << "r=" << parameters.canonical_read_length
-        << ", k=" << parameters.k
-        << ", s=" << parameters.s
+        << ", k=" << parameters.syncmer.k
+        << ", s=" << parameters.syncmer.s
+        << ", t_syncmer=" << parameters.syncmer.t_syncmer
         << ", l=" << parameters.l
         << ", u=" << parameters.u
         << ", q=" << parameters.q
         << ", max_dist=" << parameters.max_dist
-        << ", t_syncmer=" << parameters.t_syncmer
         << ", w_min=" << parameters.w_min
         << ", w_max=" << parameters.w_max
         << ")";

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -7,17 +7,44 @@
 #include <limits>
 #include "exceptions.hpp"
 
+
+struct SyncmerParameters {
+    const int k;
+    const int s;
+    const int t_syncmer;
+
+    SyncmerParameters(int k, int s)
+        : k(k)
+        , s(s)
+        , t_syncmer((k - s) / 2 + 1)
+    {
+        verify();
+    }
+
+    void verify() const {
+        if (k <= 7 || k > 32) {
+            throw BadParameter("k not in [8,32]");
+        }
+        if (s > k) {
+            throw BadParameter("s is larger than k");
+        }
+        if ((k - s) % 2 != 0) {
+            throw BadParameter("(k - s) must be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...");
+        }
+    }
+
+    bool operator==(const SyncmerParameters& other) const;
+};
+
 /* Settings that influence index creation */
 class IndexParameters {
 public:
     const size_t canonical_read_length;
-    const int k;
-    const int s;
+    const SyncmerParameters syncmer;
     const int l;
     const int u;
     const uint64_t q;
     const int max_dist;
-    const int t_syncmer;
     const unsigned w_min;
     const unsigned w_max;
 
@@ -25,13 +52,11 @@ public:
 
     IndexParameters(size_t canonical_read_length, int k, int s, int l, int u, int q, int max_dist)
         : canonical_read_length(canonical_read_length)
-        , k(k)
-        , s(s)
+        , syncmer(k, s)
         , l(l)
         , u(u)
         , q(q)
         , max_dist(max_dist)
-        , t_syncmer((k - s) / 2 + 1)
         , w_min(std::max(1, k / (k - s + 1) + l))
         , w_max(k / (k - s + 1) + u)
     {
@@ -49,15 +74,6 @@ public:
 
 private:
     void verify() const {
-        if (k <= 7 || k > 32) {
-            throw BadParameter("k not in [8,32]");
-        }
-        if (s > k) {
-            throw BadParameter("s is larger than k");
-        }
-        if ((k - s) % 2 != 0) {
-            throw BadParameter("(k - s) must be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...");
-        }
         if (max_dist > 255) {
             throw BadParameter("maximum seed length (-m <max_dist>) is larger than 255");
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,15 +58,15 @@ void warn_if_no_optimizations() {
 
 void log_parameters(const IndexParameters& index_parameters, const mapping_params& map_param, const alignment_params& aln_params) {
     logger.debug() << "Using" << std::endl
-        << "k: " << index_parameters.k << std::endl
-        << "s: " << index_parameters.s << std::endl
+        << "k: " << index_parameters.syncmer.k << std::endl
+        << "s: " << index_parameters.syncmer.s << std::endl
         << "w_min: " << index_parameters.w_min << std::endl
         << "w_max: " << index_parameters.w_max << std::endl
         << "Read length (r): " << map_param.r << std::endl
-        << "Maximum seed length: " << index_parameters.max_dist + index_parameters.k << std::endl
+        << "Maximum seed length: " << index_parameters.max_dist + index_parameters.syncmer.k << std::endl
         << "R: " << map_param.R << std::endl
         << "Expected [w_min, w_max] in #syncmers: [" << index_parameters.w_min << ", " << index_parameters.w_max << "]" << std::endl
-        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_min << ", " << (index_parameters.k - index_parameters.s + 1) * index_parameters.w_max << "]" << std::endl
+        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.w_min << ", " << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.w_max << "]" << std::endl
         << "A: " << aln_params.match << std::endl
         << "B: " << aln_params.mismatch << std::endl
         << "O: " << aln_params.gap_open << std::endl
@@ -240,7 +240,7 @@ int run_strobealign(int argc, char **argv) {
         logger.debug() << "Filtered cutoff count: " << index.stats.filter_cutoff << std::endl;
         
         if (!opt.logfile_name.empty()) {
-            index.print_diagnostics(opt.logfile_name, index_parameters.k);
+            index.print_diagnostics(opt.logfile_name, index_parameters.syncmer.k);
             logger.debug() << "Finished printing log stats" << std::endl;
         }
         if (opt.only_gen_index) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,13 +60,13 @@ void log_parameters(const IndexParameters& index_parameters, const mapping_param
     logger.debug() << "Using" << std::endl
         << "k: " << index_parameters.syncmer.k << std::endl
         << "s: " << index_parameters.syncmer.s << std::endl
-        << "w_min: " << index_parameters.w_min << std::endl
-        << "w_max: " << index_parameters.w_max << std::endl
+        << "w_min: " << index_parameters.randstrobe.w_min << std::endl
+        << "w_max: " << index_parameters.randstrobe.w_max << std::endl
         << "Read length (r): " << map_param.r << std::endl
-        << "Maximum seed length: " << index_parameters.max_dist + index_parameters.syncmer.k << std::endl
+        << "Maximum seed length: " << index_parameters.randstrobe.max_dist + index_parameters.syncmer.k << std::endl
         << "R: " << map_param.R << std::endl
-        << "Expected [w_min, w_max] in #syncmers: [" << index_parameters.w_min << ", " << index_parameters.w_max << "]" << std::endl
-        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.w_min << ", " << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.w_max << "]" << std::endl
+        << "Expected [w_min, w_max] in #syncmers: [" << index_parameters.randstrobe.w_min << ", " << index_parameters.randstrobe.w_max << "]" << std::endl
+        << "Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.randstrobe.w_min << ", " << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.randstrobe.w_max << "]" << std::endl
         << "A: " << aln_params.match << std::endl
         << "B: " << aln_params.mismatch << std::endl
         << "O: " << aln_params.gap_open << std::endl

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -90,13 +90,16 @@ NB_MODULE(strobealign_extension, m_) {
         .def_prop_ro("name", &Record::name)
         .def_prop_ro("sequence", &Record::sequence)
     ;
+    nb::class_<SyncmerParameters>(m, "SyncmerParameters")
+        .def_ro("k", &SyncmerParameters::k)
+        .def_ro("s", &SyncmerParameters::s)
+        .def_ro("t", &SyncmerParameters::t_syncmer)
+    ;
     nb::class_<IndexParameters>(m, "IndexParameters")
         .def_static("from_read_length", [](int r, int k = IndexParameters::DEFAULT, int s = IndexParameters::DEFAULT, int l = IndexParameters::DEFAULT, int u = IndexParameters::DEFAULT) {
             return IndexParameters::from_read_length(r, k, s, l, u);
         }, "r"_a, "k"_a = IndexParameters::DEFAULT, "s"_a = IndexParameters::DEFAULT, "l"_a = IndexParameters::DEFAULT, "u"_a = IndexParameters::DEFAULT)
-        .def_ro("k", &IndexParameters::k)
-        .def_ro("s", &IndexParameters::s)
-        .def_ro("t", &IndexParameters::t_syncmer)
+        .def_ro("syncmer", &IndexParameters::syncmer)
         .def_ro("max_dist", &IndexParameters::max_dist)
         .def_ro("w_min", &IndexParameters::w_min)
         .def_ro("w_max", &IndexParameters::w_max)

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -17,8 +17,8 @@ using namespace nb::literals;
 
 class SyncmerIteratorWrapper {
 public:
-    explicit SyncmerIteratorWrapper(const std::string& seq, size_t k, size_t s, size_t t)
-        : m_seq(seq), it(m_seq, k, s, t) { }
+    explicit SyncmerIteratorWrapper(const std::string& seq, SyncmerParameters parameters)
+        : m_seq(seq), it(m_seq, parameters) { }
 
     Syncmer next() {
         return it.next();
@@ -65,8 +65,19 @@ NB_MODULE(strobealign_extension, m_) {
         .def_static("get", &Logger::get, nb::rv_policy::reference)
         .def("set_level", &Logger::set_level)
     ;
+    nb::class_<SyncmerParameters>(m, "SyncmerParameters")
+        .def_ro("k", &SyncmerParameters::k)
+        .def_ro("s", &SyncmerParameters::s)
+        .def_ro("t", &SyncmerParameters::t_syncmer)
+    ;
+    nb::class_<RandstrobeParameters>(m, "RandstrobeParameters")
+        .def_ro("max_dist", &RandstrobeParameters::max_dist)
+        .def_ro("w_min", &RandstrobeParameters::w_min)
+        .def_ro("w_max", &RandstrobeParameters::w_max)
+        .def_ro("q", &RandstrobeParameters::q)
+    ;
     nb::class_<SyncmerIteratorWrapper>(m, "SyncmerIterator")
-        .def(nb::init<const std::string&, size_t, size_t, size_t>())
+        .def(nb::init<const std::string&, SyncmerParameters>())
         .def("__next__", [](SyncmerIteratorWrapper& siw) -> std::pair<size_t, randstrobe_hash_t> {
             auto syncmer = siw.next();
             if (syncmer.is_end()) {
@@ -89,17 +100,6 @@ NB_MODULE(strobealign_extension, m_) {
     nb::class_<Record>(m, "Record", "FASTA record")
         .def_prop_ro("name", &Record::name)
         .def_prop_ro("sequence", &Record::sequence)
-    ;
-    nb::class_<SyncmerParameters>(m, "SyncmerParameters")
-        .def_ro("k", &SyncmerParameters::k)
-        .def_ro("s", &SyncmerParameters::s)
-        .def_ro("t", &SyncmerParameters::t_syncmer)
-    ;
-    nb::class_<RandstrobeParameters>(m, "RandstrobeParameters")
-        .def_ro("max_dist", &RandstrobeParameters::max_dist)
-        .def_ro("w_min", &RandstrobeParameters::w_min)
-        .def_ro("w_max", &RandstrobeParameters::w_max)
-        .def_ro("q", &RandstrobeParameters::q)
     ;
     nb::class_<IndexParameters>(m, "IndexParameters")
         .def_static("from_read_length", [](int r, int k = IndexParameters::DEFAULT, int s = IndexParameters::DEFAULT, int l = IndexParameters::DEFAULT, int u = IndexParameters::DEFAULT) {

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -95,15 +95,18 @@ NB_MODULE(strobealign_extension, m_) {
         .def_ro("s", &SyncmerParameters::s)
         .def_ro("t", &SyncmerParameters::t_syncmer)
     ;
+    nb::class_<RandstrobeParameters>(m, "RandstrobeParameters")
+        .def_ro("max_dist", &RandstrobeParameters::max_dist)
+        .def_ro("w_min", &RandstrobeParameters::w_min)
+        .def_ro("w_max", &RandstrobeParameters::w_max)
+        .def_ro("q", &RandstrobeParameters::q)
+    ;
     nb::class_<IndexParameters>(m, "IndexParameters")
         .def_static("from_read_length", [](int r, int k = IndexParameters::DEFAULT, int s = IndexParameters::DEFAULT, int l = IndexParameters::DEFAULT, int u = IndexParameters::DEFAULT) {
             return IndexParameters::from_read_length(r, k, s, l, u);
         }, "r"_a, "k"_a = IndexParameters::DEFAULT, "s"_a = IndexParameters::DEFAULT, "l"_a = IndexParameters::DEFAULT, "u"_a = IndexParameters::DEFAULT)
         .def_ro("syncmer", &IndexParameters::syncmer)
-        .def_ro("max_dist", &IndexParameters::max_dist)
-        .def_ro("w_min", &IndexParameters::w_min)
-        .def_ro("w_max", &IndexParameters::w_max)
-        .def_ro("q", &IndexParameters::q)
+        .def_ro("randstrobe", &IndexParameters::randstrobe)
     ;
     nb::class_<RefRandstrobe>(m, "RefRandstrobeWithHash", "Randstrobe on a reference")
         .def_ro("position", &RefRandstrobe::position)

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -113,12 +113,10 @@ Syncmer SyncmerIterator::next() {
 
 std::vector<Syncmer> canonical_syncmers(
     const std::string_view seq,
-    const size_t k,
-    const size_t s,
-    const size_t t
+    SyncmerParameters parameters
 ) {
     std::vector<Syncmer> syncmers;
-    SyncmerIterator syncmer_iterator{seq, k, s, t};
+    SyncmerIterator syncmer_iterator{seq, parameters};
     Syncmer syncmer;
     while (!(syncmer = syncmer_iterator.next()).is_end()) {
         syncmers.push_back(syncmer);
@@ -216,17 +214,13 @@ QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexP
     }
 
     // Generate syncmers for the forward sequence
-    auto syncmers = canonical_syncmers(
-        seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer
-    );
+    auto syncmers = canonical_syncmers(seq, parameters.syncmer);
     if (syncmers.empty()) {
         return randstrobes;
     }
 
     // Generate randstrobes for the forward sequence
-    RandstrobeIterator randstrobe_fwd_iter{
-        syncmers, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist
-    };
+    RandstrobeIterator randstrobe_fwd_iter{syncmers, parameters.randstrobe};
     while (randstrobe_fwd_iter.has_next()) {
         auto randstrobe = randstrobe_fwd_iter.next();
         randstrobes.push_back(
@@ -249,9 +243,7 @@ QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexP
     // is not necessarily the case that syncmer[j] is going to be paired with
     // syncmer[i] in the reverse direction because i is fixed in the forward
     // direction and j is fixed in the reverse direction.
-    RandstrobeIterator randstrobe_rc_iter{
-        syncmers, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist
-    };
+    RandstrobeIterator randstrobe_rc_iter{syncmers, parameters.randstrobe};
     while (randstrobe_rc_iter.has_next()) {
         auto randstrobe = randstrobe_rc_iter.next();
         randstrobes.push_back(

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -217,7 +217,7 @@ QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexP
 
     // Generate syncmers for the forward sequence
     auto syncmers = canonical_syncmers(
-        seq, parameters.k, parameters.s, parameters.t_syncmer
+        seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer
     );
     if (syncmers.empty()) {
         return randstrobes;
@@ -231,7 +231,7 @@ QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexP
         auto randstrobe = randstrobe_fwd_iter.next();
         randstrobes.push_back(
             QueryRandstrobe{
-                randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.k, false
+                randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.syncmer.k, false
             }
         );
     }
@@ -241,7 +241,7 @@ QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexP
     // complementing. Only the coordinates need to be adjusted.
     std::reverse(syncmers.begin(), syncmers.end());
     for (size_t i = 0; i < syncmers.size(); i++) {
-        syncmers[i].position = seq.length() - syncmers[i].position - parameters.k;
+        syncmers[i].position = seq.length() - syncmers[i].position - parameters.syncmer.k;
     }
 
     // Randstrobes cannot be re-used for the reverse complement:
@@ -256,7 +256,7 @@ QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexP
         auto randstrobe = randstrobe_rc_iter.next();
         randstrobes.push_back(
             QueryRandstrobe{
-                randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.k, true
+                randstrobe.hash, randstrobe.strobe1_pos, randstrobe.strobe2_pos + parameters.syncmer.k, true
             }
         );
     }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -211,7 +211,7 @@ Randstrobe RandstrobeGenerator::next() {
  */
 QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexParameters& parameters) {
     QueryRandstrobeVector randstrobes;
-    if (seq.length() < parameters.w_max) {
+    if (seq.length() < parameters.randstrobe.w_max) {
         return randstrobes;
     }
 
@@ -225,7 +225,7 @@ QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexP
 
     // Generate randstrobes for the forward sequence
     RandstrobeIterator randstrobe_fwd_iter{
-        syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist
+        syncmers, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist
     };
     while (randstrobe_fwd_iter.has_next()) {
         auto randstrobe = randstrobe_fwd_iter.next();
@@ -250,7 +250,7 @@ QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexP
     // syncmer[i] in the reverse direction because i is fixed in the forward
     // direction and j is fixed in the reverse direction.
     RandstrobeIterator randstrobe_rc_iter{
-        syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist
+        syncmers, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist
     };
     while (randstrobe_rc_iter.has_next()) {
         auto randstrobe = randstrobe_rc_iter.next();

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -175,7 +175,7 @@ Randstrobe RandstrobeIterator::get(unsigned int strobe1_index) const {
     return Randstrobe{hash_randstrobe2, strobe1_pos, static_cast<uint32_t>(syncmers[strobe_index_next].position)};
 }
 
-Randstrobe RandstrobeIterator2::next() {
+Randstrobe RandstrobeGenerator::next() {
     while (syncmers.size() <= w_max) {
         Syncmer syncmer = syncmer_iterator.next();
         if (syncmer.is_end()) {
@@ -184,7 +184,7 @@ Randstrobe RandstrobeIterator2::next() {
         syncmers.push_back(syncmer);
     }
     if (syncmers.size() <= w_min) {
-        return RandstrobeIterator2::end();
+        return RandstrobeGenerator::end();
     }
     auto strobe1 = syncmers[0];
     auto max_position = strobe1.position + max_dist;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -111,7 +111,7 @@ Syncmer SyncmerIterator::next() {
     return Syncmer{0, 0}; // end marker
 }
 
-std::vector<Syncmer> make_string_to_hashvalues_open_syncmers_canonical(
+std::vector<Syncmer> canonical_syncmers(
     const std::string_view seq,
     const size_t k,
     const size_t s,
@@ -216,7 +216,7 @@ QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexP
     }
 
     // Generate syncmers for the forward sequence
-    auto syncmers = make_string_to_hashvalues_open_syncmers_canonical(
+    auto syncmers = canonical_syncmers(
         seq, parameters.k, parameters.s, parameters.t_syncmer
     );
     if (syncmers.empty()) {

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -91,15 +91,12 @@ class RandstrobeIterator {
 public:
     RandstrobeIterator(
         const std::vector<Syncmer>& syncmers,
-        unsigned w_min,
-        unsigned w_max,
-        uint64_t q,
-        int max_dist
+        RandstrobeParameters parameters
     ) : syncmers(syncmers)
-      , w_min(w_min)
-      , w_max(w_max)
-      , q(q)
-      , max_dist(max_dist)
+      , w_min(parameters.w_min)
+      , w_max(parameters.w_max)
+      , q(parameters.q)
+      , max_dist(parameters.max_dist)
     {
         if (w_min > w_max) {
             throw std::invalid_argument("w_min is greater than w_max");
@@ -128,8 +125,8 @@ std::ostream& operator<<(std::ostream& os, const Syncmer& syncmer);
 
 class SyncmerIterator {
 public:
-    SyncmerIterator(const std::string_view seq, size_t k, size_t s, size_t t)
-        : seq(seq), k(k), s(s), t(t) { }
+    SyncmerIterator(const std::string_view seq, SyncmerParameters parameters)
+        : seq(seq), k(parameters.k), s(parameters.s), t(parameters.t_syncmer) { }
 
     Syncmer next();
 
@@ -161,16 +158,14 @@ private:
 class RandstrobeGenerator {
 public:
     RandstrobeGenerator(
-        const std::string& seq, size_t k, size_t s, size_t t,
-        unsigned w_min,
-        unsigned w_max,
-        uint64_t q,
-        int max_dist
-    ) : syncmer_iterator(SyncmerIterator(seq, k, s, t))
-      , w_min(w_min)
-      , w_max(w_max)
-      , q(q)
-      , max_dist(max_dist)
+        const std::string& seq,
+        SyncmerParameters syncmer_parameters,
+        RandstrobeParameters randstrobe_parameters
+    ) : syncmer_iterator(SyncmerIterator(seq, syncmer_parameters))
+      , w_min(randstrobe_parameters.w_min)
+      , w_max(randstrobe_parameters.w_max)
+      , q(randstrobe_parameters.q)
+      , max_dist(randstrobe_parameters.max_dist)
     { }
 
     Randstrobe next();
@@ -186,11 +181,6 @@ private:
 };
 
 
-std::vector<Syncmer> canonical_syncmers(
-    const std::string_view seq,
-    const size_t k,
-    const size_t s,
-    const size_t t
-);
+std::vector<Syncmer> canonical_syncmers(const std::string_view seq, SyncmerParameters parameters);
 
 #endif

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -76,17 +76,26 @@ struct Randstrobe {
 
 std::ostream& operator<<(std::ostream& os, const Randstrobe& randstrobe);
 
+struct Syncmer {
+    syncmer_hash_t hash;
+    size_t position;
+    bool is_end() const {
+        return hash == 0 && position == 0;
+    }
+};
+
+/*
+ * Iterate over randstrobes using a pre-computed vector of syncmers
+ */
 class RandstrobeIterator {
 public:
     RandstrobeIterator(
-        const std::vector<uint64_t>& syncmer_hashes,
-        const std::vector<unsigned int>& index_to_coordinate,
+        const std::vector<Syncmer>& syncmers,
         unsigned w_min,
         unsigned w_max,
         uint64_t q,
         int max_dist
-    ) : syncmer_hashes(syncmer_hashes)
-      , index_to_coordinate(index_to_coordinate)
+    ) : syncmers(syncmers)
       , w_min(w_min)
       , w_max(w_max)
       , q(q)
@@ -102,26 +111,17 @@ public:
     }
 
     bool has_next() {
-        return strobe1_index + w_min < syncmer_hashes.size();
+        return strobe1_index + w_min < syncmers.size();
     }
 
 private:
     Randstrobe get(unsigned int strobe1_index) const;
-    const std::vector<uint64_t>& syncmer_hashes;
-    const std::vector<unsigned int>& index_to_coordinate;
+    const std::vector<Syncmer>& syncmers;
     const unsigned w_min;
     const unsigned w_max;
     const uint64_t q;
     const unsigned int max_dist;
     unsigned int strobe1_index = 0;
-};
-
-struct Syncmer {
-    syncmer_hash_t hash;
-    size_t position;
-    bool is_end() const {
-        return hash == 0 && position == 0;
-    }
 };
 
 std::ostream& operator<<(std::ostream& os, const Syncmer& syncmer);
@@ -180,7 +180,7 @@ private:
 };
 
 
-std::pair<std::vector<syncmer_hash_t>, std::vector<unsigned int>> make_string_to_hashvalues_open_syncmers_canonical(
+std::vector<Syncmer> make_string_to_hashvalues_open_syncmers_canonical(
     const std::string_view seq,
     const size_t k,
     const size_t s,

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -180,7 +180,7 @@ private:
 };
 
 
-std::vector<Syncmer> make_string_to_hashvalues_open_syncmers_canonical(
+std::vector<Syncmer> canonical_syncmers(
     const std::string_view seq,
     const size_t k,
     const size_t s,

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -79,14 +79,14 @@ std::ostream& operator<<(std::ostream& os, const Randstrobe& randstrobe);
 class RandstrobeIterator {
 public:
     RandstrobeIterator(
-        const std::vector<uint64_t> &string_hashes,
-        const std::vector<unsigned int> &pos_to_seq_coordinate,
+        const std::vector<uint64_t>& syncmer_hashes,
+        const std::vector<unsigned int>& index_to_coordinate,
         unsigned w_min,
         unsigned w_max,
         uint64_t q,
         int max_dist
-    ) : string_hashes(string_hashes)
-      , pos_to_seq_coordinate(pos_to_seq_coordinate)
+    ) : syncmer_hashes(syncmer_hashes)
+      , index_to_coordinate(index_to_coordinate)
       , w_min(w_min)
       , w_max(w_max)
       , q(q)
@@ -98,22 +98,22 @@ public:
     }
 
     Randstrobe next() {
-        return get(strobe1_start++);
+        return get(strobe1_index++);
     }
 
     bool has_next() {
-        return strobe1_start + w_min < string_hashes.size();
+        return strobe1_index + w_min < syncmer_hashes.size();
     }
 
 private:
-    Randstrobe get(unsigned int strobe1_start) const;
-    const std::vector<uint64_t> &string_hashes;
-    const std::vector<unsigned int> &pos_to_seq_coordinate;
+    Randstrobe get(unsigned int strobe1_index) const;
+    const std::vector<uint64_t>& syncmer_hashes;
+    const std::vector<unsigned int>& index_to_coordinate;
     const unsigned w_min;
     const unsigned w_max;
     const uint64_t q;
     const unsigned int max_dist;
-    unsigned int strobe1_start = 0;
+    unsigned int strobe1_index = 0;
 };
 
 struct Syncmer {

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -152,9 +152,15 @@ private:
     size_t i = 0;
 };
 
-class RandstrobeIterator2 {
+/*
+ * Iterate over randstrobes while generating syncmers on the fly
+ *
+ * Unlike RandstrobeIterator, this does not need a pre-computed vector
+ * of syncmers and therefore uses less memory.
+ */
+class RandstrobeGenerator {
 public:
-    RandstrobeIterator2(
+    RandstrobeGenerator(
         const std::string& seq, size_t k, size_t s, size_t t,
         unsigned w_min,
         unsigned w_max,

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -100,7 +100,7 @@ void Sam::add_unmapped_pair(const KSeq& r1, const KSeq& r2) {
 
 // Add single-end alignment
 void Sam::add(
-    const alignment& sam_aln,
+    const Alignment& sam_aln,
     const KSeq& record,
     const std::string& sequence_rc,
     bool is_secondary
@@ -184,8 +184,8 @@ void Sam::add_record(
 }
 
 void Sam::add_pair(
-    const alignment &sam_aln1,
-    const alignment &sam_aln2,
+    const Alignment &sam_aln1,
+    const Alignment &sam_aln2,
     const KSeq& record1,
     const KSeq& record2,
     const std::string &read1_rc,
@@ -282,7 +282,7 @@ void Sam::add_pair(
     }
 }
 
-bool is_proper_pair(const alignment& sam_aln1, const alignment& sam_aln2, float mu, float sigma) {
+bool is_proper_pair(const Alignment& sam_aln1, const Alignment& sam_aln2, float mu, float sigma) {
     const int dist = sam_aln2.ref_start - sam_aln1.ref_start;
     const bool same_reference = sam_aln1.ref_id == sam_aln2.ref_id;
     const bool both_aligned = same_reference && !sam_aln1.is_unaligned && !sam_aln2.is_unaligned;

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -7,7 +7,7 @@
 #include "cigar.hpp"
 
 
-struct alignment {
+struct Alignment {
     Cigar cigar;
     int ref_start;
     int ed;
@@ -63,8 +63,8 @@ public:
         }
 
     /* Add an alignment */
-    void add(const alignment& sam_aln, const klibpp::KSeq& record, const std::string& sequence_rc, bool is_secondary = false);
-    void add_pair(const alignment& sam_aln1, const alignment& sam_aln2, const klibpp::KSeq& record1, const klibpp::KSeq& record2, const std::string& read1_rc, const std::string& read2_rc, int mapq1, int mapq2, bool is_proper, bool is_primary);
+    void add(const Alignment& sam_aln, const klibpp::KSeq& record, const std::string& sequence_rc, bool is_secondary = false);
+    void add_pair(const Alignment& sam_aln1, const Alignment& sam_aln2, const klibpp::KSeq& record1, const klibpp::KSeq& record2, const std::string& read1_rc, const std::string& read2_rc, int mapq1, int mapq2, bool is_proper, bool is_primary);
     void add_unmapped(const klibpp::KSeq& record, int flags = UNMAP);
     void add_unmapped_pair(const klibpp::KSeq& r1, const klibpp::KSeq& r2);
     void add_unmapped_mate(const klibpp::KSeq& record, int flags, const std::string& mate_reference_name, int mate_pos);
@@ -85,6 +85,6 @@ private:
     bool output_unmapped;
 };
 
-bool is_proper_pair(const alignment& sam_aln1, const alignment& sam_aln2, float mu, float sigma);
+bool is_proper_pair(const Alignment& sam_aln1, const Alignment& sam_aln2, float mu, float sigma);
 
 #endif

--- a/src/unused.cpp
+++ b/src/unused.cpp
@@ -986,8 +986,8 @@ static inline void get_joint_MAPQ(float s1, float s2, int joint_n_matches, int &
 // from aln.cpp
 
 
-static inline bool sort_lowest_ed_scores_single(const std::tuple<int, alignment> &a,
-                                                const std::tuple<int, alignment> &b)
+static inline bool sort_lowest_ed_scores_single(const std::tuple<int, Alignment> &a,
+                                                const std::tuple<int, Alignment> &b)
 {
     return (std::get<0>(a) < std::get<0>(b));
 }

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -21,6 +21,8 @@ def test_index_parameters():
     assert isinstance(params.syncmer.k, int)
     assert isinstance(params.syncmer.s, int)
     assert isinstance(params.syncmer.t, int)
+    assert isinstance(params.randstrobe.w_min, int)
+    assert isinstance(params.randstrobe.w_max, int)
 
 
 def test_indexing_and_nams_finding():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -18,9 +18,9 @@ def test_references():
 
 def test_index_parameters():
     params = strobealign.IndexParameters.from_read_length(100)
-    assert isinstance(params.k, int)
-    assert isinstance(params.s, int)
-    assert isinstance(params.t, int)
+    assert isinstance(params.syncmer.k, int)
+    assert isinstance(params.syncmer.s, int)
+    assert isinstance(params.syncmer.t, int)
 
 
 def test_indexing_and_nams_finding():

--- a/tests/test_sam.cpp
+++ b/tests/test_sam.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Sam::add") {
     record.seq = "AACGT";
     record.qual = ">#BB";
 
-    alignment aln;
+    Alignment aln;
     aln.ref_id = 0;
     aln.is_unaligned = false;
     aln.is_rc = true;
@@ -81,7 +81,7 @@ TEST_CASE("Pair with one unmapped SAM record") {
     std::string sam_string;
     Sam sam(sam_string, references);
 
-    alignment aln1;
+    Alignment aln1;
     aln1.ref_id = 0;
     aln1.is_unaligned = false;
     aln1.ref_start = 2;
@@ -90,7 +90,7 @@ TEST_CASE("Pair with one unmapped SAM record") {
     aln1.aln_score = 9;
     aln1.cigar = Cigar("2M");
 
-    alignment aln2;
+    Alignment aln2;
     aln2.is_unaligned = true;
 
     klibpp::KSeq record1;
@@ -135,7 +135,7 @@ TEST_CASE("TLEN zero when reads map to different contigs") {
     references.add("contig2", "GGAA");
     std::string sam_string;
 
-    alignment aln1;
+    Alignment aln1;
     aln1.ref_id = 0;
     aln1.is_unaligned = false;
     aln1.ref_start = 2;
@@ -144,7 +144,7 @@ TEST_CASE("TLEN zero when reads map to different contigs") {
     aln1.aln_score = 9;
     aln1.cigar = Cigar("2M");
 
-    alignment aln2;
+    Alignment aln2;
     aln2.is_unaligned = false;
     aln2.ref_id = 1;
     aln2.ref_start = 3;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -89,9 +89,9 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
     auto& seq = references.sequences[0];
     auto parameters = IndexParameters::from_read_length(300);
 
-    auto syncmers = canonical_syncmers(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer);
-    RandstrobeIterator iter1{syncmers, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist };
-    RandstrobeGenerator iter2(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist);
+    auto syncmers = canonical_syncmers(seq, parameters.syncmer);
+    RandstrobeIterator iter1{syncmers, parameters.randstrobe};
+    RandstrobeGenerator iter2{seq, parameters.syncmer, parameters.randstrobe};
 
     while (iter1.has_next()) {
         auto randstrobe1 = iter1.next();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -90,8 +90,8 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
     auto parameters = IndexParameters::from_read_length(300);
 
     auto syncmers = canonical_syncmers(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer);
-    RandstrobeIterator iter1{syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
-    RandstrobeGenerator iter2(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+    RandstrobeIterator iter1{syncmers, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist };
+    RandstrobeGenerator iter2(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.randstrobe.w_min, parameters.randstrobe.w_max, parameters.randstrobe.q, parameters.randstrobe.max_dist);
 
     while (iter1.has_next()) {
         auto randstrobe1 = iter1.next();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -89,7 +89,7 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
     auto& seq = references.sequences[0];
     auto parameters = IndexParameters::from_read_length(300);
 
-    auto syncmers = make_string_to_hashvalues_open_syncmers_canonical(seq, parameters.k, parameters.s, parameters.t_syncmer);
+    auto syncmers = canonical_syncmers(seq, parameters.k, parameters.s, parameters.t_syncmer);
     RandstrobeIterator iter1{syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
     RandstrobeIterator2 iter2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -89,10 +89,8 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
     auto& seq = references.sequences[0];
     auto parameters = IndexParameters::from_read_length(300);
 
-    std::vector<uint64_t> string_hashes;
-    std::vector<unsigned int> pos_to_seq_coordinate;
-    std::tie(string_hashes, pos_to_seq_coordinate) = make_string_to_hashvalues_open_syncmers_canonical(seq, parameters.k, parameters.s, parameters.t_syncmer);
-    RandstrobeIterator iter1{string_hashes, pos_to_seq_coordinate, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
+    auto syncmers = make_string_to_hashvalues_open_syncmers_canonical(seq, parameters.k, parameters.s, parameters.t_syncmer);
+    RandstrobeIterator iter1{syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
     RandstrobeIterator2 iter2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
 
     while (iter1.has_next()) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -91,7 +91,7 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
 
     auto syncmers = canonical_syncmers(seq, parameters.k, parameters.s, parameters.t_syncmer);
     RandstrobeIterator iter1{syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
-    RandstrobeIterator2 iter2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+    RandstrobeGenerator iter2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
 
     while (iter1.has_next()) {
         auto randstrobe1 = iter1.next();
@@ -99,6 +99,7 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
         CHECK(randstrobe2 != iter2.end());
         CHECK(randstrobe1 == randstrobe2);
     }
+    CHECK(iter2.next() == iter2.end());
 }
 
 TEST_CASE("reverse complement") {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -89,9 +89,9 @@ TEST_CASE("both randstrobes iterator implementations give same results") {
     auto& seq = references.sequences[0];
     auto parameters = IndexParameters::from_read_length(300);
 
-    auto syncmers = canonical_syncmers(seq, parameters.k, parameters.s, parameters.t_syncmer);
+    auto syncmers = canonical_syncmers(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer);
     RandstrobeIterator iter1{syncmers, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist };
-    RandstrobeGenerator iter2(seq, parameters.k, parameters.s, parameters.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
+    RandstrobeGenerator iter2(seq, parameters.syncmer.k, parameters.syncmer.s, parameters.syncmer.t_syncmer, parameters.w_min, parameters.w_max, parameters.q, parameters.max_dist);
 
     while (iter1.has_next()) {
         auto randstrobe1 = iter1.next();


### PR DESCRIPTION
- Use a `std::vector<Syncmer>` instead of one vector for hashes and one for positions
- Rename `RandstrobeIterator2` to `RandstrobeGenerator` and add comments to explain what the difference is (to make it  clear that we need both at the moment)
- Tiny bugfix: Remove the `v` prefix from the version in the SAM PG header (only relevant when the version number is derived from a Git tag)
- Rename `alignment` struct to `Alignment`
- Move indexing parameters into separate `SyncmerParameters` and `RandstrobeParameters` structs
