### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Strobealign is a read mapper that is typically significantly faster than other r
 
 - Map single-end and paired-end reads
 - Multithreading support
-- Fast indexing (2-5 minutes for a human-sized reference genome)
+- Fast indexing (1-2 minutes for a human-sized reference genome using four cores)
 - On-the-fly indexing by default. Optionally create an on-disk index.
 - Output in standard SAM format or produce even faster results by writing PAF (without alignments)
 - Strobealign is most suited for read lengths between 100 and 500 bp


### PR DESCRIPTION
Indexing runtime is down to 1-2 minutes for CHM13 in strobealign 0.11.0.

Some details:
* AMD Ryzen 5 2400G (from 2018): ~90s. With AVX2: ~80s 
* Intel Xeon E5-2630 (rackham): ~118s. With AVX2: ~110s
* Using more than four threads doesn’t decrease runtime further.