### PR TITLE
Avoid processing hits any further when we would run rescue anyway

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1041,9 +1041,9 @@ std::vector<Nam> get_nams(
 
     // Find NAMs
     Timer nam_timer;
-    auto [nonrepetitive_fraction, n_hits, partial_hits, nams] = find_nams(query_randstrobes, index, map_param.use_mcs);
-    statistics.tot_find_nams += nam_timer.duration();
-    statistics.n_hits += n_hits;
+    auto [nonrepetitive_fraction, nonrepetitive_hits, partial_hits, sorting_needed, matches_map] = find_matches(query_randstrobes, index, map_param.use_mcs);
+    auto nams = merge_matches_into_nams_forward_and_reverse(matches_map, index.k(), sorting_needed);
+    statistics.n_hits += nonrepetitive_hits;
     statistics.n_partial_hits += partial_hits;
     details.nams = nams.size();
 
@@ -1057,6 +1057,9 @@ std::vector<Nam> get_nams(
         details.rescue_nams = nams.size();
         details.nam_rescue = true;
         statistics.tot_time_rescue += rescue_timer.duration();
+    } else {
+
+        statistics.tot_find_nams += nam_timer.duration();
     }
 
     // Sort by score

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1042,13 +1042,12 @@ std::vector<Nam> get_nams(
     // Find NAMs
     Timer nam_timer;
     auto [nonrepetitive_fraction, nonrepetitive_hits, partial_hits, sorting_needed, matches_map] = find_matches(query_randstrobes, index, map_param.use_mcs);
-    auto nams = merge_matches_into_nams_forward_and_reverse(matches_map, index.k(), sorting_needed);
+    std::vector<Nam> nams;
     statistics.n_hits += nonrepetitive_hits;
     statistics.n_partial_hits += partial_hits;
-    details.nams = nams.size();
 
     // Rescue if requested and needed
-    if (map_param.rescue_level > 1 && (nams.empty() || nonrepetitive_fraction < 0.7)) {
+    if (map_param.rescue_level > 1 && (nonrepetitive_hits == 0 || nonrepetitive_fraction < 0.7)) {
         Timer rescue_timer;
         int n_rescue_hits;
         std::tie(n_rescue_hits, partial_hits, nams) = find_nams_rescue(query_randstrobes, index, map_param.rescue_cutoff, map_param.use_mcs);
@@ -1058,7 +1057,8 @@ std::vector<Nam> get_nams(
         details.nam_rescue = true;
         statistics.tot_time_rescue += rescue_timer.duration();
     } else {
-
+        nams = merge_matches_into_nams_forward_and_reverse(matches_map, index.k(), sorting_needed);
+        details.nams = nams.size();
         statistics.tot_find_nams += nam_timer.duration();
     }
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1041,7 +1041,7 @@ std::vector<Nam> get_nams(
 
     // Find NAMs
     Timer nam_timer;
-    auto [nonrepetitive_fraction, nonrepetitive_hits, partial_hits, sorting_needed, matches_map] = find_matches(query_randstrobes, index, map_param.use_mcs);
+    auto [nonrepetitive_fraction, nonrepetitive_hits, partial_hits, sorting_needed, hits] = find_hits(query_randstrobes, index, map_param.use_mcs);
     std::vector<Nam> nams;
     statistics.n_hits += nonrepetitive_hits;
     statistics.n_partial_hits += partial_hits;
@@ -1057,6 +1057,10 @@ std::vector<Nam> get_nams(
         details.nam_rescue = true;
         statistics.tot_time_rescue += rescue_timer.duration();
     } else {
+        std::array<robin_hood::unordered_map<unsigned int, std::vector<Match>>, 2> matches_map;
+        matches_map[0].reserve(100);
+        matches_map[1].reserve(100);
+        matches_map = {hits_to_matches(hits[0], index), hits_to_matches(hits[1], index)};
         nams = merge_matches_into_nams_forward_and_reverse(matches_map, index.k(), sorting_needed);
         details.nams = nams.size();
         statistics.tot_find_nams += nam_timer.duration();

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -192,6 +192,23 @@ void merge_matches_into_nams(
 
 } // namespace
 
+robin_hood::unordered_map<unsigned int, std::vector<Match>> hits_to_matches(
+    const std::vector<Hit>& hits,
+    const StrobemerIndex& index
+) {
+    robin_hood::unordered_map<unsigned int, std::vector<Match>> matches_map;
+
+    for (const auto& hit : hits) {
+        if (hit.is_partial) {
+            add_to_matches_map_partial(matches_map, hit.query_start, hit.query_end, index, hit.position);
+        } else {
+            add_to_matches_map_full(matches_map, hit.query_start, hit.query_end, index, hit.position);
+        }
+    }
+
+    return matches_map;
+}
+
 std::vector<Nam> merge_matches_into_nams_forward_and_reverse(
     std::array<robin_hood::unordered_map<unsigned int, std::vector<Match>>, 2>& matches_map,
     int k,
@@ -205,14 +222,13 @@ std::vector<Nam> merge_matches_into_nams_forward_and_reverse(
     return nams;
 }
 
-
 /*
- * Find a query’s NAMs, ignoring randstrobes that occur too often in the
+ * Find a query’s hits, ignoring randstrobes that occur too often in the
  * reference (have a count above filter_cutoff).
  *
  * Return the fraction of nonrepetitive hits (those not above the filter_cutoff threshold)
  */
-std::tuple<float, int, int, bool, std::array<robin_hood::unordered_map<unsigned int, std::vector<Match>>, 2>> find_matches(
+std::tuple<float, int, int, bool, std::array<std::vector<Hit>, 2>> find_hits(
     const std::vector<QueryRandstrobe>& query_randstrobes,
     const StrobemerIndex& index,
     bool use_mcs
@@ -224,9 +240,7 @@ std::tuple<float, int, int, bool, std::array<robin_hood::unordered_map<unsigned 
     if (use_mcs) {
         partial_queried.reserve(10);
     }
-    std::array<robin_hood::unordered_map<unsigned int, std::vector<Match>>, 2> matches_map;
-    matches_map[0].reserve(100);
-    matches_map[1].reserve(100);
+    std::array<std::vector<Hit>, 2> hits;
     int nonrepetitive_hits = 0;
     int total_hits = 0;
     int partial_hits = 0;
@@ -237,10 +251,9 @@ std::tuple<float, int, int, bool, std::array<robin_hood::unordered_map<unsigned 
             if (index.is_filtered(position)) {
                 continue;
             }
+            hits[q.is_revcomp].push_back(Hit{position, q.start, q.end, false});
             nonrepetitive_hits++;
-            add_to_matches_map_full(matches_map[q.is_revcomp], q.start, q.end, index, position);
-        }
-        else if (use_mcs) {
+        } else if (use_mcs) {
             PartialHit ph{q.hash & index.get_main_hash_mask(), q.partial_start, q.is_revcomp};
             if (std::find(partial_queried.begin(), partial_queried.end(), ph) != partial_queried.end()) {
                 // already queried
@@ -255,7 +268,7 @@ std::tuple<float, int, int, bool, std::array<robin_hood::unordered_map<unsigned 
                 }
                 nonrepetitive_hits++;
                 partial_hits++;
-                add_to_matches_map_partial(matches_map[q.is_revcomp], q.partial_start, q.partial_end, index, partial_pos);
+                hits[q.is_revcomp].push_back(Hit{partial_pos, q.partial_start, q.partial_end, true});
             }
             partial_queried.push_back(ph);
         }
@@ -272,14 +285,14 @@ std::tuple<float, int, int, bool, std::array<robin_hood::unordered_map<unsigned 
                 }
                 nonrepetitive_hits++;
                 partial_hits++;
-                add_to_matches_map_partial(matches_map[q.is_revcomp], q.partial_start, q.partial_end, index, partial_pos);
+                hits[q.is_revcomp].push_back(Hit{partial_pos, q.partial_start, q.partial_end, true});
             }
         }
         sorting_needed = true;
     }
 
     float nonrepetitive_fraction = total_hits > 0 ? ((float) nonrepetitive_hits) / ((float) total_hits) : 1.0;
-    return {nonrepetitive_fraction, nonrepetitive_hits, partial_hits, sorting_needed, matches_map};
+    return {nonrepetitive_fraction, nonrepetitive_hits, partial_hits, sorting_needed, hits};
 }
 
 /*

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -6,6 +6,13 @@
 #include "index.hpp"
 #include "randstrobes.hpp"
 
+struct Hit {
+    size_t position;
+    size_t query_start;
+    size_t query_end;
+    bool is_partial;
+};
+
 struct Match {
     int query_start;
     int query_end;
@@ -44,7 +51,7 @@ struct Nam {
     }
 };
 
-std::tuple<float, int, int, bool, std::array<robin_hood::unordered_map<unsigned int, std::vector<Match>>, 2>> find_matches(
+std::tuple<float, int, int, bool, std::array<std::vector<Hit>, 2>> find_hits(
     const std::vector<QueryRandstrobe> &query_randstrobes,
     const StrobemerIndex& index,
     bool use_mcs
@@ -63,6 +70,11 @@ std::vector<Nam> merge_matches_into_nams_forward_and_reverse(
     std::array<robin_hood::unordered_map<unsigned int, std::vector<Match>>, 2>& matches_map,
     int k,
     bool sort
+);
+
+robin_hood::unordered_map<unsigned int, std::vector<Match>> hits_to_matches(
+    const std::vector<Hit>& hits,
+    const StrobemerIndex& index
 );
 
 #endif

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -6,6 +6,15 @@
 #include "index.hpp"
 #include "randstrobes.hpp"
 
+struct Match {
+    int query_start;
+    int query_end;
+    int ref_start;
+    int ref_end;
+};
+
+bool operator==(const Match& lhs, const Match& rhs);
+
 // Non-overlapping approximate match
 struct Nam {
     int nam_id;
@@ -35,7 +44,7 @@ struct Nam {
     }
 };
 
-std::tuple<float, int, int, std::vector<Nam>> find_nams(
+std::tuple<float, int, int, bool, std::array<robin_hood::unordered_map<unsigned int, std::vector<Match>>, 2>> find_matches(
     const std::vector<QueryRandstrobe> &query_randstrobes,
     const StrobemerIndex& index,
     bool use_mcs
@@ -49,5 +58,11 @@ std::tuple<int, int, std::vector<Nam>> find_nams_rescue(
 );
 
 std::ostream& operator<<(std::ostream& os, const Nam& nam);
+
+std::vector<Nam> merge_matches_into_nams_forward_and_reverse(
+    std::array<robin_hood::unordered_map<unsigned int, std::vector<Match>>, 2>& matches_map,
+    int k,
+    bool sort
+);
 
 #endif


### PR DESCRIPTION
In `find_nams`, we find hits, find matches and then merge matches into NAMs. However, if we determine that we need to run rescue, we throw away all of this anyway. To determine whether rescue needs to run, we only need the hits, so this PR changes `find_nams` into `find_hits`, which only finds hits. If it turns out that we do not run rescue, then looking up the hits to find matches and merging matches into NAMs is done later.

This saves approximately 1% runtime on CHM13, about 2% on drosophila and 8% on chrY.

This PR needs to be cleaned up a little bit more, but I won’t have time for that today.

For some reason, the results change very slightly although I think matches and NAMs are computed exactly the same way as before. My guess at the moment is that the iteration over the references in the matches_map changes (it’s just an unordered_map, so I believe the order in which it iterates over its keys is not defined).