### PR TITLE
Experiment: Asymmetric randstrobe hashes

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -972,6 +972,11 @@ void align_or_map_paired(
         // Find NAMs
         Timer nam_timer;
         auto [nonrepetitive_fraction, nams] = find_nams(query_randstrobes, index);
+
+        if (nams.empty()) {
+            query_randstrobes = randstrobes_query_rescue(record.seq, index_parameters);
+            std::tie(nonrepetitive_fraction, nams) = find_nams(query_randstrobes, index);
+        }
         statistics.tot_find_nams += nam_timer.duration();
 
         if (map_param.rescue_level > 1) {
@@ -1092,6 +1097,12 @@ void align_or_map_single(
     // Find NAMs
     Timer nam_timer;
     auto [nonrepetitive_fraction, nams] = find_nams(query_randstrobes, index);
+
+    if (nams.empty()) {
+        query_randstrobes = randstrobes_query_rescue(record.seq, index_parameters);
+        std::tie(nonrepetitive_fraction, nams) = find_nams(query_randstrobes, index);
+    }
+
     statistics.tot_find_nams += nam_timer.duration();
 
     if (map_param.rescue_level > 1) {

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -973,10 +973,6 @@ void align_or_map_paired(
         Timer nam_timer;
         auto [nonrepetitive_fraction, nams] = find_nams(query_randstrobes, index);
 
-        if (nams.empty()) {
-            query_randstrobes = randstrobes_query_rescue(record.seq, index_parameters);
-            std::tie(nonrepetitive_fraction, nams) = find_nams(query_randstrobes, index);
-        }
         statistics.tot_find_nams += nam_timer.duration();
 
         if (map_param.rescue_level > 1) {
@@ -984,6 +980,10 @@ void align_or_map_paired(
             if (nams.empty() || nonrepetitive_fraction < 0.7) {
                 nams = find_nams_rescue(query_randstrobes, index, map_param.rescue_cutoff);
                 details[is_revcomp].nam_rescue = true;
+                if (nams.empty()) {
+                    query_randstrobes = randstrobes_query_rescue(record.seq, index_parameters);
+                    std::tie(nonrepetitive_fraction, nams) = find_nams(query_randstrobes, index);
+                }
             }
             statistics.tot_time_rescue += rescue_timer.duration();
         }
@@ -1098,11 +1098,6 @@ void align_or_map_single(
     Timer nam_timer;
     auto [nonrepetitive_fraction, nams] = find_nams(query_randstrobes, index);
 
-    if (nams.empty()) {
-        query_randstrobes = randstrobes_query_rescue(record.seq, index_parameters);
-        std::tie(nonrepetitive_fraction, nams) = find_nams(query_randstrobes, index);
-    }
-
     statistics.tot_find_nams += nam_timer.duration();
 
     if (map_param.rescue_level > 1) {
@@ -1110,6 +1105,10 @@ void align_or_map_single(
         if (nams.empty() || nonrepetitive_fraction < 0.7) {
             details.nam_rescue = true;
             nams = find_nams_rescue(query_randstrobes, index, map_param.rescue_cutoff);
+            if (nams.empty()) {
+                query_randstrobes = randstrobes_query_rescue(record.seq, index_parameters);
+                std::tie(nonrepetitive_fraction, nams) = find_nams(query_randstrobes, index);
+            }
         }
         statistics.tot_time_rescue += rescue_timer.duration();
     }

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -45,8 +45,10 @@ static inline syncmer_hash_t syncmer_smer_hash(uint64_t packed) {
     return xxh64(packed);
 }
 
-static inline randstrobe_hash_t randstrobe_hash(syncmer_hash_t hash1, syncmer_hash_t hash2) {
-    return hash1 + hash2;
+static inline randstrobe_hash_t randstrobe_hash(syncmer_hash_t syncmer1_hash, syncmer_hash_t syncmer2_hash) {
+    // alternative:
+    // (syncmer1_hash << 1) ^ syncmer2_hash
+    return 2 * syncmer1_hash - syncmer2_hash;
 }
 
 std::ostream& operator<<(std::ostream& os, const Syncmer& syncmer) {

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -69,6 +69,7 @@ std::ostream& operator<<(std::ostream& os, const QueryRandstrobe& randstrobe);
 using QueryRandstrobeVector = std::vector<QueryRandstrobe>;
 
 QueryRandstrobeVector randstrobes_query(const std::string_view seq, const IndexParameters& parameters);
+QueryRandstrobeVector randstrobes_query_rescue(const std::string_view seq, const IndexParameters& parameters);
 
 struct Randstrobe {
     randstrobe_hash_t hash;


### PR DESCRIPTION
I’ve written about this by e-mail, but thought I’d show the code as well and a table that shows a comparison of accuracies.

This PR includes two commits.

The first commit 7ca428d changes the formula for computing randstrobe hashes from `syncmer1_hash + syncmer2_hash` to `2 * syncmer1_hash - syncmer2_hash`. Factor 2 is used to avoid a hash of zero when the two syncmer hashes are identical. This is the case at the end of the query when the syncmer is paired with itself due to there not being any downstream syncmers.

The second commit 1960bef introduces a "randstrobe rescue" step where (if no hits can be found), syncmers are paired up with all downstream syncmers between `w_min` and `w_max` to produce a set of hashes to look up in the index.

Here are the measured differences in accuracy, with some notable rows highlighted.

* d420610 was used as the baseline
* 7ca428d switches to asymmetric randstrobe hashes
* 1960bef adds randstrobe rescue (should probably be renamed as the things that are generated aren’t randstrobes)

dataset           | d420610 → 7ca428d | d420610 → 1960bef | 7ca428d → 1960bef
-|-|-|-                                                        
ecoli50-150-se    | -0.0161 | -0.0557 | -0.0396
**drosophila-50-se**  | -0.3709 | +0.0190 | +0.3899
**drosophila-75-se**  | -0.1181 | +0.0280 | +0.1461
**drosophila-100-se** | -0.0397 | +0.0453 | +0.0850
drosophila-150-se | -0.0811 | -0.0233 | +0.0578
drosophila-200-se | -0.0008 | +0.0158 | +0.0166
drosophila-300-se | -0.0386 | -0.0433 | -0.0047
drosophila-500-se | -0.0075 | -0.0075 | +0.0000
**maize-50-se**       | -0.1577 | -0.0169 | +0.1408
**maize-75-se**       | -0.1429 | -0.0998 | +0.0431
**maize-100-se**      | -0.1776 | -0.1009 | +0.0767
maize-150-se      | +0.0154 | +0.0084 | -0.0070
maize-200-se      | +0.0098 | +0.0183 | +0.0085
maize-300-se      | +0.0300 | +0.0302 | +0.0002
maize-500-se      | +0.0116 | +0.0040 | -0.0076
**CHM13-50-se**       | -0.2992 | +0.0183 | +0.3175
CHM13-75-se       | -0.0809 | +0.0153 | +0.0962
CHM13-100-se      | -0.1053 | -0.0227 | +0.0826
CHM13-150-se      | -0.0910 | -0.0567 | +0.0343
CHM13-200-se      | -0.0844 | -0.0769 | +0.0075
CHM13-300-se      | -0.1574 | -0.1423 | +0.0151
CHM13-500-se      | -0.2339 | -0.2445 | -0.0106
ecoli50-150-pe    | -0.0187 | -0.0409 | -0.0222
drosophila-50-pe  | -0.0283 | +0.0085 | +0.0368
drosophila-75-pe  | -0.0117 | -0.0386 | -0.0268
drosophila-100-pe | -0.0137 | -0.0131 | +0.0006
drosophila-150-pe | -0.0294 | +0.0089 | +0.0383
drosophila-200-pe | -0.0372 | -0.0232 | +0.0140
drosophila-300-pe | -0.0218 | -0.0276 | -0.0058
drosophila-500-pe | -0.0312 | -0.0294 | +0.0018
maize-50-pe       | +0.0389 | -0.0417 | -0.0806
**maize-75-pe**       | -0.0629 | -0.1999 | -0.1370
**maize-100-pe**      | -0.0647 | -0.1508 | -0.0862
maize-150-pe      | -0.0206 | -0.0398 | -0.0192
maize-200-pe      | +0.0066 | +0.0002 | -0.0063
maize-300-pe      | -0.0037 | +0.0070 | +0.0106
maize-500-pe      | -0.0178 | -0.0267 | -0.0090
CHM13-50-pe       | -0.0413 | -0.0369 | +0.0044
CHM13-75-pe       | -0.0695 | -0.0795 | -0.0099
CHM13-100-pe      | -0.1190 | -0.1280 | -0.0090
CHM13-150-pe      | -0.1320 | -0.1410 | -0.0090
**CHM13-200-pe**      | -0.1575 | -0.1429 | +0.0146
**CHM13-300-pe**      | -0.2974 | -0.3209 | -0.0235
**CHM13-500-pe**      | -0.3394 | -0.3449 | -0.0054


