### PR TITLE
Do not count randstrobes, but estimate their number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
 * #277, #285, PR #306: Support for very large references (exceeding ~20 Gbp) was
   added by switching from 32 bit to 64 bit strobemer indices.
   This was also enabled and made simpler by the memory layout changes.
+* #314: Generating the index became faster (by typically 10-15%) by avoiding an
+  extra iteration over the reference. Even this was enabled by the new memory
+  layout.
 * #289: Fixed missing CIGAR for secondary alignments.
 * #212: SEQ and QUAL are set to `*` for secondary alignments as recommended
   by the SAM specification.

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -148,8 +148,8 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     auto randstrobe_hashes = estimate_randstrobes(references.total_length(), parameters.syncmer);
 
     uint64_t memory_bytes = references.total_length() + sizeof(RefRandstrobe) * randstrobe_hashes + sizeof(bucket_index_t) * (1u << bits);
-    logger.debug() << "Estimated number of randstrobes: " << randstrobe_hashes << '\n';
-    logger.debug() << "Estimated total memory usage: " << memory_bytes / 1E9 << " GB\n";
+    logger.debug() << "  Estimated number of randstrobes: " << randstrobe_hashes << '\n';
+    logger.debug() << "  Estimated total memory usage: " << memory_bytes / 1E9 << " GB\n";
 
     if (randstrobe_hashes > std::numeric_limits<bucket_index_t>::max()) {
         throw std::range_error("Too many randstrobes");
@@ -159,6 +159,15 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     add_randstrobes_to_vector();
     stats.elapsed_generating_seeds = randstrobes_timer.duration();
 
+    logger.debug() << "  Actual number of randstrobes: " << randstrobes.size()
+        << " (" << 100.0 * randstrobes.size() / randstrobe_hashes << "% of estimate)\n";
+
+    if (randstrobes.size() > randstrobe_hashes) {
+        logger.warning()
+            << "WARNING: More strobemers found than expected (factor "
+            << 1.0 * randstrobes.size() / randstrobe_hashes
+            << "). Please report this to the developers\n";
+    }
     Timer sorting_timer;
     // sort by hash values
     pdqsort_branchless(randstrobes.begin(), randstrobes.end());

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -30,7 +30,6 @@ struct IndexCreationStatistics {
 
     std::chrono::duration<double> elapsed_hash_index;
     std::chrono::duration<double> elapsed_generating_seeds;
-    std::chrono::duration<double> elapsed_counting_hashes;
     std::chrono::duration<double> elapsed_sorting_seeds;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,7 +213,6 @@ int run_strobealign(int argc, char **argv) {
         Timer index_timer;
         index.populate(opt.f, opt.n_threads);
         
-        logger.info() << "  Time counting seeds: " << index.stats.elapsed_counting_hashes.count() << " s" <<  std::endl;
         logger.info() << "  Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;
         logger.info() << "  Time sorting seeds: " << index.stats.elapsed_sorting_seeds.count() << " s" <<  std::endl;
         logger.info() << "  Time generating hash table index: " << index.stats.elapsed_hash_index.count() << " s" <<  std::endl;


### PR DESCRIPTION
As discussed in #304.

- [x] Handle the case that the estimate is too low (for example, by counting to the end without appending to the vector, then starting over with the correct size; also print a warning)
- [x] Measure index generation speedup
- [x] Measure increase in memory usage and discuss whether this is acceptable