### PR TITLE
Add a debugging compilation option for showing list of NAMs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ include(FetchContent)
 
 option(ENABLE_AVX "Enable AVX2 support" OFF)
 option(PYTHON_BINDINGS "Build Python bindings" OFF)
+option(TRACE "Highly verbose debugging output" OFF)
 
 find_package(ZLIB)
 find_package(Threads)
@@ -69,6 +70,10 @@ target_link_libraries(salib PUBLIC ZLIB::ZLIB Threads::Threads zstr::zstr)
 IF(ENABLE_AVX)
   target_compile_options(salib PUBLIC "-mavx2")
 ENDIF()
+if (TRACE)
+   target_compile_definitions(salib PUBLIC "TRACE")
+endif()
+
 add_dependencies(salib version)
 
 add_executable(strobealign src/main.cpp)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,18 @@ more focused discussion.
 When compiling strobealign, you can add `-DCMAKE_BUILD_TYPE=RelWithDebInfo` to
 the `cmake` options to get debug symbols.
 
-If needed, run `make` with `VERBOSE=1` to get more logging output.
+If needed, run `make` with `VERBOSE=1` to get more logging output at build
+time.
+
+To get more logging output when running strobealign, add the `-v` option to
+the command line.
+
+Add `--details` to get more detailed SAM output with some
+strobealign-specific tags added to each alignment record.
+(See below.)
+
+To get even more verbose output, add `-DTRACE=ON` to your CMake options and
+re-compile strobealign. This outputs a list of the found NAMs for each read.
 
 ## Testing
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1059,6 +1059,18 @@ void align_or_map_paired(
         nams_pair[is_revcomp] = nams;
     }
 
+#ifdef TRACE
+    for (int is_revcomp : {0, 1}) {
+        const auto& record = is_revcomp == 0 ? record1 : record2;
+        std::cerr << "R" << is_revcomp + 1 << " name: " << record.name << '\n';
+        const auto& nams = nams_pair[is_revcomp];
+        std::cerr << "Found " << nams.size() << " NAMs\n";
+        for (auto& nam : nams) {
+            std::cerr << "- " << nam << '\n';
+        }
+    }
+#endif
+
     Timer extend_timer;
     if (map_param.output_format != OutputFormat::SAM) { // PAF or abundance
         Nam nam_read1;
@@ -1185,6 +1197,13 @@ void align_or_map_single(
     shuffle_top_nams(nams, random_engine);
     statistics.tot_sort_nams += nam_sort_timer.duration();
 
+#ifdef TRACE
+    std::cerr << "Query: " << record.name << '\n';
+    std::cerr << "Found " << nams.size() << " NAMs\n";
+    for (auto& nam : nams) {
+        std::cerr << "- " << nam << '\n';
+    }
+#endif
 
     Timer extend_timer;
     size_t n_best = 0;

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -7,7 +7,13 @@
 
 struct CommandLineOptions {
     int n_threads { 1 };
-    int chunk_size { 10000 };
+    int chunk_size {
+#ifdef TRACE
+        1
+#else
+        10000
+#endif
+    };
 
     // Input/output
     std::string output_file_name;


### PR DESCRIPTION
If `cmake` is run with `-DTRACE=ON`, then some `#ifdef`s become active that make strobealign print the list of found NAMs for each query.

I find myself adding this type of output quite often for debugging purposes, and think it would be nice to have this as part of the code, disabled by default, but easily enabled.

`CHUNK_SIZE` is forced to 1 when tracing is on to ensure that SAM/PAF output comes right after the corresponding tracing output. (Otherwise you get the tracing output for all queries within one chunk follewd by all the SAM/PAF output for all queries in the chunk.)