### PR TITLE
Rename Hit struct to Match

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -118,7 +118,7 @@ inline void align_single(
     best_alignment.is_unaligned = true;
 
     for (auto &nam : nams) {
-        float score_dropoff = (float) nam.n_hits / n_max.n_hits;
+        float score_dropoff = (float) nam.n_matches / n_max.n_matches;
         if (tries >= max_tries || (tries > 1 && best_edit_distance == 0) || score_dropoff < dropoff_threshold) {
             break;
         }
@@ -279,7 +279,7 @@ inline uint8_t proper_pair_mapq(const std::vector<Nam> &nams) {
     const float s1 = nams[0].score;
     const float s2 = nams[1].score;
     // from minimap2: MAPQ = 40(1−s2/s1) ·min{1,|M|/10} · log s1
-    const float min_matches = std::min(nams[0].n_hits / 10.0, 1.0);
+    const float min_matches = std::min(nams[0].n_matches / 10.0, 1.0);
     const int uncapped_mapq = 40 * (1 - s2 / s1) * min_matches * log(s1);
     return std::min(uncapped_mapq, 60);
 }
@@ -379,7 +379,7 @@ inline std::vector<NamPair> get_best_scoring_nam_pairs(
     int best_joint_hits = 0;
     for (auto &nam1 : nams1) {
         for (auto &nam2 : nams2) {
-            int joint_hits = nam1.n_hits + nam2.n_hits;
+            int joint_hits = nam1.n_matches + nam2.n_matches;
             if (joint_hits < best_joint_hits / 2) {
                 break;
             }
@@ -396,31 +396,31 @@ inline std::vector<NamPair> get_best_scoring_nam_pairs(
     Nam dummy_nam;
     dummy_nam.ref_start = -1;
     if (!nams1.empty()) {
-        int best_joint_hits1 = best_joint_hits > 0 ? best_joint_hits : nams1[0].n_hits;
+        int best_joint_hits1 = best_joint_hits > 0 ? best_joint_hits : nams1[0].n_matches;
         for (auto &nam1 : nams1) {
-            if (nam1.n_hits < best_joint_hits1 / 2) {
+            if (nam1.n_matches < best_joint_hits1 / 2) {
                 break;
             }
             if (added_n1.find(nam1.nam_id) != added_n1.end()) {
                 continue;
             }
 //            int n1_penalty = std::abs(nam1.query_span() - nam1.ref_span());
-            nam_pairs.push_back(NamPair{nam1.n_hits, nam1, dummy_nam});
+            nam_pairs.push_back(NamPair{nam1.n_matches, nam1, dummy_nam});
         }
     }
 
     // Find high-scoring R2 NAMs that are not part of a proper pair
     if (!nams2.empty()) {
-        int best_joint_hits2 = best_joint_hits > 0 ? best_joint_hits : nams2[0].n_hits;
+        int best_joint_hits2 = best_joint_hits > 0 ? best_joint_hits : nams2[0].n_matches;
         for (auto &nam2 : nams2) {
-            if (nam2.n_hits < best_joint_hits2 / 2) {
+            if (nam2.n_matches < best_joint_hits2 / 2) {
                 break;
             }
             if (added_n2.find(nam2.nam_id) != added_n2.end()){
                 continue;
             }
 //            int n2_penalty = std::abs(nam2.query_span() - nam2.ref_span());
-            nam_pairs.push_back(NamPair{nam2.n_hits, dummy_nam, nam2});
+            nam_pairs.push_back(NamPair{nam2.n_matches, dummy_nam, nam2});
         }
     }
 
@@ -582,7 +582,7 @@ std::vector<ScoredAlignmentPair> rescue_read(
     std::vector<Alignment> alignments1;
     std::vector<Alignment> alignments2;
     for (auto& nam : nams1) {
-        float score_dropoff1 = (float) nam.n_hits / n_max1.n_hits;
+        float score_dropoff1 = (float) nam.n_matches / n_max1.n_matches;
         // only consider top hits (as minimap2 does) and break if below dropoff cutoff.
         if (tries >= max_tries || score_dropoff1 < dropoff) {
             break;
@@ -667,11 +667,11 @@ void output_aligned_pairs(
 // compute dropoff of the first (top) NAM
 float top_dropoff(std::vector<Nam>& nams) {
     auto& n_max = nams[0];
-    if (n_max.n_hits <= 2) {
+    if (n_max.n_matches <= 2) {
         return 1.0;
     }
     if (nams.size() > 1) {
-        return (float) nams[1].n_hits / n_max.n_hits;
+        return (float) nams[1].n_matches / n_max.n_matches;
     }
     return 0.0;
 }

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -11,11 +11,11 @@ struct Nam {
     int nam_id;
     int query_start;
     int query_end;
-    int query_prev_hit_startpos;
+    int query_prev_match_startpos;
     int ref_start;
     int ref_end;
-    int ref_prev_hit_startpos;
-    int n_hits = 0;
+    int ref_prev_match_startpos;
+    int n_matches = 0;
     int ref_id;
     float score;
 //    unsigned int previous_query_start;

--- a/src/paf.cpp
+++ b/src/paf.cpp
@@ -36,7 +36,7 @@ void output_hits_paf_PE(std::string &paf_output, const Nam &n, const std::string
     paf_output.append("\t");
     paf_output.append(std::to_string(n.ref_end));
     paf_output.append("\t");
-    paf_output.append(std::to_string(n.n_hits));
+    paf_output.append(std::to_string(n.n_matches));
     paf_output.append("\t");
     paf_output.append(std::to_string(n.ref_end - n.ref_start));
     paf_output.append("\t255\n");

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -148,7 +148,7 @@ NB_MODULE(strobealign_extension, m_) {
         .def_ro("ref_start", &Nam::ref_start)
         .def_ro("ref_end", &Nam::ref_end)
         .def_ro("score", &Nam::score)
-        .def_ro("n_hits", &Nam::n_hits)
+        .def_ro("n_hits", &Nam::n_matches)
         .def_ro("reference_index", &Nam::ref_id)
         .def_rw("is_rc", &Nam::is_rc)
         .def_prop_ro("ref_span", &Nam::ref_span)


### PR DESCRIPTION
We use the term "hit" both for
- a query strobemer successfully looked up in the index
- a locus on the query paired with a locus on the reference (this type of hit is merged into NAMs)

I think choosing the name for the latter to be "match" makes sense because the M in NAM stands for "match". That is, we can then say that we merge multiple overlapping matches into non-overlapping, approximate matches (=NAMs).

The flow would then be: hit -> match -> NAM.

Marking as draft because this should only be merged after #426 as it will otherwise cause conflicts.