### PR TITLE
Get rid of add_to_hits_per_ref() min_diff parameter

### DIFF
--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -16,9 +16,9 @@ void add_to_hits_per_ref(
     int query_end,
     bool is_rc,
     const StrobemerIndex& index,
-    size_t position,
-    int min_diff
+    size_t position
 ) {
+    int min_diff = std::numeric_limits<int>::max();
     for (const auto hash = index.get_hash(position); index.get_hash(position) == hash; ++position) {
         int ref_start = index.get_strobe1_position(position);
         int ref_end = ref_start + index.strobe2_offset(position) + index.k();
@@ -160,7 +160,7 @@ std::pair<float, std::vector<Nam>> find_nams(
                 continue;
             }
             nr_good_hits++;
-            add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, position, 100'000);
+            add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, position);
         }
     }
     float nonrepetitive_fraction = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
@@ -171,6 +171,7 @@ std::pair<float, std::vector<Nam>> find_nams(
 /*
  * Find a query’s NAMs, using also some of the randstrobes that occur more often
  * than filter_cutoff.
+ *
  */
 std::vector<Nam> find_nams_rescue(
     const QueryRandstrobeVector &query_randstrobes,
@@ -218,7 +219,7 @@ std::vector<Nam> find_nams_rescue(
             if ((rh.count > filter_cutoff && cnt >= 5) || rh.count > 1000) {
                 break;
             }
-            add_to_hits_per_ref(hits_per_ref, rh.query_start, rh.query_end, rh.is_rc, index, rh.position, 1000);
+            add_to_hits_per_ref(hits_per_ref, rh.query_start, rh.query_end, rh.is_rc, index, rh.position);
             cnt++;
         }
     }


### PR DESCRIPTION
The intention of this parameter is to disallow hits that span too different lengths on the query compared to the reference.

The parameter has a bit of a misleading name because it is actually the *maximum* allowed difference. (This can come from some of my refactoring. Within the function, it represents the minimum observed difference so far. The value provided as argument is merely its initial value.)

But mainly, the parameter has no effect at all and just initializing it to `std::numeric_limits<int>::max()` leads to the same decisions being made. (I temporarily added some code tested this.)