### PR TITLE
Make Python bindings work with nanobind 2+

### DIFF
--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -54,7 +54,7 @@ NB_MODULE(strobealign_extension, m_) {
     nb::module_ m = nb::module_::import_("strobealign");
 
     m.doc() = "strobealign aligns short reads using dynamic seed size with strobemers";
-    nb::enum_<LOG_LEVELS>(m, "LOG_LEVELS")
+    nb::enum_<LOG_LEVELS>(m, "LOG_LEVELS", nb::is_arithmetic())
         .value("LOG_DEBUG", LOG_LEVELS::LOG_DEBUG)
         .value("LOG_INFO", LOG_LEVELS::LOG_INFO)
         .value("LOG_WARNING", LOG_LEVELS::LOG_WARNING)


### PR DESCRIPTION
Nanobind changelog
(https://nanobind.readthedocs.io/en/latest/changelog.html#version-2-0-0-may-23-2024):

> The nb::enum_<T>() binding declaration is now a wrapper that creates either
> a enum.Enum or enum.IntEnum-derived type. Previously, nanobind relied on a
> custom enumeration base class that was a frequent source of friction for
> users.
>
> This change may break code that casts entries to integers, which now only
> works for arithmetic (enum.IntEnum-derived) enumerations.