### PR TITLE
If R1 and R2 map to same position, treat them as proper pair

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -601,10 +601,10 @@ bool is_proper_nam_pair(const Nam nam1, const Nam nam2, float mu, float sigma) {
     int b = std::max(0, nam2.ref_s - nam2.query_s);
 
     // r1 ---> <---- r2
-    bool r1_r2 = nam2.is_rc && (a < b) && (b - a < mu + 10*sigma);
+    bool r1_r2 = nam2.is_rc && (a <= b) && (b - a < mu + 10*sigma);
 
      // r2 ---> <---- r1
-    bool r2_r1 = nam1.is_rc && (b < a) && (a - b < mu + 10*sigma);
+    bool r2_r1 = nam1.is_rc && (b <= a) && (a - b < mu + 10*sigma);
 
     return r1_r2 || r2_r1;
 }
@@ -1161,8 +1161,8 @@ inline void align_PE(
 //                    cnt = 0;
         }
 
-        bool r1_r2 = a2.is_rc && (a1.ref_start < a2.ref_start) && ((a2.ref_start - a1.ref_start) < mu+5*sigma); // r1 ---> <---- r2
-        bool r2_r1 = a1.is_rc && (a2.ref_start < a1.ref_start) && ((a1.ref_start - a2.ref_start) < mu+5*sigma); // r2 ---> <---- r1
+        bool r1_r2 = a2.is_rc && (a1.ref_start <= a2.ref_start) && ((a2.ref_start - a1.ref_start) < mu+5*sigma); // r1 ---> <---- r2
+        bool r2_r1 = a1.is_rc && (a2.ref_start <= a1.ref_start) && ((a1.ref_start - a2.ref_start) < mu+5*sigma); // r2 ---> <---- r1
 
         if (r1_r2 || r2_r1) {
             float x = std::abs(a1.ref_start - a2.ref_start);

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1161,8 +1161,8 @@ inline void align_PE(
 //                    cnt = 0;
         }
 
-        bool r1_r2 = a2.is_rc && (a1.ref_start <= a2.ref_start) && ((a2.ref_start - a1.ref_start) < mu+5*sigma); // r1 ---> <---- r2
-        bool r2_r1 = a1.is_rc && (a2.ref_start <= a1.ref_start) && ((a1.ref_start - a2.ref_start) < mu+5*sigma); // r2 ---> <---- r1
+        bool r1_r2 = a2.is_rc && (a1.ref_start <= a2.ref_start) && ((a2.ref_start - a1.ref_start) < mu + 10*sigma); // r1 ---> <---- r2
+        bool r2_r1 = a1.is_rc && (a2.ref_start <= a1.ref_start) && ((a1.ref_start - a2.ref_start) < mu + 10*sigma); // r2 ---> <---- r1
 
         if (r1_r2 || r2_r1) {
             float x = std::abs(a1.ref_start - a2.ref_start);

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=23b245f391436baafbf28027a66e266099b36343
+baseline_commit=cd2607817b38cfade89101fd3737436f5333d6ac

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=cd2607817b38cfade89101fd3737436f5333d6ac
+baseline_commit=47cb5c275dbf1d7dae40b8aa01739bf69ee16c90

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=6c67bfca9e4898064ac7ad907b31bcfee2abb85a
+baseline_commit=23b245f391436baafbf28027a66e266099b36343


### PR DESCRIPTION
The first change is to [factor out an `is_proper_nam_pair()` function](https://github.com/ksahlin/strobealign/commit/23b245f391436baafbf28027a66e266099b36343). This changes behavior slightly as the code wasn’t identical at the two call sites. The condition for the distance was `a-b < 2000` in one case and `a-b < mu+10*sigma` in the other. The factored-out function uses the latter because taking the distribution into account seems to be the intended behavior.

The second change is to treat a pair of NAM as being a "proper pair" even if the query start positions are the same.

Both commits change accuracy slightly. The overall difference is as follows:

dataset | aed4738 | cd26078| difference
-|-|-|-
drosophila-50 | 90.1908 | 90.19065 | -0.0002
drosophila-100 | 92.3875 | 92.38865 | +0.0012
drosophila-200 | 93.5184 | 93.52115 | +0.0028
drosophila-300 | 95.3617 | 95.3612 | -0.0005
maize-50 | 71.47185 | 71.472 | +0.0002
maize-100 | 87.13235 | 87.13245 | +0.0001
maize-200 | 92.921 | 92.92045 | -0.0005
maize-300 | 96.7109 | 96.7086 | -0.0023
CHM13-50 | 90.6348 | 90.63435 | -0.0004
CHM13-100 | 93.2195 | 93.21995 | +0.0004
CHM13-200 | 94.43375 | 94.43415 | +0.0004
CHM13-300 | 95.62465 | 95.62665 | +0.0020

The case that R1 and R2 map to the same location doesn’t occur in our test datasets as far as I can tell, so it’s expected that the numbers don’t improve. The actual benefit would be on real data.

Closes #317