### PR TITLE
Do not compile unused.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,11 +139,6 @@ add_executable(dumpstrobes src/dumpstrobes.cpp)
 target_link_libraries(dumpstrobes salib)
 target_include_directories(dumpstrobes PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
 
-# Currently unused code for which we only want to ensure that it still compiles
-add_executable(unused-code src/unused.cpp)
-target_link_libraries(unused-code salib)
-target_include_directories(unused-code PUBLIC src/ ext/ ${PROJECT_BINARY_DIR})
-
 if(PYTHON_BINDINGS)
   add_subdirectory(src/python)
 endif()


### PR DESCRIPTION
I would like to suggest no longer compiling the `unused.cpp` file by default for a couple of reasons:
- Because it includes some header files, it takes extra effort to make it compilable if those header files change.
- While building, many warning messages are printed just for unused.cpp while for strobealign itself almost all warnings have been eliminated. This makes it harder to see whether a change introduces a new warning.
- It takes extra time to compile (just a couple of seconds each time, but it adds up).

This PR removes the file as a target from `CMakeLists.txt` so that it no longer gets compiled. I haven’t deleted the file itself for now.