### PR TITLE
Add --count option to dumpstrobes command

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -260,7 +260,7 @@ void StrobemerIndex::add_randstrobes_to_vector() {
             for (auto randstrobe : chunk) {
                 RefRandstrobe::packed_t packed = ref_index << 8;
                 packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);
-                randstrobes.push_back(RefRandstrobe{randstrobe.hash, randstrobe.strobe1_pos, packed});
+                randstrobes.emplace_back(randstrobe.hash, randstrobe.strobe1_pos, packed);
             }
             chunk.clear();
         }


### PR DESCRIPTION
I found this useful for experiments: This adds a `--count` option to `dumpstrobes`, which will make it count all randstrobes (or syncmers if `--syncmers` is also provided).

This can also be used for benchmarking the `RandstrobeGenerator` and `SyncmerIterator` (only the overhead from reading the reference has to be subtracted from the measured runtime).