### PR TITLE
Get rid of the last compiler warning

### DIFF
--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -45,7 +45,7 @@ void merge_hits_into_nams(
         }
 
         std::vector<Nam> open_nams;
-        unsigned int prev_q_start = 0;
+        int prev_q_start = 0;
         for (auto &h : hits) {
             bool is_added = false;
             for (auto & o : open_nams) {


### PR DESCRIPTION
It would be more correct to convert all start and end coordinates on query and reference to unsigned, but this is a much smaller change and should do for now.

```
warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
   99 |             if (h.query_start > prev_q_start + k) {
      |                 ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```