### PR TITLE
Simplify baseline comparison on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check for tab characters
         run: "! grep -P -R '\\t' src/ tests/*.{cpp,py}"
 
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -49,7 +49,7 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -67,48 +67,28 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: "echo baseline_commit=$(< tests/baseline-commit.txt) >> $GITHUB_ENV"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ env.baseline_commit }}
-          path: baseline
+          fetch-depth: 0  # Baseline comparison needs older commits
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get install samtools python3-pysam picard-tools
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: brew install samtools pysam picard-tools
-
       - name: Cache test dataset
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: test-data-${{ hashFiles('tests/download.sh') }}
           path: tests/drosophila/
-      - name: Download test dataset
-        run: tests/download.sh
-
       - name: Cache baseline BAM
         id: cache-baseline-bam
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: baseline-bam-${{ hashFiles('tests/baseline-commit.txt') }}
-          path: baseline.bam
-      - name: Generate baseline BAM
-        if: ${{ steps.cache-baseline-bam.outputs.cache-hit != 'true' }}
-        run: |
-          ( cd baseline && cmake -B build )
-          make -j3 -C baseline/build
-          baseline/build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view -o baseline.bam
-
-      - name: Build HEAD version
-        run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          make -j3 -C build
-      - name: Generate HEAD BAM
-        run: build/strobealign tests/drosophila/ref.fasta tests/drosophila/reads.1.fastq.gz tests/drosophila/reads.2.fastq.gz | samtools view -o head.bam
-      - name: Compare
-        run: python3 tests/samdiff.py baseline.bam head.bam
+          path: baseline/bam/
+      - name: Compare to baseline
+        run: tests/compare-baseline.sh
       - name: Validate with Picard
         run: |
           PicardCommandLine ValidateSamFile IGNORE=RECORD_MISSING_READ_GROUP IGNORE=MISSING_READ_GROUP I=head.bam

--- a/tests/compare-baseline.sh
+++ b/tests/compare-baseline.sh
@@ -35,18 +35,18 @@ tests/download.sh
 
 baseline_commit=$(< tests/baseline-commit.txt)
 
-baseline_bam=baseline/baseline-${baseline_commit}.${ends}.bam
+baseline_bam=baseline/bam/${baseline_commit}.${ends}.bam
 baseline_binary=baseline/strobealign-${baseline_commit}
 cmake_options=-DCMAKE_BUILD_TYPE=RelWithDebInfo
 strobealign_options="-t 4"
 
 # Generate the baseline BAM if necessary
-mkdir -p baseline
+mkdir -p baseline/bam
 if ! test -f ${baseline_bam}; then
   if ! test -f ${baseline_binary}; then
     srcdir=$(mktemp -p . -d compile.XXXXXXX)
     git clone . ${srcdir}
-    ( cd ${srcdir} && git checkout ${baseline_commit} )
+    ( cd ${srcdir} && git checkout -d ${baseline_commit} )
     cmake ${srcdir} -B ${srcdir}/build ${cmake_options}
     if ! make -j 4 -C ${srcdir}/build strobealign; then
       exit 1


### PR DESCRIPTION
Do not let GitHub Actions do the work, but rely on the baseline comparison script. Only ensure caches are filled before starting it.

This reduces a little bit of code in the GitHub Actions workflow file (reduces essentially duplicate code).

We will only be able to see whether retrieving the cached baseline file works correctly on the next PR.