### PR TITLE
Let baseline comparison fail if no reads were in the input

### DIFF
--- a/tests/baseline-commit.txt
+++ b/tests/baseline-commit.txt
@@ -1,1 +1,1 @@
-baseline_commit=91f22234baf192a3167354a7f2bbfefb49cb2162
+baseline_commit=94c20bec1731b1c06d8090503cc4a0a402f6efb2

--- a/tests/samdiff.py
+++ b/tests/samdiff.py
@@ -145,7 +145,7 @@ def main():
 
     print(f"  {single_total:>9} total reads")
 
-    if unmapped_same + identical < single_total:
+    if unmapped_same + identical < single_total or single_total == 0:
         sys.exit(1)
 
 


### PR DESCRIPTION
This should ensure that the baseline comparison CI job doesn’t pass inadvertently as it did previously (see #361).

This also updates the baseline commit. To ensure we didn’t miss any changes in mapping results just because the samdiff script didn’t work, I ran it manually for each commit since the problem was introduced and can confirm that no other commit caused any changes.

Closes #361