### PR TITLE
Reduce memory usage when indexing

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -271,7 +271,7 @@ void StrobemerIndex::assign_all_randstrobes(const std::vector<uint64_t>& randstr
  * vector starting from the given offset
  */
 void StrobemerIndex::assign_randstrobes(size_t ref_index, size_t offset) {
-    auto seq = references.sequences[ref_index];
+    auto& seq = references.sequences[ref_index];
     if (seq.length() < parameters.randstrobe.w_max) {
         return;
     }


### PR DESCRIPTION
A full copy of each reference sequence was inadvertently made in each worker thread.

Reduces memory usage, especially when indexing genomes with large scaffolds in parallel.

When indexing rye with 8 threads, memory usage is reduced from 35.2 GiB to 33.4 GiB.

See #345