### PR TITLE
Make index creation deterministic

### DIFF
--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -34,8 +34,8 @@ struct RefRandstrobe {
         // RefRandstrobes in the index is reproducible no matter which sorting
         // function is used. This branchless comparison is faster than the
         // equivalent one using std::tie.
-        __uint128_t lhs = (static_cast<__uint128_t>(hash) << 64) | position;
-        __uint128_t rhs = (static_cast<__uint128_t>(other.hash) << 64) | other.position;
+        __uint128_t lhs = (static_cast<__uint128_t>(hash) << 64) | ((static_cast<uint64_t>(position) << 32) | m_packed);
+        __uint128_t rhs = (static_cast<__uint128_t>(other.hash) << 64) | ((static_cast<uint64_t>(other.position) << 32) | m_packed);
         return lhs < rhs;
     }
 


### PR DESCRIPTION
By ensuring randstrobes are sorted by all their fields.

I thought that the comparison function I added in #386 (commit 2e4ff9500e68d6e465735dd276d362cf71851dcd) was good enough, but now that I ran on some other datasets that I hadn’t used for testing previously, it became apparent that that’s not the case because I was getting non-reproducible results.

This slows down index creation again a little bit (now takes ~61s instead of ~60s for CHM13), but it’s still a lot faster than before parallel sorting.