### PR TITLE
Fix: Avoid nam id collisions that reduce accuracy

### DIFF
--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -35,7 +35,6 @@ void merge_hits_into_nams(
     bool is_revcomp,
     std::vector<Nam>& nams  // inout
 ) {
-    int nam_id_cnt = 0;
     for (auto &[ref_id, hits] : hits_per_ref) {
         if (sort) {
             std::sort(hits.begin(), hits.end(), [](const Hit& a, const Hit& b) -> bool {
@@ -81,8 +80,6 @@ void merge_hits_into_nams(
             // Add the hit to open matches
             if (!is_added){
                 Nam n;
-                n.nam_id = nam_id_cnt;
-                nam_id_cnt ++;
                 n.query_start = h.query_start;
                 n.query_end = h.query_end;
                 n.ref_start = h.ref_start;
@@ -110,6 +107,7 @@ void merge_hits_into_nams(
                         n_score = ( 2*n_min_span -  n_max_span) > 0 ? (float) (n.n_hits * ( 2*n_min_span -  n_max_span) ) : 1;   // this is really just n_hits * ( min_span - (offset_in_span) ) );
 //                        n_score = n.n_hits * n.query_span();
                         n.score = n_score;
+                        n.nam_id = nams.size();
                         nams.push_back(n);
                     }
                 }
@@ -130,6 +128,7 @@ void merge_hits_into_nams(
             n_score = ( 2*n_min_span -  n_max_span) > 0 ? (float) (n.n_hits * ( 2*n_min_span -  n_max_span) ) : 1;   // this is really just n_hits * ( min_span - (offset_in_span) ) );
 //            n_score = n.n_hits * n.query_span();
             n.score = n_score;
+            n.nam_id = nams.size();
             nams.push_back(n);
         }
     }


### PR DESCRIPTION
The nam_id started from 0 both for forward and reverse hits, which resulted in NAM ids being reused for different NAMs. This regression was introduced by commit 91f2223 and reduced accuracy.

This PR brings accuracy back to the expected levels (that is, higher than v0.11.0 due to tuned parameters).

I will need to re-run the parameter evaluation ...

See #345

## Comparison

for a couple of datasets

dataset           | v0.11.0 (93be0c2) | this PR (a290e7b) | difference
-|-|-|-
drosophila-50-pe  | 90.1908 | 90.499 | +0.3082
drosophila-100-pe | 92.3875 | 92.40435 | +0.0168
drosophila-150-pe | 93.21175 | 93.2124 | +0.0007
drosophila-200-pe | 93.5184 | 93.54275 | +0.0243
drosophila-300-pe | 95.3617 | 95.37225 | +0.0105
maize-50-pe       | 71.47185 | 72.9601 | +1.4882
maize-100-pe      | 87.13235 | 87.2842 | +0.1519
CHM13-50-pe       | 90.6348 | 91.1365 | +0.5017
CHM13-100-pe      | 93.2195 | 93.2809 | +0.0614
CHM13-150-pe      | 94.14135 | 94.1508 | +0.0094
CHM13-200-pe      | 94.43375 | 94.43975 | +0.0060
CHM13-300-pe      | 95.62465 | 95.63985 | +0.0152
rye-50-pe         | 69.1411 | 70.8096 | +1.6685
rye-100-pe        | 85.6489 | 85.73105 | +0.0821
rye-150-pe        | 90.20365 | 90.23185 | +0.0282
rye-200-pe        | 91.47915 | 91.50855 | +0.0294
