### PR TITLE
Fix misspelled "strobealign"

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -8,7 +8,7 @@ class Version {};
 
 CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
 
-    args::ArgumentParser parser("strobelign " + version_string());
+    args::ArgumentParser parser("strobealign " + version_string());
     parser.helpParams.showTerminator = false;
     parser.helpParams.helpindent = 20;
     parser.helpParams.width = 90;


### PR DESCRIPTION
This is embarrassing.

`grep` tells me that this is the only occurrence.
 
Closes #383