### PR TITLE
Version 0.13.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## development version
 
+* #394: Added option `--aemb` (abundance estimation for metagenomic binning),
+  which makes strobealign output a table with estimated abundance values for
+  each contig (instead of SAM or PAF). This was contributed by Shaojun Pan
+  (@psj1997).
 * #386: Parallelize indexing even more by using @alugowski’s
   [poolSTL](https://github.com/alugowski/) `pluggable_sort`.
   Indexing a human reference (measured on CHM13) now takes only ~45 s on a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Strobealign Changelog
 
-## development version
+## v0.13.0 (2024-03-04)
 
 * #394: Added option `--aemb` (abundance estimation for metagenomic binning),
   which makes strobealign output a table with estimated abundance values for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(strobealign VERSION 0.12.0)
+project(strobealign VERSION 0.13.0)
 include(FetchContent)
 
 option(ENABLE_AVX "Enable AVX2 support" OFF)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If needed, run `make` with `VERBOSE=1` to get more logging output.
 After CMake has been run, you can use this one-liner to compile strobealign and
 run the tests:
 ```
-make -j -C build && tests/run.sh
+make -s -j -C build && tests/run.sh
 ```
 
 Whenever you make changes that could potentially affect mapping results, you can

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="strobealign",
     description="Python bindings for strobealign",
     license="MIT",
-    version="0.12.0",
+    version="0.13.0",
     packages=["strobealign"],
     package_dir={"": "src/python"},
     cmake_install_dir="src/python",


### PR DESCRIPTION
- Streamline "Usage" section in README
- Make the three output modes (alignment, mapping only, aemb) clearer
- Add `--aemb` to changelog
- Bump version to 0.13.0
