### PR TITLE
Set default number of threads to 1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Strobealign Changelog
 
+## development version
+
+* #401: The default number of threads is now 1 instead of 3.
+
 ## v0.13.0 (2024-03-04)
 
 * #394: Added option `--aemb` (abundance estimation for metagenomic binning),

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -19,7 +19,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::ActionFlag version(parser, "version", "Print version and exit", {"version"}, []() { throw Version(); });
 
     // Threading
-    args::ValueFlag<int> threads(parser, "INT", "Number of threads [3]", {'t', "threads"});
+    args::ValueFlag<int> threads(parser, "INT", "Number of threads [1]", {'t', "threads"});
     args::ValueFlag<int> chunk_size(parser, "INT", "Number of reads processed by a worker thread at once [10000]", {"chunk-size"}, args::Options::Hidden);
 
     args::Group io(parser, "Input/output:");

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -6,7 +6,7 @@
 #include <utility>
 
 struct CommandLineOptions {
-    int n_threads { 3 };
+    int n_threads { 1 };
     int chunk_size { 10000 };
 
     // Input/output

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -316,7 +316,14 @@ int run_strobealign(int argc, char **argv) {
 
     std::vector<AlignmentStatistics> log_stats_vec(opt.n_threads);
     
-    logger.info() << "Running in " << (opt.is_SE ? "single-end" : "paired-end") << " mode" << std::endl;
+    logger.info() << "Processing " << (opt.is_SE ? "single-end" : "paired-end") << " reads ";
+    if (map_param.output_format == OutputFormat::PAF) {
+        logger.info() << "in mapping-only mode ";
+    }
+    if (map_param.output_format == OutputFormat::Abundance) {
+        logger.info() << "in abundance estimation mode ";
+    }
+    logger.info() << "using " << opt.n_threads << " worker thread" << (opt.n_threads != 1 ? "s" : "") << std::endl;
 
     OutputBuffer output_buffer(out);
     std::vector<std::thread> workers;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -323,7 +323,7 @@ int run_strobealign(int argc, char **argv) {
     if (map_param.output_format == OutputFormat::Abundance) {
         logger.info() << "in abundance estimation mode ";
     }
-    logger.info() << "using " << opt.n_threads << " worker thread" << (opt.n_threads != 1 ? "s" : "") << std::endl;
+    logger.info() << "using " << opt.n_threads << " thread" << (opt.n_threads != 1 ? "s" : "") << std::endl;
 
     OutputBuffer output_buffer(out);
     std::vector<std::thread> workers;


### PR DESCRIPTION
Also, adjusted logging output to make it more obvious how many threads are used (and which mode). Example:

```
...
Total time indexing: 3.79 s
Processing paired-end reads in mapping-only mode using 1 worker thread
 Mapped         1.00 M reads @    11.02 us/read
Done!
```
Other example messages:
```
Processing single-end reads in abundance estimation mode using 4 worker threads
...
Processing single-end reads using 4 worker threads
```

Closes #401