### PR TITLE
Report number of generated randstrobes

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1034,6 +1034,7 @@ void align_or_map_paired(
 
         Timer strobe_timer;
         auto query_randstrobes = randstrobes_query(record.seq, index_parameters);
+        statistics.n_randstrobes += query_randstrobes.size();
         statistics.tot_construct_strobemers += strobe_timer.duration();
 
         // Find NAMs
@@ -1177,6 +1178,7 @@ void align_or_map_single(
     Details details;
     Timer strobe_timer;
     auto query_randstrobes = randstrobes_query(record.seq, index_parameters);
+    statistics.n_randstrobes += query_randstrobes.size();
     statistics.tot_construct_strobemers += strobe_timer.duration();
 
     // Find NAMs

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -365,6 +365,8 @@ int run_strobealign(int argc, char **argv) {
 
     logger.debug()
         << "Number of reads: " << tot_statistics.n_reads << std::endl
+        << "Number of randstrobes: " << tot_statistics.n_randstrobes
+        << " total. Per read: " << static_cast<float>(tot_statistics.n_randstrobes) / tot_statistics.n_reads << std::endl
         << "Number of non-rescue hits: " << tot_statistics.n_hits
         << " total. Per read: " << static_cast<float>(tot_statistics.n_hits) / tot_statistics.n_reads << std::endl
         << "Number of non-rescue NAMs: " << tot_statistics.n_nams

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -36,6 +36,7 @@ struct AlignmentStatistics {
     std::chrono::duration<double> tot_write_file{0};
 
     uint64_t n_reads{0};
+    uint64_t n_randstrobes{0};
     uint64_t n_hits{0}; // non-rescue hits
     uint64_t n_rescue_hits{0};
     uint64_t n_nams{0};
@@ -56,6 +57,7 @@ struct AlignmentStatistics {
         this->tot_extend += other.tot_extend;
         this->tot_write_file += other.tot_write_file;
         this->n_reads += other.n_reads;
+        this->n_randstrobes += other.n_randstrobes;
         this->n_hits += other.n_hits;
         this->n_rescue_hits += other.n_rescue_hits;
         this->n_nams += other.n_nams;


### PR DESCRIPTION
With `-v`, this reports the number of generated randstrobes in total and per read.