### PR TITLE
Prepare release: Bump version to 0.14.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Strobealign Changelog
 
-## development version
+## v0.14.0 (2024-10-03)
 
 * #401: The default number of threads is now 1 instead of 3.
 * #409: Ensure reference names are unique and conform to the SAM
@@ -13,6 +13,10 @@
   a separate thread. We tested up to 128 cores, and strobealign was still
   able to use all cores.
   Contributed by @telmin.
+* #447: Switched to a new way for hashing randstrobes in preparation for the
+  introduction of multi-context seeds.
+  Pre-generated index files (`.sti` files) therefore need to be re-generated.
+  (Strobealign will complain if you try to use an outdated index file.)
 
 ## v0.13.0 (2024-03-04)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(strobealign VERSION 0.13.0)
+project(strobealign VERSION 0.14.0)
 include(FetchContent)
 include(ExternalProject)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="strobealign",
     description="Python bindings for strobealign",
     license="MIT",
-    version="0.13.0",
+    version="0.14.0",
     packages=["strobealign"],
     package_dir={"": "src/python"},
     cmake_install_dir="src/python",


### PR DESCRIPTION
I think this is a good time for a release, with the ISA-L improvements and just after we switched to multi-context ~~seeds~~ hashes (which gives a slight speedup), but before actually using them.

(Edited)