### PR TITLE
Add dumpstrobes --seeds option for writing out the full seed vector

### DIFF
--- a/src/index.hpp
+++ b/src/index.hpp
@@ -104,6 +104,14 @@ struct StrobemerIndex {
         return randstrobes[position].reference_index();
     }
 
+    RefRandstrobe get_randstrobe(bucket_index_t position) const {
+        return randstrobes[position];
+    }
+
+    size_t size() const {
+        return randstrobes.size();
+    }
+
     unsigned int get_count(bucket_index_t position) const {
         // For 95% of cases, the result will be small and a brute force search
         // is the best option. Once, we go over MAX_LINEAR_SEARCH, though, we


### PR DESCRIPTION
With this, `dumpstrobes --seeds genome.fa` dumps the sorted randstrobes vector to standard output in a comma-separated format.

Columns:
- hash
- position
- reference index
- strobe 2 offset

I also had to move two functions in `index.cpp` into an anonymous namespace as otherwise the linker complains about a duplicate name (`count_randstrobes` exists twice).