### PR TITLE
Multi-context seeds refactoring and docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Strobealign Changelog
 
+## Development version
+
+* #388 and #426: Increase accuracy and mapping rate for reads shorter than
+  about 200 bp by introducing multi-context seeds.
+  Previously, seeds always consisted of two k-mers and would only be found if
+  both occur in query and reference.
+  With this change, strobealign falls back to looking up just one of the k-mers
+  when appropriate.
+  This feature is currently *experimental* and only enabled when using the
+  `--mcs` command-line option.
+  Contributed by Ivan Tolstoganov (@Itolstoganov).
+
 ## v0.14.0 (2024-10-03)
 
 * #401: The default number of threads is now 1 instead of 3.

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -335,7 +335,7 @@ void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) c
 
     for (size_t it = 0; it < randstrobes.size(); it++) {
         seed_length = strobe2_offset(it) + k;
-        auto count = get_count(find(get_hash(it)));
+        auto count = get_count_full(find_full(get_hash(it)));
 
         if (seed_length < max_size){
             log_count[seed_length] ++;

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -210,7 +210,7 @@ std::tuple<float, int, std::vector<Nam>> find_nams(
     int nr_good_hits = 0;
     int total_hits = 0;
     for (const auto &q : query_randstrobes) {
-        size_t position = index.find(q.hash);
+        size_t position = index.find_full(q.hash);
         if (position != index.end()){
             total_hits++;
             if (index.is_filtered(position)) {
@@ -225,7 +225,7 @@ std::tuple<float, int, std::vector<Nam>> find_nams(
                 // already queried
                 continue;
             }
-            size_t partial_pos = index.partial_find(q.hash);
+            size_t partial_pos = index.find_partial(q.hash);
             if (partial_pos != index.end()) {
                 total_hits++;
                 if (index.is_partial_filtered(partial_pos)) {
@@ -278,9 +278,9 @@ std::pair<int, std::vector<Nam>> find_nams_rescue(
     hits_rc.reserve(5000);
 
     for (auto &qr : query_randstrobes) {
-        size_t position = index.find(qr.hash);
+        size_t position = index.find_full(qr.hash);
         if (position != index.end()) {
-            unsigned int count = index.get_count(position);
+            unsigned int count = index.get_count_full(position);
             RescueHit rh{position, count, qr.start, qr.end, false};
             if (qr.is_reverse){
                 hits_rc.push_back(rh);
@@ -294,9 +294,9 @@ std::pair<int, std::vector<Nam>> find_nams_rescue(
                 // already queried
                 continue;
             }
-            size_t partial_pos = index.partial_find(qr.hash);
+            size_t partial_pos = index.find_partial(qr.hash);
             if (partial_pos != index.end()) {
-                unsigned int partial_count = index.get_partial_count(partial_pos);
+                unsigned int partial_count = index.get_count_partial(partial_pos);
                 RescueHit rh{partial_pos, partial_count, qr.partial_start, qr.partial_end, true};
                 if (qr.is_reverse){
                     hits_rc.push_back(rh);

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -119,7 +119,7 @@ NB_MODULE(strobealign_extension, m_) {
         .def(nb::init<References&, IndexParameters&>())
         .def("find", [](const StrobemerIndex& index, uint64_t key) -> std::vector<RefRandstrobe> {
             std::vector<RefRandstrobe> v;
-            auto position = index.find(key);
+            auto position = index.find_full(key);
             while (position != index.end() && index.get_hash(position) == key) {
                 v.push_back(index.get_randstrobe(position));
                 position++;

--- a/src/randstrobes.cpp
+++ b/src/randstrobes.cpp
@@ -45,6 +45,17 @@ static inline syncmer_hash_t syncmer_smer_hash(uint64_t packed) {
     return xxh64(packed);
 }
 
+/*
+ * This function combines two individual syncmer hashes into a single hash
+ * for the randstrobe.
+ *
+ * The syncmer with the smaller hash is designated as the "main", the other is
+ * the "auxiliary".
+ * The combined hash is obtained by setting the top aux_len bits to the bits of
+ * the main hash and the bottom 64 - aux_len bits to the bits of the auxiliary
+ * hash. Since entries in the index are sorted by randstrobe hash, this allows
+ * us to search for the main syncmer only by masking out the lower aux_len bits.
+ */
 static inline randstrobe_hash_t randstrobe_hash(syncmer_hash_t hash1, syncmer_hash_t hash2, size_t aux_len) {
     // Make the function symmetric
     if (hash1 > hash2) {

--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -65,6 +65,9 @@ struct QueryRandstrobe {
     randstrobe_hash_t hash;
     unsigned int start;
     unsigned int end;
+    /* Start and end of the main syncmer (relevant if the randstrobe couldn’t
+     * be found in the index and we fall back to a partial hit)
+     */
     unsigned int partial_start;
     unsigned int partial_end;
     bool is_reverse;


### PR DESCRIPTION
Mainly, this removes one of the currently duplicated `StrobemerIndex::find*()` functions.

Instead, have a common function that has a parameter which tells it how many bit of the hash to ignore (0 for finding a full hash and aux_len for a partial one).

Same for `get_count()`.