### PR TITLE
Logging cleanup and some minor refactoring

### DIFF
--- a/src/aligner.cpp
+++ b/src/aligner.cpp
@@ -193,3 +193,15 @@ AlignmentInfo hamming_align(
     aln.query_end = segment_end;
     return aln;
 }
+
+std::ostream& operator<<(std::ostream& os, const AlignmentParameters& params) {
+    os
+        << "AlignmentParameters("
+        << "match=" << params.match
+        << ", mismatch=" << params.mismatch
+        << ", gap_open=" << params.gap_open
+        << ", gap_extend=" << params.gap_extend
+        << ", end_bonus=" << params.end_bonus
+        << ")";
+    return os;
+}

--- a/src/aligner.hpp
+++ b/src/aligner.hpp
@@ -17,6 +17,8 @@ struct AlignmentParameters {
     int end_bonus;
 };
 
+std::ostream& operator<<(std::ostream& os, const AlignmentParameters& params);
+
 struct AlignmentInfo {
     Cigar cigar;
     unsigned int edit_distance{0};

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -123,7 +123,7 @@ inline void align_single(
             break;
         }
         bool consistent_nam = reverse_nam_if_needed(nam, read, references, k);
-        details.nam_inconsistent += !consistent_nam;
+        details.inconsistent_nams += !consistent_nam;
         auto alignment = extend_seed(aligner, nam, references, read, consistent_nam);
         details.tried_alignment++;
         if (alignment.is_unaligned) {
@@ -597,7 +597,7 @@ std::vector<ScoredAlignmentPair> rescue_read(
         }
 
         const bool consistent_nam = reverse_nam_if_needed(nam, read1, references, k);
-        details[0].nam_inconsistent += !consistent_nam;
+        details[0].inconsistent_nams += !consistent_nam;
         auto alignment = extend_seed(aligner, nam, references, read1, consistent_nam);
         details[0].gapped += alignment.gapped;
         alignments1.emplace_back(alignment);
@@ -756,9 +756,9 @@ std::vector<ScoredAlignmentPair> align_paired(
         Nam n_max2 = nams2[0];
 
         bool consistent_nam1 = reverse_nam_if_needed(n_max1, read1, references, k);
-        details[0].nam_inconsistent += !consistent_nam1;
+        details[0].inconsistent_nams += !consistent_nam1;
         bool consistent_nam2 = reverse_nam_if_needed(n_max2, read2, references, k);
-        details[1].nam_inconsistent += !consistent_nam2;
+        details[1].inconsistent_nams += !consistent_nam2;
 
         auto alignment1 = extend_seed(aligner, n_max1, references, read1, consistent_nam1);
         details[0].tried_alignment++;
@@ -785,7 +785,7 @@ std::vector<ScoredAlignmentPair> align_paired(
     {
         auto n1_max = nams1[0];
         bool consistent_nam1 = reverse_nam_if_needed(n1_max, read1, references, k);
-        details[0].nam_inconsistent += !consistent_nam1;
+        details[0].inconsistent_nams += !consistent_nam1;
         a1_indv_max = extend_seed(aligner, n1_max, references, read1, consistent_nam1);
         is_aligned1[n1_max.nam_id] = a1_indv_max;
         details[0].tried_alignment++;
@@ -793,7 +793,7 @@ std::vector<ScoredAlignmentPair> align_paired(
 
         auto n2_max = nams2[0];
         bool consistent_nam2 = reverse_nam_if_needed(n2_max, read2, references, k);
-        details[1].nam_inconsistent += !consistent_nam2;
+        details[1].inconsistent_nams += !consistent_nam2;
         a2_indv_max = extend_seed(aligner, n2_max, references, read2, consistent_nam2);
         is_aligned2[n2_max.nam_id] = a2_indv_max;
         details[1].tried_alignment++;
@@ -820,14 +820,14 @@ std::vector<ScoredAlignmentPair> align_paired(
                 a1 = is_aligned1[n1.nam_id];
             } else {
                 bool consistent_nam = reverse_nam_if_needed(n1, read1, references, k);
-                details[0].nam_inconsistent += !consistent_nam;
+                details[0].inconsistent_nams += !consistent_nam;
                 a1 = extend_seed(aligner, n1, references, read1, consistent_nam);
                 is_aligned1[n1.nam_id] = a1;
                 details[0].tried_alignment++;
                 details[0].gapped += a1.gapped;
             }
         } else {
-            details[1].nam_inconsistent += !reverse_nam_if_needed(n2, read2, references, k);
+            details[1].inconsistent_nams += !reverse_nam_if_needed(n2, read2, references, k);
             a1 = rescue_align(aligner, n2, references, read1, mu, sigma, k);
             details[0].mate_rescue += !a1.is_unaligned;
             details[0].tried_alignment++;
@@ -843,14 +843,14 @@ std::vector<ScoredAlignmentPair> align_paired(
                 a2 = is_aligned2[n2.nam_id];
             } else {
                 bool consistent_nam = reverse_nam_if_needed(n2, read2, references, k);
-                details[1].nam_inconsistent += !consistent_nam;
+                details[1].inconsistent_nams += !consistent_nam;
                 a2 = extend_seed(aligner, n2, references, read2, consistent_nam);
                 is_aligned2[n2.nam_id] = a2;
                 details[1].tried_alignment++;
                 details[1].gapped += a2.gapped;
             }
         } else {
-            details[0].nam_inconsistent += !reverse_nam_if_needed(n1, read1, references, k);
+            details[0].inconsistent_nams += !reverse_nam_if_needed(n1, read1, references, k);
             a2 = rescue_align(aligner, n1, references, read2, mu, sigma, k);
             details[1].mate_rescue += !a2.is_unaligned;
             details[1].tried_alignment++;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -374,7 +374,7 @@ int run_strobealign(int argc, char **argv) {
         << "Total time finding NAMs (non-rescue mode): " << statistics.tot_find_nams.count() / opt.n_threads << " s." << std::endl
         << "Total time finding NAMs (rescue mode): " << statistics.tot_time_rescue.count() / opt.n_threads << " s." << std::endl
         << "Total time sorting NAMs (candidate sites): " << statistics.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
-        << "Total time base level alignment (ssw): " << statistics.tot_extend.count() / opt.n_threads << " s." << std::endl;
+        << "Total time extending and pairing seeds: " << statistics.tot_extend.count() / opt.n_threads << " s." << std::endl;
     return EXIT_SUCCESS;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -364,7 +364,7 @@ int run_strobealign(int argc, char **argv) {
         << "Number of rescue NAMs:         " << std::setw(12) << statistics.n_rescue_nams
         << "  Per rescue attempt: " << std::setw(7) << static_cast<float>(statistics.n_rescue_nams) / statistics.nam_rescue << std::endl;
     logger.info()
-        << "Total mapping sites tried: " << statistics.tot_all_tried << std::endl
+        << "Total mapping sites tried: " << statistics.tried_alignment << std::endl
         << "Total calls to ssw: " << statistics.tot_aligner_calls << std::endl
         << "Inconsistent NAM ends: " << statistics.inconsistent_nams << std::endl
         << "Mates rescued by alignment: " << statistics.tot_rescued << std::endl

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -387,7 +387,6 @@ int run_strobealign(int argc, char **argv) {
         << "Total time creating strobemers: " << tot_statistics.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl
         << "Total time finding NAMs (non-rescue mode): " << tot_statistics.tot_find_nams.count() / opt.n_threads << " s." << std::endl
         << "Total time finding NAMs (rescue mode): " << tot_statistics.tot_time_rescue.count() / opt.n_threads << " s." << std::endl;
-    //<< "Total time finding NAMs ALTERNATIVE (candidate sites): " << tot_find_nams_alt.count()/opt.n_threads  << " s." <<  std::endl;
     logger.info() << "Total time sorting NAMs (candidate sites): " << tot_statistics.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
         << "Total time base level alignment (ssw): " << tot_statistics.tot_extend.count() / opt.n_threads << " s." << std::endl
         << "Total time writing alignment to files: " << tot_statistics.tot_write_file.count() << " s." << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -374,8 +374,7 @@ int run_strobealign(int argc, char **argv) {
         << "Total time finding NAMs (non-rescue mode): " << statistics.tot_find_nams.count() / opt.n_threads << " s." << std::endl
         << "Total time finding NAMs (rescue mode): " << statistics.tot_time_rescue.count() / opt.n_threads << " s." << std::endl
         << "Total time sorting NAMs (candidate sites): " << statistics.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
-        << "Total time base level alignment (ssw): " << statistics.tot_extend.count() / opt.n_threads << " s." << std::endl
-        << "Total time writing alignment to files: " << statistics.tot_write_file.count() << " s." << std::endl;
+        << "Total time base level alignment (ssw): " << statistics.tot_extend.count() / opt.n_threads << " s." << std::endl;
     return EXIT_SUCCESS;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,7 +305,7 @@ int run_strobealign(int argc, char **argv) {
             }
     }
 
-    std::vector<AlignmentStatistics> log_stats_vec(opt.n_threads);
+    std::vector<AlignmentStatistics> worker_statistics(opt.n_threads);
     
     logger.info() << "Processing " << (opt.is_SE ? "single-end" : "paired-end") << " reads ";
     if (map_param.output_format == OutputFormat::PAF) {
@@ -322,22 +322,22 @@ int run_strobealign(int argc, char **argv) {
     std::vector<std::vector<double>> worker_abundances(opt.n_threads, std::vector<double>(references.size(), 0));
     for (int i = 0; i < opt.n_threads; ++i) {
         std::thread consumer(perform_task, std::ref(input_buffer), std::ref(output_buffer),
-            std::ref(log_stats_vec[i]), std::ref(worker_done[i]), std::ref(aln_params),
+            std::ref(worker_statistics[i]), std::ref(worker_done[i]), std::ref(aln_params),
             std::ref(map_param), std::ref(index_parameters), std::ref(references),
             std::ref(index), std::ref(opt.read_group_id), std::ref(worker_abundances[i]));
         workers.push_back(std::move(consumer));
     }
     if (opt.show_progress && isatty(2)) {
-        show_progress_until_done(worker_done, log_stats_vec);
+        show_progress_until_done(worker_done, worker_statistics);
     }
     for (auto& worker : workers) {
         worker.join();
     }
     logger.info() << "Done!\n";
 
-    AlignmentStatistics tot_statistics;
-    for (auto& it : log_stats_vec) {
-        tot_statistics += it;
+    AlignmentStatistics statistics;
+    for (auto& it : worker_statistics) {
+        statistics += it;
     }
 
     if (map_param.output_format == OutputFormat::Abundance) {
@@ -351,31 +351,31 @@ int run_strobealign(int argc, char **argv) {
     }
 
     logger.debug()
-        << "Number of reads:           " << std::setw(12) << tot_statistics.n_reads << std::endl
-        << "Number of randstrobes:     " << std::setw(12) << tot_statistics.n_randstrobes
-        << "  Per read: " << std::setw(7) << static_cast<float>(tot_statistics.n_randstrobes) / tot_statistics.n_reads << std::endl
-        << "Number of non-rescue hits: " << std::setw(12) << tot_statistics.n_hits
-        << "  Per read: " << std::setw(7) << static_cast<float>(tot_statistics.n_hits) / tot_statistics.n_reads << std::endl
-        << "Number of non-rescue NAMs: " << std::setw(12) << tot_statistics.n_nams
-        << "  Per read: " << std::setw(7) << static_cast<float>(tot_statistics.n_nams) / tot_statistics.n_reads << std::endl
-        << "Number of rescue hits:     " << std::setw(12) << tot_statistics.n_rescue_hits
-        << "  Per rescue attempt: " << std::setw(7) << static_cast<float>(tot_statistics.n_rescue_hits) / tot_statistics.nam_rescue << std::endl
-        << "Number of rescue NAMs:     " << std::setw(12) << tot_statistics.n_rescue_nams
-        << "  Per rescue attempt: " << std::setw(7) << static_cast<float>(tot_statistics.n_rescue_nams) / tot_statistics.nam_rescue << std::endl;
+        << "Number of reads:               " << std::setw(12) << statistics.n_reads << std::endl
+        << "Number of randstrobes:         " << std::setw(12) << statistics.n_randstrobes
+        << "  Per read: " << std::setw(7) << static_cast<float>(statistics.n_randstrobes) / statistics.n_reads << std::endl
+        << "Number of non-rescue hits:     " << std::setw(12) << statistics.n_hits
+        << "  Per read: " << std::setw(7) << static_cast<float>(statistics.n_hits) / statistics.n_reads << std::endl
+        << "Number of non-rescue NAMs:     " << std::setw(12) << statistics.n_nams
+        << "  Per read: " << std::setw(7) << static_cast<float>(statistics.n_nams) / statistics.n_reads << std::endl
+        << "Number of NAM rescue attempts: " << std::setw(12) << statistics.nam_rescue << std::endl
+        << "Number of rescue hits:         " << std::setw(12) << statistics.n_rescue_hits
+        << "  Per rescue attempt: " << std::setw(7) << static_cast<float>(statistics.n_rescue_hits) / statistics.nam_rescue << std::endl
+        << "Number of rescue NAMs:         " << std::setw(12) << statistics.n_rescue_nams
+        << "  Per rescue attempt: " << std::setw(7) << static_cast<float>(statistics.n_rescue_nams) / statistics.nam_rescue << std::endl;
     logger.info()
-        << "Total mapping sites tried: " << tot_statistics.tot_all_tried << std::endl
-        << "Total calls to ssw: " << tot_statistics.tot_aligner_calls << std::endl
-        << "Inconsistent NAM ends: " << tot_statistics.inconsistent_nams << std::endl
-        << "Tried NAM rescue: " << tot_statistics.nam_rescue << std::endl
-        << "Mates rescued by alignment: " << tot_statistics.tot_rescued << std::endl
+        << "Total mapping sites tried: " << statistics.tot_all_tried << std::endl
+        << "Total calls to ssw: " << statistics.tot_aligner_calls << std::endl
+        << "Inconsistent NAM ends: " << statistics.inconsistent_nams << std::endl
+        << "Mates rescued by alignment: " << statistics.tot_rescued << std::endl
         << "Total time mapping: " << map_align_timer.elapsed() << " s." << std::endl
-        << "Total time reading read-file(s): " << tot_statistics.tot_read_file.count() / opt.n_threads << " s." << std::endl
-        << "Total time creating strobemers: " << tot_statistics.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl
-        << "Total time finding NAMs (non-rescue mode): " << tot_statistics.tot_find_nams.count() / opt.n_threads << " s." << std::endl
-        << "Total time finding NAMs (rescue mode): " << tot_statistics.tot_time_rescue.count() / opt.n_threads << " s." << std::endl;
-    logger.info() << "Total time sorting NAMs (candidate sites): " << tot_statistics.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
-        << "Total time base level alignment (ssw): " << tot_statistics.tot_extend.count() / opt.n_threads << " s." << std::endl
-        << "Total time writing alignment to files: " << tot_statistics.tot_write_file.count() << " s." << std::endl;
+        << "Total time reading read-file(s): " << statistics.tot_read_file.count() / opt.n_threads << " s." << std::endl
+        << "Total time creating strobemers: " << statistics.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl
+        << "Total time finding NAMs (non-rescue mode): " << statistics.tot_find_nams.count() / opt.n_threads << " s." << std::endl
+        << "Total time finding NAMs (rescue mode): " << statistics.tot_time_rescue.count() / opt.n_threads << " s." << std::endl
+        << "Total time sorting NAMs (candidate sites): " << statistics.tot_sort_nams.count() / opt.n_threads << " s." << std::endl
+        << "Total time base level alignment (ssw): " << statistics.tot_extend.count() / opt.n_threads << " s." << std::endl
+        << "Total time writing alignment to files: " << statistics.tot_write_file.count() << " s." << std::endl;
     return EXIT_SUCCESS;
 }
 

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -6,7 +6,7 @@ struct Details {
     bool nam_rescue{false}; // find_nams_rescue() was needed
     uint32_t nams{0};  // No. of NAMs found
     uint32_t rescue_nams{0}; // No. of NAMs found during rescue
-    uint32_t nam_inconsistent{0};
+    uint32_t inconsistent_nams{0};
     uint32_t mate_rescue{0}; // No. of times rescue by local alignment was attempted
     uint32_t tried_alignment{0}; // No. of computed alignments (get_alignment or rescue_mate)
     uint32_t gapped{0};  // No. of gapped alignments computed (in get_alignment)
@@ -16,7 +16,7 @@ struct Details {
         nam_rescue = nam_rescue || other.nam_rescue;
         nams += other.nams;
         rescue_nams += other.rescue_nams;
-        nam_inconsistent += other.nam_inconsistent;
+        inconsistent_nams += other.inconsistent_nams;
         mate_rescue += other.mate_rescue;
         tried_alignment += other.tried_alignment;
         gapped += other.gapped;
@@ -72,7 +72,7 @@ struct AlignmentStatistics {
         this->nam_rescue += details.nam_rescue;
         this->tot_rescued += details.mate_rescue;
         this->tot_all_tried += details.tried_alignment;
-        this->inconsistent_nams += details.nam_inconsistent;
+        this->inconsistent_nams += details.inconsistent_nams;
 
         return *this;
     }

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -41,7 +41,7 @@ struct AlignmentStatistics {
     uint64_t n_rescue_nams{0};
     uint64_t tot_aligner_calls{0};
     uint64_t tot_rescued{0};
-    uint64_t tot_all_tried{0};
+    uint64_t tried_alignment{0};
     uint64_t inconsistent_nams{0};
     uint64_t nam_rescue{0};
 
@@ -60,7 +60,7 @@ struct AlignmentStatistics {
         this->n_rescue_nams += other.n_rescue_nams;
         this->tot_aligner_calls += other.tot_aligner_calls;
         this->tot_rescued += other.tot_rescued;
-        this->tot_all_tried += other.tot_all_tried;
+        this->tried_alignment += other.tried_alignment;
         this->inconsistent_nams += other.inconsistent_nams;
         this->nam_rescue += other.nam_rescue;
         return *this;
@@ -71,7 +71,7 @@ struct AlignmentStatistics {
         this->n_rescue_nams += details.rescue_nams;
         this->nam_rescue += details.nam_rescue;
         this->tot_rescued += details.mate_rescue;
-        this->tot_all_tried += details.tried_alignment;
+        this->tried_alignment += details.tried_alignment;
         this->inconsistent_nams += details.inconsistent_nams;
 
         return *this;

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -30,7 +30,6 @@ struct AlignmentStatistics {
     std::chrono::duration<double> tot_construct_strobemers{0};
     std::chrono::duration<double> tot_find_nams{0};
     std::chrono::duration<double> tot_time_rescue{0};
-    std::chrono::duration<double> tot_find_nams_alt{0};
     std::chrono::duration<double> tot_sort_nams{0};
     std::chrono::duration<double> tot_extend{0};
     std::chrono::duration<double> tot_write_file{0};
@@ -52,7 +51,6 @@ struct AlignmentStatistics {
         this->tot_construct_strobemers += other.tot_construct_strobemers;
         this->tot_find_nams += other.tot_find_nams;
         this->tot_time_rescue += other.tot_time_rescue;
-        this->tot_find_nams_alt += other.tot_find_nams_alt;
         this->tot_sort_nams += other.tot_sort_nams;
         this->tot_extend += other.tot_extend;
         this->tot_write_file += other.tot_write_file;

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -32,7 +32,6 @@ struct AlignmentStatistics {
     std::chrono::duration<double> tot_time_rescue{0};
     std::chrono::duration<double> tot_sort_nams{0};
     std::chrono::duration<double> tot_extend{0};
-    std::chrono::duration<double> tot_write_file{0};
 
     uint64_t n_reads{0};
     uint64_t n_randstrobes{0};
@@ -53,7 +52,6 @@ struct AlignmentStatistics {
         this->tot_time_rescue += other.tot_time_rescue;
         this->tot_sort_nams += other.tot_sort_nams;
         this->tot_extend += other.tot_extend;
-        this->tot_write_file += other.tot_write_file;
         this->n_reads += other.n_reads;
         this->n_randstrobes += other.n_randstrobes;
         this->n_hits += other.n_hits;


### PR DESCRIPTION
Mostly a small logging cleanup.

Before:
```
Number of reads: 1
Number of randstrobes: 46 total. Per read: 46.00
Number of non-rescue hits: 19 total. Per read: 19.00
Number of non-rescue NAMs: 8 total. Per read: 8.00
Number of rescue hits: 0 total. Per rescue attempt: -nan
Number of rescue NAMs: 0 total. Per rescue attempt: -nan
```

After:
```
Number of reads:                          1
Number of randstrobes:                   46  Per read:   46.00
Number of non-rescue hits:               19  Per read:   19.00
Number of non-rescue NAMs:                8  Per read:    8.00
Number of NAM rescue attempts:            0
Number of rescue hits:                    0  Per rescue attempt:    -nan
Number of rescue NAMs:                    0  Per rescue attempt:    -nan
```


