### PR TITLE
Fix index construction statistics

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -334,7 +334,7 @@ void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) c
 
     for (size_t it = 0; it < randstrobes.size(); it++) {
         seed_length = strobe2_offset(it) + k;
-        auto count = get_count(it);
+        auto count = get_count(find(get_hash(it)));
 
         if (seed_length < max_size){
             log_count[seed_length] ++;
@@ -371,10 +371,11 @@ void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) c
 
     // Get median
     size_t n = 0;
-    int median = 0;
+    size_t median = 0;
     for (size_t i = 0; i < log_count.size(); ++i) {
         n += log_count[i];
         if (n >= tot_seed_count/2) {
+            median = i;
             break;
         }
     }
@@ -387,7 +388,8 @@ void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) c
         }
     }
 
-    log_file << "E_size for total seeding wih max seed size m below (m, tot_seeds, E_hits)" << std::endl;
+    log_file << "E_size for total seeding with median seed size m below (m, tot_seeds, E_hits, fraction_masked)"
+             << std::endl;
     double e_hits = (double) tot_seed_count_sq/ (double) tot_seed_count;
     double fraction_masked = 1.0 - (double) tot_seed_count_1000_limit/ (double) tot_seed_count;
     log_file << median << ',' << tot_seed_count << ',' << e_hits << ',' << 100*fraction_masked << std::endl;

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -120,6 +120,9 @@ struct StrobemerIndex {
         // a hash will be queried is proportional to the frequency it appears in the table, 
         // with MAX_LINEAR_SEARCH=8, the actual value will be 96%.
 
+        // Since the result depends on position, this function must be used on the smallest position which points to the
+        // seed with the given hash to yield the number of seeds with this hash.
+
         constexpr unsigned int MAX_LINEAR_SEARCH = 8;
         const auto key = randstrobes[position].hash;
         const unsigned int top_N = key >> (64 - bits);


### PR DESCRIPTION
Fixed several issues in the index statistics

- Since `get_count(size_t position)` counts the seed abundance starting from the argument position, `get_count` is now used with the first occurrence position 
- Fixed median seed length
- Clarified statistics text