### PR TITLE
With --details, add a SAM tag that shows the no. of identically scored best alignments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Strobealign Changelog
 
+## development version
+
+* If `--details` is used, output `X0:i` SAM tag with the number of
+  identically-scored best alignments
+
 ## v0.12.0 (2023-11-23)
 
 * #293: Fix: When mapping single-end reads, many multimappers were previously

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ style guide, but new code should follow it.
 
 ## Detailed SAM output (`--details`)
 
-When `--details` or `-d` is provided, the following additional SAM tags are output for
+When `--details` is provided, the following additional SAM tags are output for
 mapped reads.
 
 `na`: Number of NAMs (seeds) found
@@ -77,3 +77,6 @@ mapped reads.
   the expected region given its mate)
 `al`: Number of times an attempt was made to extend a seed (by gapped or ungapped alignment)
 `ga`: Number of times an attempt was made to extend a seed by gapped alignment
+`X0`: Number of equally scored best alignments (greater than 1 for multimappers).
+ For paired-end reads, the tag is output for both reads, but the value is
+ identical and is the number of equally scored best alignment *pairs*.

--- a/src/sam.cpp
+++ b/src/sam.cpp
@@ -46,10 +46,11 @@ void Sam::append_rg_and_newline() {
 
 void Sam::append_details(const Details& details) {
     std::stringstream s;
-    s << "\tna:i:" << details.nams;
-    s << "\tnr:i:" << details.nam_rescue;
-    s << "\tal:i:" << details.tried_alignment;
-    s << "\tga:i:" << details.gapped;
+    s << "\tna:i:" << details.nams
+        << "\tnr:i:" << details.nam_rescue
+        << "\tal:i:" << details.tried_alignment
+        << "\tga:i:" << details.gapped
+        << "\tX0:i:" << details.best_alignments;
     sam_string.append(s.str());
 }
 

--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -51,6 +51,7 @@ struct Details {
     uint64_t mate_rescue{0}; // No. of times rescue by local alignment was attempted
     uint64_t tried_alignment{0}; // No. of computed alignments (get_alignment or rescue_mate)
     uint64_t gapped{0};  // No. of gapped alignments computed (in get_alignment)
+    uint64_t best_alignments{0}; // No. of best alignments with same score
 
     Details& operator+=(const Details& other) {
         nam_rescue = nam_rescue || other.nam_rescue;
@@ -59,6 +60,7 @@ struct Details {
         mate_rescue += other.mate_rescue;
         tried_alignment += other.tried_alignment;
         gapped += other.gapped;
+        best_alignments += other.best_alignments;
         return *this;
     }
 };


### PR DESCRIPTION
This is the number of alignments among which we (pseudo-randomly) choose one to output.

Is this useful? I thought I needed this for debugging, but then never actually looked at the numbers.

Regarding the name of the tag: The old `bwa aln` used `X0` for "Number of best hits", which I think is the same thing. There is a `H0` tag in the SAM specification with the description "Number of perfect hits", which could be something similar, but I could not find what it is actually intended to be used for, so I went with `X0`.

This requires #368 to be merged first.