### PR TITLE
Use optimized indexing parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## development version
 
+* #376: Improve accuracy for read length 50 by optimizing the default
+  indexing parameters. Paired-end accuracy increases by 0.3 percentage
+  points on average. Single-end accuracy increases by 1 percentage point.
 * If `--details` is used, output `X0:i` SAM tag with the number of
   identically-scored best alignments
 * #371: Add `--no-PG` option for not outputting the PG SAM header

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ it can map reads to it.
 The optimal indexing parameters depend on the length of the input reads.
 There are currently seven different pre-defined sets of parameters that are
 optimized for different read lengths. These *canonical read lengths* are
-50, 100, 125, 150, 250, 300 and 400. When deciding which of the pre-defined
+50, 100, 125, 150, 250 and 400. When deciding which of the pre-defined
 indexing parameter sets to use, strobealign chooses one whose canonical
 read length is close to the average read length of the input.
 

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -39,8 +39,7 @@ static std::vector<Profile> profiles = {
         Profile{100, 110, 20, -4, -2,  2},
         Profile{125, 135, 20, -4, -1,  4},
         Profile{150, 175, 20, -4,  1,  7},
-        Profile{250, 275, 22, -4,  2, 12},
-        Profile{300, 375, 22, -4,  2, 12},
+        Profile{250, 375, 22, -4,  2, 12},
         Profile{400, max, 23, -6,  2, 12},
     };
 

--- a/src/indexparameters.cpp
+++ b/src/indexparameters.cpp
@@ -35,11 +35,11 @@ struct Profile {
 static auto max{std::numeric_limits<int>::max()};
 
 static std::vector<Profile> profiles = {
-        Profile{ 50,  90, 20, -4, -3,  2},
+        Profile{ 50,  90, 18, -4, -2,  1},
         Profile{100, 110, 20, -4, -2,  2},
         Profile{125, 135, 20, -4, -1,  4},
         Profile{150, 175, 20, -4,  1,  7},
-        Profile{250, 275, 20, -4,  4, 13},
+        Profile{250, 275, 22, -4,  2, 12},
         Profile{300, 375, 22, -4,  2, 12},
         Profile{400, max, 23, -6,  2, 12},
     };


### PR DESCRIPTION
Also, remove canonical read length 300 because after changing the parameters, 250 and 300 were using the same.