### PR TITLE
Fix read length estimation crash on chromosome-sized "reads"

### DIFF
--- a/src/readlen.cpp
+++ b/src/readlen.cpp
@@ -1,8 +1,8 @@
 #include "readlen.hpp"
 
-int total_read_len(const std::vector<klibpp::KSeq> &records) {
+uint64_t total_read_len(const std::vector<klibpp::KSeq> &records) {
 
-    int tot_read_len = 0;
+    uint64_t tot_read_len = 0;
     for (size_t i = 0; i < records.size(); ++i) {
         tot_read_len += records[i].seq.length();
     }
@@ -13,7 +13,7 @@ int total_read_len(const std::vector<klibpp::KSeq> &records) {
  * Return average read length of single-end or paired-end reads.
  * Set filename2 to the empty string if data is single end.
  */
-int estimate_read_length(InputBuffer& input_buffer) {
+uint64_t estimate_read_length(InputBuffer& input_buffer) {
     std::vector<klibpp::KSeq> records1;
     std::vector<klibpp::KSeq> records2;
     std::vector<klibpp::KSeq> records3;
@@ -27,4 +27,3 @@ int estimate_read_length(InputBuffer& input_buffer) {
     auto tot_read_num = records1.size() + records2.size() + records3.size();
     return tot_read_len / tot_read_num;
 }
-

--- a/src/readlen.hpp
+++ b/src/readlen.hpp
@@ -5,6 +5,6 @@
 #include <zlib.h>
 #include "pc.hpp"
 
-int estimate_read_length(InputBuffer& input_buffer);
+uint64_t estimate_read_length(InputBuffer& input_buffer);
 
 #endif


### PR DESCRIPTION
Closes #343

(This does not mean that it is actually possible to run CHM13 vs CHM13 in a reasonable amount of time, strobealign just doesn’t crash anymore before getting stuck.)