### PR TITLE
Ensure pick_bits does not take the logarithm of 0

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -133,8 +133,8 @@ void StrobemerIndex::read(const std::string& filename) {
 }
 
 /* Pick a suitable number of bits for indexing randstrobe start indices */
-int StrobemerIndex::pick_bits(size_t size) const {
-    size_t estimated_number_of_randstrobes = size / (parameters.syncmer.k - parameters.syncmer.s + 1);
+int pick_bits(SyncmerParameters parameters, size_t size) {
+    size_t estimated_number_of_randstrobes = size / (parameters.k - parameters.s + 1) + 1;
     // Two randstrobes per bucket on average
     return std::clamp(static_cast<int>(log2(estimated_number_of_randstrobes)) - 1, 8, 31);
 }

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -34,6 +34,8 @@ struct IndexCreationStatistics {
     std::chrono::duration<double> elapsed_sorting_seeds;
 };
 
+int pick_bits(SyncmerParameters parameters, size_t size);
+
 struct StrobemerIndex {
     using bucket_index_t = uint64_t;
     StrobemerIndex(const References& references, const IndexParameters& parameters, int bits=-1)
@@ -41,7 +43,7 @@ struct StrobemerIndex {
         , partial_filter_cutoff(0)
         , parameters(parameters)
         , references(references)
-        , bits(bits == -1 ? pick_bits(references.total_length()) : bits)
+        , bits(bits == -1 ? pick_bits(parameters.syncmer, references.total_length()) : bits)
     {
         if (this->bits < 8 || this->bits > 31) {
             throw BadParameter("Bits must be between 8 and 31");
@@ -58,7 +60,6 @@ struct StrobemerIndex {
     void read(const std::string& filename);
     void populate(float f, unsigned n_threads);
     void print_diagnostics(const std::string& logfile_name, int k) const;
-    int pick_bits(size_t size) const;
 
     // Find first entry that matches the given key
     size_t find_full(randstrobe_hash_t key) const {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -171,3 +171,7 @@ TEST_CASE("reverse complement") {
     CHECK(reverse_complement("ACG") == "CGT");
     CHECK(reverse_complement("AACGT") == "ACGTT");
 }
+
+TEST_CASE("pick_bits") {
+    CHECK(pick_bits(SyncmerParameters{20, 16}, 0) == 8);
+}


### PR DESCRIPTION
Otherwise, on a very short reference (size 0 or so), pick_bits returns 31 and creates a huge randstrobe_starts vector.

Closes #487