### PR TITLE
Rework single-end MAPQ computation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 * #321: Fix: For paired-end reads that cannot be placed as proper pairs, we now
   prefer placing them onto the same chrosome instead of on different ones if
   there is a choice.
+* #328: Adjust MAPQ computation for single-end reads.
 * #318: Added a `--details` option mainly intended for debugging. When used,
   some strobealign-specific tags are added to the SAM output that inform about
   things like no. of seeds found, whether mate rescue was performed etc.

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -106,12 +106,11 @@ static inline void align_SE(
     Nam n_max = nams[0];
 
     int best_edit_distance = std::numeric_limits<int>::max();
-    int best_score = -1000;
+    int best_score = 0;
+    int second_best_score = 0;
 
     Alignment best_alignment;
-    best_alignment.score = -100000;
     best_alignment.is_unaligned = true;
-    int min_mapq_diff = best_edit_distance;
 
     for (auto &nam : nams) {
         float score_dropoff = (float) nam.n_hits / n_max.n_hits;
@@ -124,24 +123,25 @@ static inline void align_SE(
         details.tried_alignment++;
         details.gapped += alignment.gapped;
 
-        int diff_to_best = std::abs(best_score - alignment.score);
-        min_mapq_diff = std::min(min_mapq_diff, diff_to_best);
-
         if (max_secondary > 0) {
             alignments.emplace_back(alignment);
         }
         if (alignment.score > best_score) {
-            min_mapq_diff = std::max(0, alignment.score - best_score); // new distance to next best match
+            second_best_score = best_score;
             best_score = alignment.score;
             best_alignment = std::move(alignment);
             if (max_secondary == 0) {
                 best_edit_distance = best_alignment.global_ed;
             }
+        } else if (alignment.score > second_best_score) {
+            second_best_score = alignment.score;
         }
         tries++;
     }
+    uint8_t mapq = 60.0 * (best_score - second_best_score) / best_score;
+
     if (max_secondary == 0) {
-        best_alignment.mapq = std::min(min_mapq_diff, 60);
+        best_alignment.mapq = mapq;
         sam.add(best_alignment, record, read.rc, true, details);
         return;
     }
@@ -160,7 +160,7 @@ static inline void align_SE(
         }
         bool is_primary = i == 0;
         if (is_primary) {
-            alignment.mapq = std::min(min_mapq_diff, 60);
+            alignment.mapq = mapq;
         } else {
             alignment.mapq = 255;
         }

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -141,8 +141,7 @@ static inline void align_SE(
     uint8_t mapq = 60.0 * (best_score - second_best_score) / best_score;
 
     if (max_secondary == 0) {
-        best_alignment.mapq = mapq;
-        sam.add(best_alignment, record, read.rc, true, details);
+        sam.add(best_alignment, record, read.rc, mapq, true, details);
         return;
     }
     // Sort alignments by score, highest first
@@ -159,12 +158,7 @@ static inline void align_SE(
             break;
         }
         bool is_primary = i == 0;
-        if (is_primary) {
-            alignment.mapq = mapq;
-        } else {
-            alignment.mapq = 255;
-        }
-        sam.add(alignment, record, read.rc, is_primary, details);
+        sam.add(alignment, record, read.rc, mapq, is_primary, details);
     }
 }
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -138,7 +138,7 @@ static inline void align_SE(
         }
         tries++;
     }
-    uint8_t mapq = 60.0 * (best_score - second_best_score) / best_score;
+    uint8_t mapq = (60.0 * (best_score - second_best_score) + best_score - 1) / best_score;
 
     if (max_secondary == 0) {
         sam.add(best_alignment, record, read.rc, mapq, true, details);

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -120,6 +120,7 @@ void Sam::add(
     const Alignment& alignment,
     const KSeq& record,
     const std::string& sequence_rc,
+    uint8_t mapq,
     bool is_primary,
     const Details& details
 ) {
@@ -131,8 +132,9 @@ void Sam::add(
     }
     if (!is_primary) {
         flags |= SECONDARY;
+        mapq = 255;
     }
-    add_record(record.name, flags, references.names[alignment.ref_id], alignment.ref_start, alignment.mapq, alignment.cigar, "*", -1, 0, record.seq, sequence_rc, record.qual, alignment.edit_distance, alignment.score, details);
+    add_record(record.name, flags, references.names[alignment.ref_id], alignment.ref_start, mapq, alignment.cigar, "*", -1, 0, record.seq, sequence_rc, record.qual, alignment.edit_distance, alignment.score, details);
 }
 
 // Add one individual record

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -15,7 +15,6 @@ struct Alignment {
     int edit_distance;
     int global_ed;
     int score;
-    uint8_t mapq;
     int length;
     bool is_rc;
     bool is_unaligned{false};
@@ -79,7 +78,7 @@ public:
         }
 
     /* Add an alignment */
-    void add(const Alignment& alignment, const klibpp::KSeq& record, const std::string& sequence_rc, bool is_primary, const Details& details);
+    void add(const Alignment& alignment, const klibpp::KSeq& record, const std::string& sequence_rc, uint8_t mapq, bool is_primary, const Details& details);
     void add_pair(const Alignment& alignment1, const Alignment& alignment2, const klibpp::KSeq& record1, const klibpp::KSeq& record2, const std::string& read1_rc, const std::string& read2_rc, uint8_t mapq1, uint8_t mapq2, bool is_proper, bool is_primary, const std::array<Details, 2>& details);
     void add_unmapped(const klibpp::KSeq& record, uint16_t flags = UNMAP);
     void add_unmapped_pair(const klibpp::KSeq& r1, const klibpp::KSeq& r2);

--- a/tests/test_sam.cpp
+++ b/tests/test_sam.cpp
@@ -52,7 +52,6 @@ TEST_CASE("Sam::add") {
     aln.ref_start = 2;
     aln.edit_distance = 3;
     aln.score = 9;
-    aln.mapq = 55;
     aln.cigar = Cigar("2S2=1X3=3S");
 
     std::string read_rc = reverse_complement(record.seq);
@@ -61,7 +60,7 @@ TEST_CASE("Sam::add") {
     SUBCASE("Cigar =/X") {
         std::string sam_string;
         Sam sam(sam_string, references);
-        sam.add(aln, record, read_rc, is_primary, details);
+        sam.add(aln, record, read_rc, 55, is_primary, details);
         CHECK(sam_string ==
             "readname\t16\tcontig1\t3\t55\t2S2=1X3=3S\t*\t0\t0\tACGTT\tBB#>\tNM:i:3\tAS:i:9\n"
         );
@@ -69,7 +68,7 @@ TEST_CASE("Sam::add") {
     SUBCASE("Cigar M") {
         std::string sam_string;
         Sam sam(sam_string, references, CigarOps::M);
-        sam.add(aln, record, read_rc, is_primary, details);
+        sam.add(aln, record, read_rc, 55, is_primary, details);
         CHECK(sam_string ==
             "readname\t16\tcontig1\t3\t55\t2S6M3S\t*\t0\t0\tACGTT\tBB#>\tNM:i:3\tAS:i:9\n"
         );


### PR DESCRIPTION
This contains two changes: A bugfix and a change to the way MAPQ values are computed for single-end mapping.

First, the fix: There was a bug in MAPQ computation due to initializing `best_score` to -1000. In the first iteration, `min_mapq_diff` is updated in this way:
```c
min_mapq_diff = std::max(0, alignment.score - best_score);
```
With `best_score=-1000`, this is just `alignment.score + 1000`, so most of the time, `min_mapq_diff` ends up being something like 1600 or so for typical read lengths. This is then clamped to 60 in the output, which is probably the reason why we see MAPQ=60 most of the time.

Even with the fix, I didn’t understand what the code was doing. I think the *intention* is to use the second best score and relate it to the best score to compute the mapping quality, but it appears this isn’t implemented that way. So the second change is to compute MAPQ values differently:

- We keep track of the highest and second-highest alignment score in `best_score` and `second_best_score`.
- MAPQ is computed such that it is
  * 60 for `second_best_score=0` and
  * 0 for `second_best_score=best_score`,
  where anything in between is interpolated:
  ```c
  uint8_t mapq = 60.0 * (best_score - second_best_score) / best_score;
  ```

To me, the two extreme cases (MAPQ=0 and MAPQ=60) make sense.

I’m not so sure about the linear interpolation, but it also seems to give the results one would want in some cases. For example, if `best_score` is 600 and `second_best_score` is 595, the formula gives `60 * (600-595)/600 = 0.5`, which is rounded down and gives mapq=0, so if the scores are very close, the read is still considered a multimapper.

This is intended to address the single-end part of #25.