### PR TITLE
Explicit error if too many sequences are used

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "timer.hpp"
 #include "readlen.hpp"
 #include "version.hpp"
+#include "randstrobes.hpp"
 #include "buildconfig.hpp"
 
 
@@ -207,6 +208,10 @@ int run_strobealign(int argc, char **argv) {
         << (*std::max_element(references.lengths.begin(), references.lengths.end()) / 1E6) << " Mbp)\n";
     if (references.total_length() == 0) {
         throw InvalidFasta("No reference sequences found");
+    }
+
+    if (references.size() > RefRandstrobe::max_number_of_references) {
+        throw InvalidFasta("Too many reference sequences. Current maximum is " + std::to_string(RefRandstrobe::max_number_of_references));
     }
 
     StrobemerIndex index(references, index_parameters, opt.bits);

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -41,10 +41,14 @@ struct RefRandstrobe {
         return m_packed & mask;
     }
 
+
 private:
     static constexpr int bit_alloc = 8;
     static constexpr int mask = (1 << bit_alloc) - 1;
     packed_t m_packed; // packed representation of ref_index and strobe offset
+
+public:
+    static constexpr uint32_t max_number_of_references = (1 << (32 - bit_alloc)) - 1;
 };
 
 struct QueryRandstrobe {


### PR DESCRIPTION
Right now, strobealign only supports up to 2²⁴ sequences. If the user tries more, it would silently accept it, but later crash.