### PR TITLE
Better fix for #409

### DIFF
--- a/src/refs.cpp
+++ b/src/refs.cpp
@@ -1,5 +1,4 @@
 #include <vector>
-#include <set>
 #include <fstream>
 #include <sstream>
 #include <algorithm>
@@ -18,62 +17,10 @@ void to_uppercase(std::string& s) {
 
 namespace {
 
-/* Following the SAM specification, section 1.2.1,
-   return true if a given character is allowed in a reference sequence name. */
-bool is_rname_char(char c) {
-    // The specification uses:
-    //      [0-9A-Za-z!#$%&*+./:;=?@^_|~-]
-
-    if ('0' <= c && c <= '9') {
-        return true;
-    }
-    if ('A' <= c && c <= 'Z') {
-        return true;
-    }
-    if ('a' <= c && c <= 'z') {
-        return true;
-    }
-    static constexpr auto other = "!#$%&*+./:;=?@^_|~-";
-    for (auto p = other; *p; ++p) {
-        if (c == *p) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/* Following the SAM specification, section 1.2.1,
-   return true if the given character is allowed at the start of a reference sequence name */
-bool is_rname_start_char(char c) {
-    return is_rname_char(c) && c != '*' && c != '=';
-}
-
-/* Return the longest prefix of the given string that satisfies the SAM specification
-   rules for sequence names. */
-std::string get_rname_prefix(std::string::const_iterator begin, std::string::const_iterator end) {
-    if (begin == end) {
-        return std::string{};
-    }
-    if (!is_rname_start_char(*begin)) {
-        return std::string{};
-    }
-    for (auto itr = begin + 1; itr != end; ++itr) {
-        if (!is_rname_char(*itr)) {
-            std::string res;
-            res.insert(res.end(), begin, itr);
-            return res;
-        }
-    }
-    std::string res;
-    res.insert(res.end(), begin, end);
-    return res;
-}
-
 template <typename T>
 References references_from_stream(T& stream) {
     std::vector<std::string> sequences;
     std::vector<std::string> names;
-    std::set<std::string> seen_names;
 
     if (!stream.good()) {
         throw InvalidFasta("Cannot read from FASTA file");
@@ -89,31 +36,16 @@ References references_from_stream(T& stream) {
 
     std::string line, seq, name;
     bool eof = false;
-    size_t line_num = 0;
     do {
-        line_num += 1;
         eof = !bool{getline(stream, line)};
         if (eof || (!line.empty() && line[0] == '>')) {
             if (seq.length() > 0) {
                 to_uppercase(seq);
                 sequences.push_back(seq);
                 names.push_back(name);
-                seen_names.insert(name);
             }
             if (!eof) {
-                name = get_rname_prefix(line.begin() + 1, line.end());
-                if (name.size() == 0) {
-                    std::ostringstream oss;
-                    oss << "Cannot extract a valid reference sequence name at line "
-                        << line_num;
-                    throw InvalidFasta(oss.str().c_str());
-                }
-                if (seen_names.count(name)) {
-                    std::ostringstream oss;
-                    oss << "Duplicate reference sequence name '"
-                        << name << "' at line " << line_num;
-                    throw InvalidFasta(oss.str().c_str());
-                }
+                name = line.substr(1, line.find(' ') - 1); // cut at first space
             }
             seq = "";
         } else {

--- a/src/refs.cpp
+++ b/src/refs.cpp
@@ -1,4 +1,5 @@
 #include <vector>
+#include <set>
 #include <fstream>
 #include <sstream>
 #include <algorithm>
@@ -17,10 +18,62 @@ void to_uppercase(std::string& s) {
 
 namespace {
 
+/* Following the SAM specification, section 1.2.1,
+   return true if a given character is allowed in a reference sequence name. */
+bool is_rname_char(char c) {
+    // The specification uses:
+    //      [0-9A-Za-z!#$%&*+./:;=?@^_|~-]
+
+    if ('0' <= c && c <= '9') {
+        return true;
+    }
+    if ('A' <= c && c <= 'Z') {
+        return true;
+    }
+    if ('a' <= c && c <= 'z') {
+        return true;
+    }
+    static constexpr auto other = "!#$%&*+./:;=?@^_|~-";
+    for (auto p = other; *p; ++p) {
+        if (c == *p) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Following the SAM specification, section 1.2.1,
+   return true if the given character is allowed at the start of a reference sequence name */
+bool is_rname_start_char(char c) {
+    return is_rname_char(c) && c != '*' && c != '=';
+}
+
+/* Return the longest prefix of the given string that satisfies the SAM specification
+   rules for sequence names. */
+std::string get_rname_prefix(std::string::const_iterator begin, std::string::const_iterator end) {
+    if (begin == end) {
+        return std::string{};
+    }
+    if (!is_rname_start_char(*begin)) {
+        return std::string{};
+    }
+    for (auto itr = begin + 1; itr != end; ++itr) {
+        if (!is_rname_char(*itr)) {
+            std::string res;
+            res.insert(res.end(), begin, itr);
+            return res;
+        }
+    }
+    std::string res;
+    res.insert(res.end(), begin, end);
+    return res;
+}
+
 template <typename T>
 References references_from_stream(T& stream) {
     std::vector<std::string> sequences;
     std::vector<std::string> names;
+    std::set<std::string> seen_names;
 
     if (!stream.good()) {
         throw InvalidFasta("Cannot read from FASTA file");
@@ -36,16 +89,31 @@ References references_from_stream(T& stream) {
 
     std::string line, seq, name;
     bool eof = false;
+    size_t line_num = 0;
     do {
+        line_num += 1;
         eof = !bool{getline(stream, line)};
         if (eof || (!line.empty() && line[0] == '>')) {
             if (seq.length() > 0) {
                 to_uppercase(seq);
                 sequences.push_back(seq);
                 names.push_back(name);
+                seen_names.insert(name);
             }
             if (!eof) {
-                name = line.substr(1, line.find(' ') - 1); // cut at first space
+                name = get_rname_prefix(line.begin() + 1, line.end());
+                if (name.size() == 0) {
+                    std::ostringstream oss;
+                    oss << "Cannot extract a valid reference sequence name at line "
+                        << line_num;
+                    throw InvalidFasta(oss.str().c_str());
+                }
+                if (seen_names.count(name)) {
+                    std::ostringstream oss;
+                    oss << "Duplicate reference sequence name '"
+                        << name << "' at line " << line_num;
+                    throw InvalidFasta(oss.str().c_str());
+                }
             }
             seq = "";
         } else {


### PR DESCRIPTION
I've reworked the change I proposed earlier to use `std::regex` which makes it neater.

It now splits on whitespace, then checks that the name is SAM-compatible.