### PR TITLE
Speed up NAM merging a bit

### DIFF
--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -7,14 +7,12 @@ struct Hit {
     int query_end;
     int ref_start;
     int ref_end;
-    bool is_rc = false;
 };
 
 void add_to_hits_per_ref(
     robin_hood::unordered_map<unsigned int, std::vector<Hit>>& hits_per_ref,
     int query_start,
     int query_end,
-    bool is_rc,
     const StrobemerIndex& index,
     size_t position
 ) {
@@ -24,7 +22,7 @@ void add_to_hits_per_ref(
         int ref_end = ref_start + index.strobe2_offset(position) + index.k();
         int diff = std::abs((query_end - query_start) - (ref_end - ref_start));
         if (diff <= min_diff) {
-            hits_per_ref[index.reference_index(position)].push_back(Hit{query_start, query_end, ref_start, ref_end, is_rc});
+            hits_per_ref[index.reference_index(position)].push_back(Hit{query_start, query_end, ref_start, ref_end});
             min_diff = diff;
         }
     }
@@ -166,7 +164,7 @@ std::pair<float, std::vector<Nam>> find_nams(
                 continue;
             }
             nr_good_hits++;
-            add_to_hits_per_ref(hits_per_ref[q.is_reverse], q.start, q.end, q.is_reverse, index, position);
+            add_to_hits_per_ref(hits_per_ref[q.is_reverse], q.start, q.end, index, position);
         }
     }
     float nonrepetitive_fraction = total_hits > 0 ? ((float) nr_good_hits) / ((float) total_hits) : 1.0;
@@ -226,7 +224,7 @@ std::vector<Nam> find_nams_rescue(
             if ((rh.count > rescue_cutoff && cnt >= 5) || rh.count > 1000) {
                 break;
             }
-            add_to_hits_per_ref(hits_per_ref[rh.is_rc], rh.query_start, rh.query_end, rh.is_rc, index, rh.position);
+            add_to_hits_per_ref(hits_per_ref[rh.is_rc], rh.query_start, rh.query_end, index, rh.position);
             cnt++;
         }
     }

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -2,6 +2,7 @@
 #define STROBEALIGN_NAM_HPP
 
 #include <vector>
+#include <array>
 #include "index.hpp"
 #include "randstrobes.hpp"
 

--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=19d5d20f5fb1051169639a1efb37bd7371a078f2
+baseline_commit=91f22234baf192a3167354a7f2bbfefb49cb2162


### PR DESCRIPTION
`merge_hits_into_nams()` has two nested `for` loops that iterate over a single vector that contains both forward and reverse hits. In the inner loop, there’s a check to ensure that forward and reverse hits are never merged into NAMs.

We can instead keep forward and reverse hits in two different hash tables and work on them separately. This reduces the number of comparisons done in the inner loop. Interestingly, that change by itself doesn’t really reduce runtime. But what does reduce runtime is the subsequent commit that makes the `Hit` struct smaller by removing its `is_rc` attribute, which we no longer need.

Measurements on 100 bp single-end reads:

Reference | speedup
-|-
drosophila | ~2%
maize | ~9%
CHM13 | ~7%
rye | ~1%

I’ll post how accuracy changes tomorrow (so far, it looks as if there’s nearly no change).