### PR TITLE
Refactor aln.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(salib STATIC ${SOURCES}
   src/readlen.cpp
   src/version.cpp
   src/io.cpp
+  src/insertsizedistribution.cpp
   ext/xxhash.c
   ext/ssw/ssw_cpp.cpp
   ext/ssw/ssw.c

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -410,9 +410,6 @@ static inline std::vector<NamPair> get_best_scoring_nam_pairs(
         }
     }
 
-    added_n1.clear();
-    added_n2.clear();
-
     std::sort(
         nam_pairs.begin(),
         nam_pairs.end(),

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -84,7 +84,7 @@ bool reverse_nam_if_needed(Nam& nam, const Read& read, const References& referen
     return false;
 }
 
-static inline void align_SE(
+static inline void align_single(
     const Aligner& aligner,
     Sam& sam,
     std::vector<Nam>& nams,
@@ -679,7 +679,7 @@ float top_dropoff(std::vector<Nam>& nams) {
     return 0.0;
 }
 
-inline void align_PE(
+inline void align_paired(
     const Aligner& aligner,
     Sam &sam,
     std::vector<Nam> &nams1,
@@ -1026,7 +1026,7 @@ void shuffle_top_nams(std::vector<Nam>& nams, std::minstd_rand& random_engine) {
     }
 }
 
-void align_PE_read(
+void align_or_map_paired(
     const KSeq &record1,
     const KSeq &record2,
     Sam& sam,
@@ -1085,7 +1085,7 @@ void align_PE_read(
                            references,
                            record2.seq.length());
     } else {
-        align_PE(aligner, sam, nams_pair[0], nams_pair[1], record1,
+        align_paired(aligner, sam, nams_pair[0], nams_pair[1], record1,
                  record2,
                  index_parameters.syncmer.k,
                  references, details,
@@ -1097,7 +1097,7 @@ void align_PE_read(
 }
 
 
-void align_SE_read(
+void align_or_map_single(
     const KSeq &record,
     Sam& sam,
     std::string &outstring,
@@ -1140,7 +1140,7 @@ void align_SE_read(
         output_hits_paf(outstring, nams, record.name, references,
                         record.seq.length());
     } else {
-        align_SE(
+        align_single(
             aligner, sam, nams, record, index_parameters.syncmer.k,
             references, details, map_param.dropoff_threshold, map_param.max_tries,
             map_param.max_secondary, random_engine

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -963,11 +963,11 @@ inline void get_best_map_location(
     // get individual best scores
     float score_indiv = 0;
     if (!nams1.empty()) {
-        score_indiv += nams1[0].score - nams1[0].score / 2.0; //Penalty for being mapped individually
+        score_indiv += nams1[0].score / 2.0; //Penalty for being mapped individually
         best_nam1 = nams1[0];
     }
     if (!nams2.empty()) {
-        score_indiv += nams2[0].score - nams2[0].score / 2.0; //Penalty for being mapped individually
+        score_indiv += nams2[0].score / 2.0; //Penalty for being mapped individually
         best_nam2 = nams2[0];
     }
     if (score_joint > score_indiv) { // joint score is better than individual

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -258,14 +258,14 @@ static inline Alignment extend_seed(
 /*
  * Return mapping quality for a read mapped in a proper pair
  */
-static inline uint8_t proper_pair_mapq(const std::vector<Nam> &nams, const Nam &n_max) {
+static inline uint8_t proper_pair_mapq(const std::vector<Nam> &nams) {
     if (nams.size() <= 1) {
         return 60;
     }
-    const float s1 = n_max.score;
+    const float s1 = nams[0].score;
     const float s2 = nams[1].score;
     // from minimap2: MAPQ = 40(1−s2/s1) ·min{1,|M|/10} · log s1
-    const float min_matches = std::min(n_max.n_hits / 10.0, 1.0);
+    const float min_matches = std::min(nams[0].n_hits / 10.0, 1.0);
     const int uncapped_mapq = 40 * (1 - s2 / s1) * min_matches * log(s1);
     return std::min(uncapped_mapq, 60);
 }
@@ -773,8 +773,8 @@ inline void align_PE(
         auto alignment2 = extend_seed(aligner, n_max2, references, read2, consistent_nam2);
         details[1].tried_alignment++;
         details[1].gapped += alignment2.gapped;
-        int mapq1 = proper_pair_mapq(nams1, n_max1);
-        int mapq2 = proper_pair_mapq(nams2, n_max2);
+        int mapq1 = proper_pair_mapq(nams1);
+        int mapq2 = proper_pair_mapq(nams2);
         bool is_proper = is_proper_pair(alignment1, alignment2, mu, sigma);
         bool is_primary = true;
         sam.add_pair(alignment1, alignment2, record1, record2, read1.rc, read2.rc, mapq1, mapq2, is_proper, is_primary, details);

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -12,6 +12,7 @@
 
 using namespace klibpp;
 
+namespace {
 
 struct NamPair {
     int score;
@@ -25,7 +26,7 @@ struct ScoredAlignmentPair {
     Alignment alignment2;
 };
 
-static inline Alignment extend_seed(
+inline Alignment extend_seed(
     const Aligner& aligner,
     const Nam &nam,
     const References& references,
@@ -84,7 +85,7 @@ bool reverse_nam_if_needed(Nam& nam, const Read& read, const References& referen
     return false;
 }
 
-static inline void align_single(
+inline void align_single(
     const Aligner& aligner,
     Sam& sam,
     std::vector<Nam>& nams,
@@ -203,7 +204,7 @@ static inline void align_single(
  Extend a NAM so that it covers the entire read and return the resulting
  alignment.
 */
-static inline Alignment extend_seed(
+inline Alignment extend_seed(
     const Aligner& aligner,
     const Nam &nam,
     const References& references,
@@ -258,7 +259,7 @@ static inline Alignment extend_seed(
 /*
  * Return mapping quality for a read mapped in a proper pair
  */
-static inline uint8_t proper_pair_mapq(const std::vector<Nam> &nams) {
+inline uint8_t proper_pair_mapq(const std::vector<Nam> &nams) {
     if (nams.size() <= 1) {
         return 60;
     }
@@ -271,7 +272,7 @@ static inline uint8_t proper_pair_mapq(const std::vector<Nam> &nams) {
 }
 
 /* Compute paired-end mapping score given best alignments (sorted by score) */
-static std::pair<int, int> joint_mapq_from_high_scores(const std::vector<ScoredAlignmentPair>& pairs) {
+std::pair<int, int> joint_mapq_from_high_scores(const std::vector<ScoredAlignmentPair>& pairs) {
     if (pairs.size() <= 1) {
         return std::make_pair(60, 60);
     }
@@ -294,7 +295,7 @@ static std::pair<int, int> joint_mapq_from_high_scores(const std::vector<ScoredA
     return std::make_pair(mapq, mapq);
 }
 
-static inline float normal_pdf(float x, float mu, float sigma)
+inline float normal_pdf(float x, float mu, float sigma)
 {
     static const float inv_sqrt_2pi = 0.3989422804014327;
     const float a = (x - mu) / sigma;
@@ -302,7 +303,7 @@ static inline float normal_pdf(float x, float mu, float sigma)
     return inv_sqrt_2pi / sigma * std::exp(-0.5f * a * a);
 }
 
-static inline std::vector<ScoredAlignmentPair> get_best_scoring_pairs(
+inline std::vector<ScoredAlignmentPair> get_best_scoring_pairs(
     const std::vector<Alignment>& alignments1,
     const std::vector<Alignment>& alignments2,
     float mu,
@@ -348,7 +349,7 @@ bool is_proper_nam_pair(const Nam nam1, const Nam nam2, float mu, float sigma) {
  * high-scoring NAMs that could not be paired up are returned (these get a
  * "dummy" NAM as partner in the returned vector).
  */
-static inline std::vector<NamPair> get_best_scoring_nam_pairs(
+inline std::vector<NamPair> get_best_scoring_nam_pairs(
     const std::vector<Nam> &nams1,
     const std::vector<Nam> &nams2,
     float mu,
@@ -420,28 +421,11 @@ static inline std::vector<NamPair> get_best_scoring_nam_pairs(
 }
 
 /*
- * Determine (roughly) whether the read sequence has some l-mer (with l = k*2/3)
- * in common with the reference sequence
- */
-bool has_shared_substring(const std::string& read_seq, const std::string& ref_seq, int k) {
-    int sub_size = 2 * k / 3;
-    int step_size = k / 3;
-    std::string submer;
-    for (size_t i = 0; i + sub_size < read_seq.size(); i += step_size) {
-        submer = read_seq.substr(i, sub_size);
-        if (ref_seq.find(submer) != std::string::npos) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/*
  * Align a read to the reference given the mapping location of its mate.
  *
  * Return true if rescue by alignment was actually attempted
  */
-static inline Alignment rescue_align(
+inline Alignment rescue_align(
     const Aligner& aligner,
     const Nam &mate_nam,
     const References& references,
@@ -997,6 +981,25 @@ void shuffle_top_nams(std::vector<Nam>& nams, std::minstd_rand& random_engine) {
     if (it != nams.end()) {
         std::shuffle(nams.begin(), it, random_engine);
     }
+}
+
+} // end of anonymous namespace
+
+/*
+ * Determine (roughly) whether the read sequence has some l-mer (with l = k*2/3)
+ * in common with the reference sequence
+ */
+bool has_shared_substring(const std::string& read_seq, const std::string& ref_seq, int k) {
+    int sub_size = 2 * k / 3;
+    int step_size = k / 3;
+    std::string submer;
+    for (size_t i = 0; i + sub_size < read_seq.size(); i += step_size) {
+        submer = read_seq.substr(i, sub_size);
+        if (ref_seq.find(submer) != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void align_or_map_paired(

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -255,7 +255,10 @@ static inline Alignment extend_seed(
     return alignment;
 }
 
-static inline uint8_t get_mapq(const std::vector<Nam> &nams, const Nam &n_max) {
+/*
+ * Return mapping quality for a read mapped in a proper pair
+ */
+static inline uint8_t proper_pair_mapq(const std::vector<Nam> &nams, const Nam &n_max) {
     if (nams.size() <= 1) {
         return 60;
     }
@@ -770,8 +773,8 @@ inline void align_PE(
         auto alignment2 = extend_seed(aligner, n_max2, references, read2, consistent_nam2);
         details[1].tried_alignment++;
         details[1].gapped += alignment2.gapped;
-        int mapq1 = get_mapq(nams1, n_max1);
-        int mapq2 = get_mapq(nams2, n_max2);
+        int mapq1 = proper_pair_mapq(nams1, n_max1);
+        int mapq2 = proper_pair_mapq(nams2, n_max2);
         bool is_proper = is_proper_pair(alignment1, alignment2, mu, sigma);
         bool is_primary = true;
         sam.add_pair(alignment1, alignment2, record1, record2, read1.rc, read2.rc, mapq1, mapq2, is_proper, is_primary, details);

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -983,30 +983,6 @@ inline void get_best_map_location(
     }
 }
 
-/* Add a new observation */
-void InsertSizeDistribution::update(int dist) {
-    if (dist >= 2000) {
-        return;
-    }
-    const float e = dist - mu;
-    mu += e / sample_size; // (1.0/(sample_size +1.0)) * (sample_size*mu + d);
-    SSE += e * (dist - mu);
-    if (sample_size > 1) {
-        //d < 1000 ? ((sample_size +1.0)/sample_size) * ( (V*sample_size/(sample_size +1)) + ((mu-d)*(mu-d))/sample_size ) : V;
-        V = SSE / (sample_size - 1.0);
-    } else {
-        V = SSE;
-    }
-    sigma = std::sqrt(V);
-    sample_size = sample_size + 1.0;
-    if (mu < 0) {
-        std::cerr << "mu negative, mu: " << mu << " sigma: " << sigma << " SSE: " << SSE << " sample size: " << sample_size << std::endl;
-    }
-    if (SSE < 0) {
-        std::cerr << "SSE negative, mu: " << mu << " sigma: " << sigma << " SSE: " << SSE << " sample size: " << sample_size << std::endl;
-    }
-}
-
 /* Shuffle the top-scoring NAMs. Input must be sorted by score.
  *
  * This helps to ensure we pick a random location in case there are multiple

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -676,7 +676,7 @@ std::vector<ScoredAlignmentPair> align_paired(
     const References& references,
     std::array<Details, 2>& details,
     float dropoff,
-    InsertSizeDistribution &isize_est,
+    const InsertSizeDistribution &isize_est,
     unsigned max_tries
 ) {
     const auto mu = isize_est.mu;

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -9,7 +9,7 @@
 #include "refs.hpp"
 #include "sam.hpp"
 #include "aligner.hpp"
-
+#include "insertsizedistribution.hpp"
 
 struct AlignmentStatistics {
     std::chrono::duration<double> tot_read_file{0};
@@ -73,20 +73,6 @@ struct MappingParameters {
             throw BadParameter("max_tries must be greater than zero");
         }
     }
-};
-
-/* Estimator for a normal distribution, used for insert sizes.
- */
-class InsertSizeDistribution {
-public:
-    float sample_size = 1;
-    float mu = 300;
-    float sigma = 100;
-    float V = 10000;
-    float SSE = 10000;
-
-    // Add a new observation
-    void update(int dist);
 };
 
 void align_or_map_paired(

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -89,7 +89,7 @@ public:
     void update(int dist);
 };
 
-void align_PE_read(
+void align_or_map_paired(
     const klibpp::KSeq& record1,
     const klibpp::KSeq& record2,
     Sam& sam,
@@ -104,7 +104,7 @@ void align_PE_read(
     std::minstd_rand& random_engine
 );
 
-void align_SE_read(
+void align_or_map_single(
     const klibpp::KSeq& record,
     Sam& sam,
     std::string& outstring,

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -103,10 +103,8 @@ void align_or_map_single(
     std::minstd_rand& random_engine
 );
 
-// Private declarations, only here because we need them in tests
+// Private declarations, only needed for tests
 
 bool has_shared_substring(const std::string& read_seq, const std::string& ref_seq, int k);
-
-std::pair<size_t, size_t> highest_scoring_segment(const std::string& query, const std::string& ref, int match, int mismatch);
 
 #endif

--- a/src/insertsizedistribution.cpp
+++ b/src/insertsizedistribution.cpp
@@ -1,0 +1,28 @@
+#include "insertsizedistribution.hpp"
+#include <cmath>
+#include <iostream>
+
+
+/* Add a new observation */
+void InsertSizeDistribution::update(int dist) {
+    if (dist >= 2000) {
+        return;
+    }
+    const float e = dist - mu;
+    mu += e / sample_size; // (1.0/(sample_size +1.0)) * (sample_size*mu + d);
+    SSE += e * (dist - mu);
+    if (sample_size > 1) {
+        //d < 1000 ? ((sample_size +1.0)/sample_size) * ( (V*sample_size/(sample_size +1)) + ((mu-d)*(mu-d))/sample_size ) : V;
+        V = SSE / (sample_size - 1.0);
+    } else {
+        V = SSE;
+    }
+    sigma = std::sqrt(V);
+    sample_size = sample_size + 1.0;
+    if (mu < 0) {
+        std::cerr << "mu negative, mu: " << mu << " sigma: " << sigma << " SSE: " << SSE << " sample size: " << sample_size << std::endl;
+    }
+    if (SSE < 0) {
+        std::cerr << "SSE negative, mu: " << mu << " sigma: " << sigma << " SSE: " << SSE << " sample size: " << sample_size << std::endl;
+    }
+}

--- a/src/insertsizedistribution.hpp
+++ b/src/insertsizedistribution.hpp
@@ -1,0 +1,18 @@
+#ifndef STROBEALIGN_INSERTSIZEDISTRIBUTION_HPP
+#define STROBEALIGN_INSERTSIZEDISTRIBUTION_HPP
+
+/* Estimator for a normal distribution, used for insert sizes.
+ */
+class InsertSizeDistribution {
+public:
+    float sample_size = 1;
+    float mu = 300;
+    float sigma = 100;
+    float V = 10000;
+    float SSE = 10000;
+
+    // Add a new observation
+    void update(int dist);
+};
+
+#endif

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -169,13 +169,13 @@ void perform_task(
             auto record2 = records2[i];
             to_uppercase(record1.seq);
             to_uppercase(record2.seq);
-            align_PE_read(record1, record2, sam, sam_out, statistics, isize_est, aligner,
+            align_or_map_paired(record1, record2, sam, sam_out, statistics, isize_est, aligner,
                         map_param, index_parameters, references, index, random_engine);
             statistics.n_reads += 2;
         }
         for (size_t i = 0; i < records3.size(); ++i) {
             auto record = records3[i];
-            align_SE_read(record, sam, sam_out, statistics, aligner, map_param, index_parameters, references, index, random_engine);
+            align_or_map_single(record, sam, sam_out, statistics, aligner, map_param, index_parameters, references, index, random_engine);
             statistics.n_reads++;
         }
         output_buffer.output_records(std::move(sam_out), chunk_index);

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -48,9 +48,19 @@ struct Details {
     bool nam_rescue{false}; // find_nams_rescue() was needed
     uint64_t nams{0};  // No. of NAMs found
     uint64_t nam_inconsistent{0};
-    uint64_t mate_rescue{false}; // No. of times rescue by local alignment was attempted
+    uint64_t mate_rescue{0}; // No. of times rescue by local alignment was attempted
     uint64_t tried_alignment{0}; // No. of computed alignments (get_alignment or rescue_mate)
     uint64_t gapped{0};  // No. of gapped alignments computed (in get_alignment)
+
+    Details& operator+=(const Details& other) {
+        nam_rescue = nam_rescue || other.nam_rescue;
+        nams += other.nams;
+        nam_inconsistent += other.nam_inconsistent;
+        mate_rescue += other.mate_rescue;
+        tried_alignment += other.tried_alignment;
+        gapped += other.gapped;
+        return *this;
+    }
 };
 
 class Sam {


### PR DESCRIPTION
This renames:

* `align_SE` → `align_single`
* `align_PE` → `align_paired`
* `align_SE_read` → `align_or_map_single`
* `align_PE_read` → `align_or_map_paired`
* `joint_nam_scores` → `nam_pairs` (since we now use the `NamPair` struct)
* `rescue_mate` → `rescue_align` (could never remember what it does differently from `rescue_read`)
* Rename `get_mapq` to `proper_pair_mapq` (since this is only used to compute MAPQ for uniquely mapping proper pairs)

Also, `InsertSizeDistribution` is moved to a separate file.

The main change is to factor out an output_aligned_pairs() function. The rescue_read() and align_paired() functions previously did two things:
- Compute a list of paired alignments
- Output them to SAM

When working on random alignment selection for #367, I noticed that the code outputting to SAM was duplicated (and had slightly diverged already). This commit moves that part to a
new function output_aligned_pairs(). Now rescue_read() and align_paired() just
return a vector of ScoredAlignmentPairs.

This should fix at least two bugs:
- The details for R1 and R2 were swapped when R1 was rescued
- MAPQ of secondary alignments was inconsistently set to 0 or 255 depending on whether it was a rescued alignment or not.