### PR TITLE
Fix strobemer count statistics

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -105,7 +105,7 @@ uint64_t count_randstrobes(const std::string& seq, const IndexParameters& parame
     }
 }
 
-std::vector<uint64_t> count_randstrobes_parallel(const References& references, const IndexParameters& parameters, size_t n_threads) {
+std::vector<uint64_t> count_all_randstrobes(const References& references, const IndexParameters& parameters, size_t n_threads) {
     std::vector<std::thread> workers;
     std::atomic_size_t ref_index{0};
 
@@ -137,7 +137,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.tot_strobemer_count = 0;
 
     Timer count_hash;
-    auto randstrobe_counts = count_randstrobes_parallel(references, parameters, n_threads);
+    auto randstrobe_counts = count_all_randstrobes(references, parameters, n_threads);
     stats.elapsed_counting_hashes = count_hash.duration();
 
     uint64_t total_randstrobes = 0;
@@ -155,7 +155,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     Timer randstrobes_timer;
     logger.debug() << "  Generating randstrobes ...\n";
     randstrobes.assign(total_randstrobes, RefRandstrobe{0, 0, 0});
-    assign_all_randstrobes_parallel(randstrobe_counts, n_threads);
+    assign_all_randstrobes(randstrobe_counts, n_threads);
     stats.elapsed_generating_seeds = randstrobes_timer.duration();
 
     Timer sorting_timer;
@@ -237,15 +237,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     stats.unique_strobemers = unique_mers;
 }
 
-void StrobemerIndex::assign_all_randstrobes(const std::vector<uint64_t>& randstrobe_counts) {
-    size_t offset = 0;
-    for (size_t ref_index = 0; ref_index < references.size(); ++ref_index) {
-        assign_randstrobes(ref_index, offset);
-        offset += randstrobe_counts[ref_index];
-    }
-}
-
-void StrobemerIndex::assign_all_randstrobes_parallel(const std::vector<uint64_t>& randstrobe_counts, size_t n_threads) {
+void StrobemerIndex::assign_all_randstrobes(const std::vector<uint64_t>& randstrobe_counts, size_t n_threads) {
     // Compute offsets
     std::vector<size_t> offsets;
     size_t offset = 0;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -234,7 +234,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     }
     stats.filter_cutoff = filter_cutoff;
     stats.elapsed_hash_index = hash_index_timer.duration();
-    stats.unique_strobemers = unique_mers;
+    stats.distinct_strobemers = unique_mers;
 }
 
 void StrobemerIndex::assign_all_randstrobes(const std::vector<uint64_t>& randstrobe_counts, size_t n_threads) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -134,8 +134,6 @@ std::vector<uint64_t> count_all_randstrobes(const References& references, const 
 }
 
 void StrobemerIndex::populate(float f, size_t n_threads) {
-    stats.tot_strobemer_count = 0;
-
     Timer count_hash;
     auto randstrobe_counts = count_all_randstrobes(references, parameters, n_threads);
     stats.elapsed_counting_hashes = count_hash.duration();
@@ -144,6 +142,7 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
     for (auto& count : randstrobe_counts) {
         total_randstrobes += count;
     }
+    stats.tot_strobemer_count = total_randstrobes;
 
     logger.debug() << "  Total number of randstrobes: " << total_randstrobes << '\n';
     uint64_t memory_bytes = references.total_length() + sizeof(RefRandstrobe) * total_randstrobes + sizeof(bucket_index_t) * (1u << bits);
@@ -295,7 +294,6 @@ void StrobemerIndex::assign_randstrobes(size_t ref_index, size_t offset) {
             }
             chunk.push_back(randstrobe);
         }
-        stats.tot_strobemer_count += chunk.size();
         for (auto randstrobe : chunk) {
             RefRandstrobe::packed_t packed = ref_index << 8;
             packed = packed + (randstrobe.strobe2_pos - randstrobe.strobe1_pos);

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -26,7 +26,7 @@ struct IndexCreationStatistics {
     uint64_t tot_mid_ab = 0;
     uint64_t index_cutoff = 0;
     uint64_t filter_cutoff = 0;
-    uint64_t unique_strobemers = 0;
+    uint64_t distinct_strobemers = 0;
 
     std::chrono::duration<double> elapsed_hash_index;
     std::chrono::duration<double> elapsed_generating_seeds;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -152,8 +152,7 @@ struct StrobemerIndex {
     }
 
 private:
-    void assign_all_randstrobes(const std::vector<uint64_t>& randstrobe_counts);
-    void assign_all_randstrobes_parallel(const std::vector<uint64_t>& randstrobe_counts, size_t n_threads);
+    void assign_all_randstrobes(const std::vector<uint64_t>& randstrobe_counts, size_t n_threads);
     void assign_randstrobes(size_t ref_index, size_t offset);
 
     const IndexParameters& parameters;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,19 +223,19 @@ int run_strobealign(int argc, char **argv) {
         logger.debug()
             << "Index statistics\n"
             << "  Total strobemers:    " << std::setw(14) << index.stats.tot_strobemer_count << '\n'
-            << "  Distinct strobemers: " << std::setw(14) << index.stats.unique_strobemers << " (100.00%)\n"
+            << "  Distinct strobemers: " << std::setw(14) << index.stats.distinct_strobemers << " (100.00%)\n"
             << "    1 occurrence:      " << std::setw(14) << index.stats.tot_occur_once
-                << " (" << std::setw(6) << (100.0 * index.stats.tot_occur_once / index.stats.unique_strobemers) << "%)\n"
+                << " (" << std::setw(6) << (100.0 * index.stats.tot_occur_once / index.stats.distinct_strobemers) << "%)\n"
             << "    2..100 occurrences:" << std::setw(14) << index.stats.tot_mid_ab
-                << " (" << std::setw(6) << (100.0 * index.stats.tot_mid_ab / index.stats.unique_strobemers) << "%)\n"
+                << " (" << std::setw(6) << (100.0 * index.stats.tot_mid_ab / index.stats.distinct_strobemers) << "%)\n"
             << "    >100 occurrences:  " << std::setw(14) << index.stats.tot_high_ab
-                << " (" << std::setw(6) << (100.0 * index.stats.tot_high_ab / index.stats.unique_strobemers) << "%)\n"
+                << " (" << std::setw(6) << (100.0 * index.stats.tot_high_ab / index.stats.distinct_strobemers) << "%)\n"
             ;
         if (index.stats.tot_high_ab >= 1) {
-            logger.debug() << "Ratio distinct to highly abundant: " << index.stats.unique_strobemers / index.stats.tot_high_ab << std::endl;
+            logger.debug() << "Ratio distinct to highly abundant: " << index.stats.distinct_strobemers / index.stats.tot_high_ab << std::endl;
         }
         if (index.stats.tot_mid_ab >= 1) {
-            logger.debug() << "Ratio distinct to non distinct: " << index.stats.unique_strobemers / (index.stats.tot_high_ab + index.stats.tot_mid_ab) << std::endl;
+            logger.debug() << "Ratio distinct to non distinct: " << index.stats.distinct_strobemers / (index.stats.tot_high_ab + index.stats.tot_mid_ab) << std::endl;
         }
         logger.debug() << "Filtered cutoff index: " << index.stats.index_cutoff << std::endl;
         logger.debug() << "Filtered cutoff count: " << index.stats.filter_cutoff << std::endl;


### PR DESCRIPTION
There was a race condition in updating `stats.tot_strobemer_count`, which led to the statistics being off. The strobemer count is already available from the first (counting-only) pass over the reference; we can just use that number instead.

This PR also includes a couple of refactoring commits.