### PR TITLE
Fix incorrect baseline commit hash

### DIFF
--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=44c032d19c6ab0bae7e274dbb7b8181b9745dbac
+baseline_commit=6c67bfca9e4898064ac7ad907b31bcfee2abb85a


### PR DESCRIPTION
It refers to a nonexisting commit (probably arose because of rebasing)