### PR TITLE
Experiment: Fast path for exact matches

### DIFF
--- a/src/index.hpp
+++ b/src/index.hpp
@@ -133,6 +133,10 @@ struct StrobemerIndex {
         return (get_hash(position) >> shift) == (get_hash(position + partial_filter_cutoff) >> shift);
     }
 
+    bool is_unique(bucket_index_t position) const {
+        return get_hash(position) != get_hash(position + 1);
+    }
+
     unsigned int get_strobe1_position(bucket_index_t position) const {
         return randstrobes[position].position;
     }

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -33,6 +33,22 @@ struct Nam {
     int projected_ref_start() const {
         return std::max(0, ref_start - query_start);
     }
+
+    static Nam make_exact_match(int ref_id, int ref_start, int length, bool is_rc) {
+        return Nam{
+            0, // nam_id
+            0, // query_start
+            length, // query_end
+            0, // query_prev_match_startpos
+            ref_start,
+            ref_start + length, // ref_end
+            0, // ref_prev_match_startpos
+            0, // n_matches
+            ref_id,
+            0, // score
+            is_rc
+        };
+    }
 };
 
 std::tuple<float, int, std::vector<Nam>> find_nams(


### PR DESCRIPTION
Thinking about ways to alleviate the multi-context seeds slowdown, I tried to add a "fast path" for exact matches (this has nothing to do with mcs, but if we add an unrelated optimization at the same time, it feels less bad): The first randstrobe from the query is looked up in the index, and if it results in a unique hit (only one entry for that hash in the index), the query and reference are compared and if they match exactly, the match is output and everything else is skipped (that is, looking up other hits in the index, merging them into NAMs, ungapped alignments for the top NAMs).

This is a just hack for the moment (with some code duplication) that is also incomplete as it does not check the reverse-complemented sequence.

I tested this on sim5-drosophila-100 first, and there was no improvement (although ~30% of all CIGARs are `100=`), but it does help a little bit with the sim3-drosophila-100 library, which appears to gets 3% faster.

I’ll need to do some more measurements.