### PR TITLE
Decompress with ISA-L

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install isa-l
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install isa-l
       - name: Build
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -54,6 +60,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install isa-l
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install isa-l
       - name: Install Python dependencies
         run: pip install pytest
       - name: Install Python bindings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install isa-l
+        run: sudo apt-get install libisal-dev
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: brew install isa-l
@@ -62,7 +62,7 @@ jobs:
           python-version: "3.10"
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install isa-l
+        run: sudo apt-get install libisal-dev
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: brew install isa-l
@@ -84,10 +84,10 @@ jobs:
           fetch-depth: 0  # Baseline comparison needs older commits
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install samtools python3-pysam picard-tools
+        run: sudo apt-get install samtools python3-pysam picard-tools libisal-dev
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
-        run: brew install samtools pysam picard-tools
+        run: brew install samtools pysam picard-tools isa-l
       - name: Cache test dataset
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install Linux dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,8 @@ jobs:
       - name: Build
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          cd build
-          make -j3
-          make install
+          cmake --build build -j 3
+          cmake --install build
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: sudo apt-get install samtools
@@ -48,6 +47,25 @@ jobs:
         run: brew install samtools
       - name: Run
         run: tests/run.sh
+
+  # Test building with a downloaded ISA-L
+  externalisal:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install nasm
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install nasm
+      - uses: actions/checkout@v4
+      - name: Build
+        run: |
+          cmake -B build -DISAL=download
+          cmake --build build -j3
 
   pythonbindings:
     if: >-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 * #401: The default number of threads is now 1 instead of 3.
 * #409: Ensure reference names are unique and conform to the SAM
   specification. Contributed by @drtconway in PR #411.
+* #269, #418: Decompress .gz files with ISA-L, which is about three
+  times faster than zlib. This is particularly relevant when using
+  strobealign with many threads (more than about 30), where decompressing
+  the input was the bottleneck before. Initially contributed by @telmin.
 
 ## v0.13.0 (2024-03-04)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,14 @@
 * #401: The default number of threads is now 1 instead of 3.
 * #409: Ensure reference names are unique and conform to the SAM
   specification. Contributed by @drtconway in PR #411.
-* #269, #418: Decompress .gz files with ISA-L, which is about three
-  times faster than zlib. This is particularly relevant when using
-  strobealign with many threads (more than about 30), where decompressing
-  the input was the bottleneck before. Initially contributed by @telmin.
+* #269, #418: Strobealign scales now much better to systems with many cores.
+  Previously, decompressing gzipped-compressed input files was a bottleneck
+  starting at about 30 threads.
+  We now use [ISA-L](https://github.com/intel/isa-l/) for decompression,
+  which is about three times as fast as zlib, and decompression is also done in
+  a separate thread. We tested up to 128 cores, and strobealign was still
+  able to use all cores.
+  Contributed by @telmin.
 
 ## v0.13.0 (2024-03-04)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,14 +74,21 @@ add_library(salib STATIC ${SOURCES}
 if(ISAL STREQUAL "system")
   pkg_check_modules(ISAL IMPORTED_TARGET GLOBAL libisal>=2.30.0)
   if (NOT ISAL_FOUND)
-    message(FATAL_ERROR "libisal (ISA-L) could not be found. Either install "
-        "the library using your package manager or add '-DISAL=download' to "
+    message(FATAL_ERROR "libisal (ISA-L) could not be found. You have two options:\n"
+        "- Install the library using your package manager (try 'sudo apt install "
+        "libisal-dev' or 'brew install isa-l')\n"
+        "- or add '-DISAL=download' to "
         "the CMake options in order to download ISA-L at build time."
       )
   endif()
   add_library(ISAL ALIAS PkgConfig::ISAL)
 elseif(ISAL STREQUAL "download")
-  find_program(NASM_program NAMES nasm REQUIRED)
+  find_program(NASM NAMES nasm)
+  if (NASM STREQUAL NASM-NOTFOUND)
+    message(FATAL_ERROR "NASM is required to build ISA-L. Try 'sudo apt "
+        "install nasm' or 'brew install nasm'"
+    )
+  endif()
   set(ISAL_ROOT ${CMAKE_BINARY_DIR}/ISAL)
   ExternalProject_Add(
     isal_external

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(TRACE "Highly verbose debugging output" OFF)
 find_package(ZLIB)
 find_package(Threads)
 find_package(OpenMP)
+find_package(PkgConfig REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -61,12 +62,14 @@ add_library(salib STATIC ${SOURCES}
   src/version.cpp
   src/io.cpp
   src/insertsizedistribution.cpp
+  src/iowrap.cpp
   ext/xxhash.c
   ext/ssw/ssw_cpp.cpp
   ext/ssw/ssw.c
 )
+pkg_check_modules(ISAL REQUIRED IMPORTED_TARGET GLOBAL libisal>=2.30.0)
 target_include_directories(salib PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
-target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr)
+target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr PkgConfig::ISAL)
 IF(ENABLE_AVX)
   target_compile_options(salib PUBLIC "-mavx2")
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(strobealign VERSION 0.13.0)
 include(FetchContent)
+include(ExternalProject)
 
 option(ENABLE_AVX "Enable AVX2 support" OFF)
 option(PYTHON_BINDINGS "Build Python bindings" OFF)
@@ -23,6 +24,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
     "RelWithDebInfo" "Debug" "Release")
 endif()
+
+set(ISAL "system" CACHE STRING "Where to find ISA-L: system (uses pkg-config), download (at build time)")
+set_property(CACHE ISAL PROPERTY STRINGS "system" "download")
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 add_compile_options(-Wall -Wextra -Werror=maybe-uninitialized)
@@ -67,9 +71,38 @@ add_library(salib STATIC ${SOURCES}
   ext/ssw/ssw_cpp.cpp
   ext/ssw/ssw.c
 )
-pkg_check_modules(ISAL REQUIRED IMPORTED_TARGET GLOBAL libisal>=2.30.0)
+if(ISAL STREQUAL "system")
+  pkg_check_modules(ISAL IMPORTED_TARGET GLOBAL libisal>=2.30.0)
+  if (NOT ISAL_FOUND)
+    message(FATAL_ERROR "libisal (ISA-L) could not be found. Either install "
+        "the library using your package manager or add '-DISAL=download' to "
+        "the CMake options in order to download ISA-L at build time."
+      )
+  endif()
+  add_library(ISAL ALIAS PkgConfig::ISAL)
+elseif(ISAL STREQUAL "download")
+  find_program(NASM_program NAMES nasm REQUIRED)
+  set(ISAL_ROOT ${CMAKE_BINARY_DIR}/ISAL)
+  ExternalProject_Add(
+    isal_external
+    GIT_REPOSITORY https://github.com/intel/isa-l
+    GIT_TAG v2.30.0
+    BUILD_COMMAND make -f Makefile.unx
+    CONFIGURE_COMMAND ""
+    INSTALL_DIR ${ISAL_ROOT}
+    INSTALL_COMMAND make -f Makefile.unx install prefix=<INSTALL_DIR>
+    BUILD_IN_SOURCE ON
+  )
+  target_include_directories(salib PUBLIC "${ISAL_ROOT}/include")
+  add_library(ISAL STATIC IMPORTED)
+  set_target_properties(ISAL PROPERTIES IMPORTED_LOCATION ${ISAL_ROOT}/lib/libisal.a)
+  add_dependencies(salib isal_external)
+#elseif(ISAL STREQUAL "off")
+#  message(FATAL_ERROR "Building without ISA-L support is currently not supported")
+endif()
+
 target_include_directories(salib PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
-target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr PkgConfig::ISAL)
+target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr ISAL)
 IF(ENABLE_AVX)
   target_compile_options(salib PUBLIC "-mavx2")
 ENDIF()

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ Strobealign is available from [Bioconda](https://bioconda.github.io/).
 ### From source
 
 To compile from the source, you need CMake,
-a recent `g++` (tested with version 8), [zlib](https://zlib.net/) and
+a recent `g++` (tested with version 8), [zlib](https://zlib.net/), `pkg-config` and
 [ISA-L](https://github.com/intel/isa-l/) (Intel Intelligent Storage Acceleration Library).
 On Debian/Ubuntu,
 running `sudo apt-get install build-essential libisal-dev cmake` should take care of this.
+On macOS, use `brew install pkg-config isa-l`.
 
 Then do the following:
 ```

--- a/README.md
+++ b/README.md
@@ -56,13 +56,18 @@ Strobealign is available from [Bioconda](https://bioconda.github.io/).
 
 ### From source
 
-To compile from the source, you need to have CMake, a recent `g++` (tested with version 8) and [zlib](https://zlib.net/) installed.
+To compile from the source, you need CMake,
+a recent `g++` (tested with version 8), [zlib](https://zlib.net/) and
+[ISA-L](https://github.com/intel/isa-l/) (Intel Intelligent Storage Acceleration Library).
+On Debian/Ubuntu,
+running `sudo apt-get install build-essential libisal-dev cmake` should take care of this.
+
 Then do the following:
 ```
 git clone https://github.com/ksahlin/strobealign
 cd strobealign
 cmake -B build -DCMAKE_C_FLAGS="-march=native" -DCMAKE_CXX_FLAGS="-march=native"
-make -j -C build
+cmake --build build -j $(nproc)
 ```
 The resulting binary is `build/strobealign`.
 

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -31,7 +31,7 @@ namespace {
         if(is_gzip(filename)) {
             io = std::make_unique<IsalGzipReader>(filename);
         } else if(is_raw(filename)) {
-            io = std::make_unique<UncompressReader>(filename);
+            io = std::make_unique<UncompressedReader>(filename);
         } else {
             io = std::make_unique<GzipReader>(filename);
         }

--- a/src/fastq.cpp
+++ b/src/fastq.cpp
@@ -15,14 +15,9 @@ namespace {
         return false;
     }
 
-    inline bool is_gzip(const std::string& filename)
+    bool is_gzip(const std::string& filename)
     {
         return check_ext(filename, ".gz");
-    }
-
-    inline bool is_raw(const std::string& filename)
-    {
-        return check_ext(filename, ".fq") || check_ext(filename, ".fastq");
     }
 
     std::unique_ptr<Reader> make_reader(const std::string& filename)
@@ -30,10 +25,8 @@ namespace {
         std::unique_ptr<Reader> io;
         if(is_gzip(filename)) {
             io = std::make_unique<IsalGzipReader>(filename);
-        } else if(is_raw(filename)) {
-            io = std::make_unique<UncompressedReader>(filename);
         } else {
-            io = std::make_unique<GzipReader>(filename);
+            io = std::make_unique<UncompressedReader>(filename);
         }
         return io;
     }

--- a/src/fastq.hpp
+++ b/src/fastq.hpp
@@ -7,6 +7,8 @@
 #include "exceptions.hpp"
 #include "kseq++/kseq++.hpp"
 
+#include "iowrap.hpp"
+
 // File that can be rewound (once only!)
 class RewindableFile {
 
@@ -23,7 +25,7 @@ public:
     void rewind();
 
 protected:
-    gzFile file;
+    std::unique_ptr<Reader> file;
     std::vector<std::vector<unsigned char>> saved_buffer;
     // if rewindable is false, the file cannot be rewound anymore and is consuming from saved_buffer (if it is not empty)
     bool rewindable;

--- a/src/fastq.hpp
+++ b/src/fastq.hpp
@@ -25,7 +25,7 @@ public:
     void rewind();
 
 protected:
-    std::unique_ptr<Reader> file;
+    std::unique_ptr<Reader> reader;
     std::vector<std::vector<unsigned char>> saved_buffer;
     // if rewindable is false, the file cannot be rewound anymore and is consuming from saved_buffer (if it is not empty)
     bool rewindable;

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -25,14 +25,9 @@ void UncompressedReader::open(const std::string& filename) {
     if (fd < 0) {
         throw InvalidFile("Could not open file: " + filename);
     }
-
-    thread_reader = std::thread(&UncompressedReader::preload, this, preload_size);
 }
 
 void UncompressedReader::close() {
-    if (thread_reader.joinable())
-        thread_reader.join();
-
     if (fd != -1) {
         ::close(fd);
     }
@@ -40,36 +35,7 @@ void UncompressedReader::close() {
 }
 
 int64_t UncompressedReader::read(void* buffer, size_t length) {
-    size_t actual_count = 0;
-    while (length > 0) {
-        size_t size_from_data = std::min(length, read_buffer.size() - read_buffer_copied);
-        memcpy(buffer, read_buffer.data() + read_buffer_copied, size_from_data);
-        buffer = (uint8_t*) buffer + size_from_data;
-        length -= size_from_data;
-        read_buffer_copied += size_from_data;
-        actual_count += size_from_data;
-
-        if (read_buffer_copied == read_buffer.size()) {
-            if (thread_reader.joinable()) {
-                thread_reader.join();
-                std::swap(read_buffer, read_buffer_work);
-                read_buffer_copied = 0;
-                if (read_buffer.size() == 0) {
-                    break;
-                }
-            }
-            thread_reader = std::thread(&UncompressedReader::preload, this, preload_size);
-        }
-    }
-    return actual_count;
-}
-
-void UncompressedReader::preload(size_t size) {
-    read_buffer_work.resize(preload_size);
-    auto actual_size = ::read(fd, read_buffer_work.data(), size);
-    if (actual_size != (decltype(actual_size)) size) {
-        read_buffer_work.resize(actual_size);
-    }
+    return ::read(fd, buffer, length);
 }
 
 void IsalGzipReader::initialize() {

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -1,0 +1,202 @@
+#include "iowrap.hpp"
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <cstring>
+#include <system_error>
+#include "exceptions.hpp"
+
+void GzipReader::open(const std::string& filename) {
+    if (filename != "") {
+        file = gzopen(filename.c_str(), "r");
+        if (file == nullptr) {
+            throw InvalidFile("Could not open FASTQ file: " + filename);
+        }
+    }
+}
+
+int64_t GzipReader::read(void* buffer, size_t length) {
+    return gzread(file, buffer, length);
+}
+
+void UncompressReader::open(const std::string& filename) {
+    fd = ::open(filename.c_str(), 0);
+    if (fd < 0) {
+        throw InvalidFile("Could not open FASTQ file: " + filename);
+    }
+
+    thread_reader = std::thread(&UncompressReader::preload, this, preload_size);
+}
+
+void UncompressReader::close() {
+    if (thread_reader.joinable())
+        thread_reader.join();
+
+    if (fd != -1) {
+        ::close(fd);
+    }
+    fd = -1;
+}
+
+int64_t UncompressReader::read(void* buffer, size_t length) {
+    size_t actual_count = 0;
+    while (length > 0) {
+        size_t size_from_data = std::min(length, read_buffer.size() - read_buffer_copied);
+        memcpy(buffer, read_buffer.data() + read_buffer_copied, size_from_data);
+        buffer = (uint8_t*) buffer + size_from_data;
+        length -= size_from_data;
+        read_buffer_copied += size_from_data;
+        actual_count += size_from_data;
+
+        if (read_buffer_copied == read_buffer.size()) {
+            if (thread_reader.joinable()) {
+                thread_reader.join();
+                std::swap(read_buffer, read_buffer_work);
+                read_buffer_copied = 0;
+                if (read_buffer.size() == 0) {
+                    break;
+                }
+            }
+            thread_reader = std::thread(&UncompressReader::preload, this, preload_size);
+        }
+    }
+    return actual_count;
+}
+
+void UncompressReader::preload(size_t size) {
+    read_buffer_work.resize(preload_size);
+    auto actual_size = ::read(fd, read_buffer_work.data(), size);
+    if (actual_size != (decltype(actual_size)) size) {
+        read_buffer_work.resize(actual_size);
+    }
+}
+
+void IsalGzipReader::initialize() {
+    isal_inflate_init(&state);
+    state.crc_flag = ISAL_GZIP_NO_HDR_VER;
+
+    isal_gzip_header_init(&gz_hdr);
+}
+
+void IsalGzipReader::open(const std::string& filename) {
+    fd = ::open(filename.c_str(), 0);
+    if (fd < 0) {
+        throw InvalidFile("Could not open FASTQ file: " + filename);
+    }
+
+    struct stat _stat;
+    if (fstat(fd, &_stat) < 0) {
+        throw std::system_error(errno, std::generic_category(), filename);
+    }
+    filesize = _stat.st_size;
+
+    mmap_mem = mmap(NULL, filesize, PROT_READ, MAP_SHARED, fd, 0);
+    if (mmap_mem == MAP_FAILED) {
+        mmap_mem = NULL;
+        if (errno == ENODEV) {
+            throw std::system_error(
+                errno, std::generic_category(), "mmap is not supported on this file: " + filename
+            );
+        }
+        if (errno == ENOMEM) {
+            throw std::system_error(
+                errno, std::generic_category(), "There not enough memory to open file: " + filename
+            );
+        } else {
+            throw std::system_error(errno, std::generic_category(), "mmap failed to open file: " + filename);
+        }
+    }
+    mmap_size = filesize;
+    compressed_data = reinterpret_cast<uint8_t*>(mmap_mem);
+    compressed_size = mmap_size;
+
+    // decompress gz header
+    state.next_in = compressed_data;
+    state.avail_in = std::min(decompress_chunk_size, compressed_size);
+    auto pre = state.avail_in;
+
+    int ret = isal_read_gzip_header(&state, &gz_hdr);
+    if (ret != ISAL_DECOMP_OK) {
+        throw std::runtime_error("Invalid gzip header found");
+    }
+    size_t processed_size = pre - state.avail_in;
+    compressed_data += processed_size;
+    compressed_size -= processed_size;
+
+    thread_reader = std::thread(&IsalGzipReader::decompress, this, std::min(decompress_chunk_size, compressed_size));
+}
+
+void IsalGzipReader::close() {
+    if (thread_reader.joinable())
+        thread_reader.join();
+
+    if (mmap_mem != nullptr) {
+        munmap(mmap_mem, mmap_size);
+    }
+    mmap_mem = nullptr;
+    mmap_size = 0;
+
+    if (fd != -1)
+        ::close(fd);
+    fd = -1;
+}
+
+int64_t IsalGzipReader::read(void* buffer, size_t length) {
+    size_t actual_count = 0;
+    while (length > 0) {
+        size_t size_from_data = std::min(length, uncompressed_data.size() - uncompressed_data_copied);
+        memcpy(buffer, uncompressed_data.data() + uncompressed_data_copied, size_from_data);
+        buffer = (uint8_t*) buffer + size_from_data;
+        length -= size_from_data;
+        uncompressed_data_copied += size_from_data;
+        actual_count += size_from_data;
+
+        if (uncompressed_data_copied == uncompressed_data.size()) {
+            if (thread_reader.joinable()) {
+                thread_reader.join();
+                std::swap(uncompressed_data, uncompressed_data_work);
+                uncompressed_data_copied = 0;
+                if (uncompressed_data.size() == 0) {
+                    break;
+                }
+            }
+            thread_reader =
+                std::thread(&IsalGzipReader::decompress, this, std::min(decompress_chunk_size, compressed_size));
+        }
+    }
+    return actual_count;
+}
+
+void IsalGzipReader::decompress(size_t count) {
+    uncompressed_data_work.resize(std::max(count, previous_member_size));
+    uint8_t* ptr = uncompressed_data_work.data();
+
+    while ((uintptr_t) (ptr - uncompressed_data_work.data()) < (uintptr_t) count) {
+        if (compressed_size == 0)
+            break;
+
+        size_t actual_input_size = std::min(decompress_chunk_size, compressed_size);
+        size_t output_size_available = uncompressed_data_work.data() + uncompressed_data_work.size() - ptr;
+
+        state.next_in = compressed_data;
+        state.avail_in = actual_input_size;
+
+        state.next_out = ptr;
+        state.avail_out = output_size_available;
+
+        auto ret = isal_inflate(&state);
+        if (ret != ISAL_DECOMP_OK) {
+            throw std::runtime_error("Error encountered while decompressing");
+        }
+
+        size_t processed = actual_input_size - state.avail_in;
+        size_t decomp = (size_t) (uintptr_t) (state.next_out - ptr);
+
+        compressed_data += processed;
+        compressed_size -= processed;
+        ptr += decomp;
+    }
+    uncompressed_data_work.resize(ptr - uncompressed_data_work.data());
+    previous_member_size = uncompressed_data_work.size();
+}

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -138,7 +138,7 @@ void IsalGzipReader::decompress(size_t count) {
     uncompressed_data_work.resize(std::max(count, previous_member_size));
     uint8_t* ptr = uncompressed_data_work.data();
 
-    while ((uintptr_t) (ptr - uncompressed_data_work.data()) < (uintptr_t) count) {
+    while (state.block_state != ISAL_BLOCK_FINISH && (uintptr_t) (ptr - uncompressed_data_work.data()) < (uintptr_t) count) {
         if (compressed_size == 0)
             break;
 

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -20,16 +20,16 @@ int64_t GzipReader::read(void* buffer, size_t length) {
     return gzread(file, buffer, length);
 }
 
-void UncompressReader::open(const std::string& filename) {
+void UncompressedReader::open(const std::string& filename) {
     fd = ::open(filename.c_str(), 0);
     if (fd < 0) {
         throw InvalidFile("Could not open FASTQ file: " + filename);
     }
 
-    thread_reader = std::thread(&UncompressReader::preload, this, preload_size);
+    thread_reader = std::thread(&UncompressedReader::preload, this, preload_size);
 }
 
-void UncompressReader::close() {
+void UncompressedReader::close() {
     if (thread_reader.joinable())
         thread_reader.join();
 
@@ -39,7 +39,7 @@ void UncompressReader::close() {
     fd = -1;
 }
 
-int64_t UncompressReader::read(void* buffer, size_t length) {
+int64_t UncompressedReader::read(void* buffer, size_t length) {
     size_t actual_count = 0;
     while (length > 0) {
         size_t size_from_data = std::min(length, read_buffer.size() - read_buffer_copied);
@@ -58,13 +58,13 @@ int64_t UncompressReader::read(void* buffer, size_t length) {
                     break;
                 }
             }
-            thread_reader = std::thread(&UncompressReader::preload, this, preload_size);
+            thread_reader = std::thread(&UncompressedReader::preload, this, preload_size);
         }
     }
     return actual_count;
 }
 
-void UncompressReader::preload(size_t size) {
+void UncompressedReader::preload(size_t size) {
     read_buffer_work.resize(preload_size);
     auto actual_size = ::read(fd, read_buffer_work.data(), size);
     if (actual_size != (decltype(actual_size)) size) {

--- a/src/iowrap.cpp
+++ b/src/iowrap.cpp
@@ -11,7 +11,7 @@ void GzipReader::open(const std::string& filename) {
     if (filename != "") {
         file = gzopen(filename.c_str(), "r");
         if (file == nullptr) {
-            throw InvalidFile("Could not open FASTQ file: " + filename);
+            throw InvalidFile("Could not open file: " + filename);
         }
     }
 }
@@ -23,7 +23,7 @@ int64_t GzipReader::read(void* buffer, size_t length) {
 void UncompressedReader::open(const std::string& filename) {
     fd = ::open(filename.c_str(), 0);
     if (fd < 0) {
-        throw InvalidFile("Could not open FASTQ file: " + filename);
+        throw InvalidFile("Could not open file: " + filename);
     }
 
     thread_reader = std::thread(&UncompressedReader::preload, this, preload_size);
@@ -82,7 +82,7 @@ void IsalGzipReader::initialize() {
 void IsalGzipReader::open(const std::string& filename) {
     fd = ::open(filename.c_str(), 0);
     if (fd < 0) {
-        throw InvalidFile("Could not open FASTQ file: " + filename);
+        throw InvalidFile("Could not open file: " + filename);
     }
 
     struct stat _stat;

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -17,7 +17,6 @@ class Reader {
     virtual ~Reader() { }
 
     virtual int64_t read(void* buffer, size_t length) = 0;
-    [[maybe_unused]] virtual std::string name() const = 0;
 
    protected:
     virtual void open(const std::string& filename) = 0;
@@ -34,7 +33,6 @@ class GzipReader : public Reader {
     }
 
     int64_t read(void* buffer, size_t length) override;
-    [[maybe_unused]] std::string name() const override { return "GzipReader"; }
 
    private:
     gzFile file;
@@ -61,7 +59,6 @@ class UncompressedReader : public Reader {
     }
 
     int64_t read(void* buffer, size_t length) override;
-    [[maybe_unused]] std::string name() const override { return "UncompressReader"; }
 
    private:
     int fd;
@@ -107,7 +104,6 @@ class IsalGzipReader : public Reader {
     }
 
     int64_t read(void* buffer, size_t length) override;
-    [[maybe_unused]] std::string name() const override { return "IsalGzipReader"; }
 
    private:
     int fd;

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -41,9 +41,9 @@ class GzipReader : public Reader {
     void open(const std::string& filename) override;
 };
 
-class UncompressReader : public Reader {
+class UncompressedReader : public Reader {
    public:
-    UncompressReader(const std::string& filename)
+    UncompressedReader(const std::string& filename)
         : Reader(filename)
         , fd(-1)
         , preload_size(64ull * 1024 * 1024)
@@ -54,7 +54,7 @@ class UncompressReader : public Reader {
         open(filename);
     }
 
-    virtual ~UncompressReader() {
+    virtual ~UncompressedReader() {
         if (fd != -1) {
             close();
         }

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -44,11 +44,7 @@ class UncompressedReader : public Reader {
     UncompressedReader(const std::string& filename)
         : Reader(filename)
         , fd(-1)
-        , preload_size(64ull * 1024 * 1024)
-        , read_buffer()
-        , read_buffer_work()
-        , read_buffer_copied(0)
-        , thread_reader() {
+    {
         open(filename);
     }
 
@@ -62,16 +58,6 @@ class UncompressedReader : public Reader {
 
    private:
     int fd;
-
-    void preload(size_t size);
-
-    size_t preload_size;
-
-    std::vector<uint8_t> read_buffer;
-    std::vector<uint8_t> read_buffer_work;
-    size_t read_buffer_copied;
-
-    std::thread thread_reader;
 
     void open(const std::string& filename) override;
     void close();

--- a/src/iowrap.hpp
+++ b/src/iowrap.hpp
@@ -1,0 +1,139 @@
+#ifndef STROBEALIGN_IOWRAP_HPP
+#define STROBEALIGN_IOWRAP_HPP
+
+#include <cstdint>
+#include <string>
+
+#include <isa-l/igzip_lib.h>
+#include <zlib.h>
+#include <vector>
+
+#include <thread>
+
+class Reader {
+   public:
+    Reader(const std::string&) { }
+
+    virtual ~Reader() { }
+
+    virtual int64_t read(void* buffer, size_t length) = 0;
+    [[maybe_unused]] virtual std::string name() const = 0;
+
+   protected:
+    virtual void open(const std::string& filename) = 0;
+};
+
+class GzipReader : public Reader {
+   public:
+    GzipReader(const std::string& filename) : Reader(filename), file() { open(filename); }
+
+    virtual ~GzipReader() {
+        if (file) {
+            gzclose(file);
+        }
+    }
+
+    int64_t read(void* buffer, size_t length) override;
+    [[maybe_unused]] std::string name() const override { return "GzipReader"; }
+
+   private:
+    gzFile file;
+    void open(const std::string& filename) override;
+};
+
+class UncompressReader : public Reader {
+   public:
+    UncompressReader(const std::string& filename)
+        : Reader(filename)
+        , fd(-1)
+        , preload_size(64ull * 1024 * 1024)
+        , read_buffer()
+        , read_buffer_work()
+        , read_buffer_copied(0)
+        , thread_reader() {
+        open(filename);
+    }
+
+    virtual ~UncompressReader() {
+        if (fd != -1) {
+            close();
+        }
+    }
+
+    int64_t read(void* buffer, size_t length) override;
+    [[maybe_unused]] std::string name() const override { return "UncompressReader"; }
+
+   private:
+    int fd;
+
+    void preload(size_t size);
+
+    size_t preload_size;
+
+    std::vector<uint8_t> read_buffer;
+    std::vector<uint8_t> read_buffer_work;
+    size_t read_buffer_copied;
+
+    std::thread thread_reader;
+
+    void open(const std::string& filename) override;
+    void close();
+};
+
+class IsalGzipReader : public Reader {
+   public:
+    IsalGzipReader(const std::string& filename)
+        : Reader(filename)
+        , fd(-1)
+        , mmap_mem(nullptr)
+        , filesize(-1)
+        , mmap_size(-1)
+        , uncompressed_data()
+        , uncompressed_data_work()
+        , uncompressed_data_copied(0)
+        , compressed_data(nullptr)
+        , compressed_size(0)
+        , decompress_chunk_size(2ull * 1024 * 1024)
+        , previous_member_size(8ull * 1024 * 1024)
+        , thread_reader() {
+        initialize();
+        open(filename);
+    }
+
+    virtual ~IsalGzipReader() {
+        if (fd != -1) {
+            close();
+        }
+    }
+
+    int64_t read(void* buffer, size_t length) override;
+    [[maybe_unused]] std::string name() const override { return "IsalGzipReader"; }
+
+   private:
+    int fd;
+    void* mmap_mem;
+    ssize_t filesize;
+    ssize_t mmap_size;
+    std::vector<uint8_t> uncompressed_data;
+    std::vector<uint8_t> uncompressed_data_work;
+    size_t uncompressed_data_copied;
+
+    uint8_t* compressed_data;
+    size_t compressed_size;
+
+    size_t decompress_chunk_size;
+    size_t previous_member_size;
+
+    std::thread thread_reader;
+
+    inflate_state state;
+    isal_gzip_header gz_hdr;
+
+    void initialize();
+    void open(const std::string& filename) override;
+    void close();
+
+    void decompress(size_t count);
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,8 +170,8 @@ int run_strobealign(int argc, char **argv) {
     if (!opt.r_set && !opt.reads_filename1.empty()) {
         opt.r = estimate_read_length(input_buffer);
         logger.info() << "Estimated read length: " << opt.r << " bp\n";
+        input_buffer.rewind_reset();
     }
-    input_buffer.rewind_reset();
     IndexParameters index_parameters = IndexParameters::from_read_length(
         opt.r,
         opt.k_set ? opt.k : IndexParameters::DEFAULT,

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -23,7 +23,7 @@ class InputBuffer {
 public:
 
     InputBuffer(std::string fname1, std::string fname2, int chunk_size, bool is_interleaved)
-    : ks1(open_fastq(fname1)),
+    : ks1(fname1 == "" ? nullptr : open_fastq(fname1)),
     ks2(fname2 == "" ? nullptr : open_fastq(fname2)),
     chunk_size(chunk_size),
     is_interleaved(is_interleaved) { }


### PR DESCRIPTION
This is a continuation of #269 where I fixed the things I commented on.

I will need to re-measure memory usage. At some point, it was higher than previously, but that seems to be fixed now.

As intended, runtime improves slightly.

Marked as draft because two issues remain:
- [x] Memory usage increases significantly, probably because of `mmap` usage, which I don’t think makes so much sense.
- [x] Multi-block gzips (concatenated gzip files) are not supported and hang the input thread.