### PR TITLE
Allow w_min to be zero

### DIFF
--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -35,7 +35,7 @@ struct Profile {
 static auto max{std::numeric_limits<int>::max()};
 
 static std::vector<Profile> profiles = {
-        Profile{ 50,  90, 20, -4, -4,  2},
+        Profile{ 50,  90, 20, -4, -3,  2},
         Profile{100, 110, 20, -4, -2,  2},
         Profile{125, 135, 20, -4, -1,  4},
         Profile{150, 175, 20, -4,  1,  7},

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -62,6 +62,9 @@ private:
         if (max_dist > 255) {
             throw BadParameter("maximum seed length (-m <max_dist>) is larger than 255");
         }
+        if (w_min > w_max) {
+            throw BadParameter("w_min is greater than w_max (choose different -l/-u parameters)");
+        }
     }
 };
 

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -80,7 +80,7 @@ public:
     IndexParameters(size_t canonical_read_length, int k, int s, int l, int u, int q, int max_dist)
         : canonical_read_length(canonical_read_length)
         , syncmer(k, s)
-        , randstrobe(l, u, q, max_dist, std::max(1, k / (k - s + 1) + l), k / (k - s + 1) + u)
+        , randstrobe(l, u, q, max_dist, std::max(0, k / (k - s + 1) + l), k / (k - s + 1) + u)
     {
     }
 


### PR DESCRIPTION
There’s nothing inherently problematic with `w_min=0` and, as we see in #272, it even leads to higher accuracy for 50 bp reads.

This requires changing the `l` parameter from -4 to -3 for 50 bp reads if we want w_min to remain equal to 1 as before.