### PR TITLE
Extend Python bindings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,11 @@ re-compile strobealign. This outputs a list of the found NAMs for each read.
 
 ## Testing
 
-After CMake has been run, you can use this one-liner to compile strobealign and
-run the tests:
+When your `build/` directory already exists
+(i.e., after you have run `cmake -B build`),
+you can use this one-liner to compile strobealign and run the tests:
 ```
-make -s -j -C build && tests/run.sh
+cmake --build build -j && tests/run.sh
 ```
 
 Whenever you make changes that could potentially affect mapping results, you can
@@ -48,9 +49,11 @@ The first time, it will download a *D. melanogaster* genome and some reads from
 the Sequence Read Archive (SRA). Since the dataset is truncated to the first
 100'000 reads, mapping it should take less than 30 seconds.
 
-The baseline commit is configured in `tests/baseline-commit.txt`. The script
-builds strobealign from that commit and runs it against the downloaded test
-data, then builds strobealign as it is in your working copy and compares the
+The baseline commit is the most recent commit that contains the trailer
+`Is-new-baseline: yes`.
+The script builds strobealign from that commit
+and runs it against the downloaded test data,
+then builds strobealign as it is in your working copy and compares the
 two produced BAM files. The baseline BAM is cached and re-used as long as the
 baseline commit does not change.
 

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -331,6 +331,11 @@ std::tuple<int, int, robin_hood::unordered_map<unsigned int, std::vector<Match>>
     return {n_hits, partial_hits, matches_map};
 }
 
+std::ostream& operator<<(std::ostream& os, const Hit& hit) {
+    os << "Hit(query_start=" << hit.query_start << ", query_end=" << hit.query_end << ", position=" << hit.position << ", is_partial=" << hit.is_partial << ")";
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& os, const Nam& n) {
     os << "Nam(ref_id=" << n.ref_id << ", query: " << n.query_start << ".." << n.query_end << ", ref: " << n.ref_start << ".." << n.ref_end << ", rc=" << static_cast<int>(n.is_revcomp) << ", score=" << n.score << ")";
     return os;

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -4,6 +4,7 @@ bool operator==(const Match& lhs, const Match& rhs) {
     return (lhs.query_start == rhs.query_start) && (lhs.query_end == rhs.query_end) && (lhs.ref_start == rhs.ref_start) && (lhs.ref_end == rhs.ref_end);
 }
 
+
 namespace {
 
 inline void add_to_matches_map_full(
@@ -335,6 +336,12 @@ std::ostream& operator<<(std::ostream& os, const Hit& hit) {
     os << "Hit(query_start=" << hit.query_start << ", query_end=" << hit.query_end << ", position=" << hit.position << ", is_partial=" << hit.is_partial << ")";
     return os;
 }
+
+std::ostream& operator<<(std::ostream& os, const Match& match) {
+    os << "Match(query_start=" << match.query_start << ", query_end=" << match.query_end << ", ref_start=" << match.ref_start << ", ref_end=" << match.ref_end << ")";
+    return os;
+}
+
 
 std::ostream& operator<<(std::ostream& os, const Nam& n) {
     os << "Nam(ref_id=" << n.ref_id << ", query: " << n.query_start << ".." << n.query_end << ", ref: " << n.ref_start << ".." << n.ref_end << ", rc=" << static_cast<int>(n.is_revcomp) << ", score=" << n.score << ")";

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -22,6 +22,8 @@ struct Match {
 };
 
 bool operator==(const Match& lhs, const Match& rhs);
+std::ostream& operator<<(std::ostream& os, const Match& match);
+
 
 // Non-overlapping approximate match
 struct Nam {

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -12,6 +12,8 @@ struct Hit {
     bool is_partial;
 };
 
+std::ostream& operator<<(std::ostream& os, const Hit& hit);
+
 struct Match {
     int query_start;
     int query_end;

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <sstream>
 #include "randstrobes.hpp"
+#include "revcomp.hpp"
 #include "refs.hpp"
 #include "index.hpp"
 #include "nam.hpp"
@@ -170,6 +171,7 @@ NB_MODULE(strobealign_extension, m_) {
         .def_ro("query_end", &Hit::query_end)
         .def_ro("is_partial", &Hit::is_partial)
     ;
+    m.def("reverse_complement", &reverse_complement);
     m.def("randstrobes_query", &randstrobes_query);
 
     m.def("find_hits", [](const std::vector<QueryRandstrobe>& query_randstrobes, const StrobemerIndex& index, bool use_mcs) -> std::vector<Hit> {

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -203,4 +203,20 @@ NB_MODULE(strobealign_extension, m_) {
 
         return map;
     }, nb::arg("hits"), nb::arg("index"));
+
+    m.def("merge_matches_into_nams", [](
+            const std::unordered_map<unsigned int, std::vector<Match>>& matches_map,
+            int k,
+            bool sort,
+            bool is_revcomp
+        ) -> std::vector<Nam> {
+        std::vector<Nam> nams;
+
+        robin_hood::unordered_map<unsigned int, std::vector<Match>> rhmap;
+        for (const auto& [key, value] : matches_map)
+            rhmap.insert({key, value});
+        merge_matches_into_nams(rhmap, k, sort, is_revcomp, nams);
+
+        return nams;
+    }, nb::arg("matches_map"), nb::arg("k"), nb::arg("sort"), nb::arg("is_revcomp"));
 }

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -170,6 +170,9 @@ NB_MODULE(strobealign_extension, m_) {
         .def_ro("query_start", &Hit::query_start)
         .def_ro("query_end", &Hit::query_end)
         .def_ro("is_partial", &Hit::is_partial)
+        .def("__repr__", [](const Hit& hit) {
+            std::stringstream s; s << hit; return s.str();
+        })
     ;
     m.def("reverse_complement", &reverse_complement);
     m.def("randstrobes_query", &randstrobes_query);

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -1,6 +1,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/bind_vector.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/array.h>
@@ -164,6 +165,7 @@ NB_MODULE(strobealign_extension, m_) {
     ;
     nb::bind_vector<std::vector<Nam>>(m, "NamVector");
     nb::bind_vector<std::vector<Hit>>(m, "HitVector");
+    nb::bind_vector<std::vector<Match>>(m, "MatchVector");
 
     nb::class_<Hit>(m, "Hit")
         .def_ro("position", &Hit::position)
@@ -174,12 +176,31 @@ NB_MODULE(strobealign_extension, m_) {
             std::stringstream s; s << hit; return s.str();
         })
     ;
+
+    nb::class_<Match>(m, "Match")
+        .def_ro("query_start", &Match::query_start)
+        .def_ro("query_end", &Match::query_end)
+        .def_ro("ref_start", &Match::ref_start)
+        .def_ro("ref_end", &Match::ref_end)
+        .def("__repr__", [](const Match& match) {
+            std::stringstream s; s << match; return s.str();
+        })
+    ;
+
     m.def("reverse_complement", &reverse_complement);
     m.def("randstrobes_query", &randstrobes_query);
 
     m.def("find_hits", [](const std::vector<QueryRandstrobe>& query_randstrobes, const StrobemerIndex& index, bool use_mcs) -> std::vector<Hit> {
         auto [total_hits, partial_hits, sorting_needed, hits] = find_hits(query_randstrobes, index, use_mcs);
         return hits;
-    }, nb::arg("query_randstrobes_pair"), nb::arg("index"), nb::arg("use_mcs"));
+    }, nb::arg("query_randstrobes"), nb::arg("index"), nb::arg("use_mcs"));
 
+    m.def("hits_to_matches", [](const std::vector<Hit>& hits, const StrobemerIndex& index) -> std::unordered_map<unsigned int, std::vector<Match>> {
+        auto rhmap = hits_to_matches(hits, index);
+        std::unordered_map<unsigned int, std::vector<Match>> map;
+        for (const auto& [key, value] : rhmap)
+            map.insert({key, value});
+
+        return map;
+    }, nb::arg("hits"), nb::arg("index"));
 }

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -55,6 +55,10 @@ def test_indexing_and_match_finding():
         assert ref_aligned == query_aligned
 
     matches = strobealign.hits_to_matches(hits, index)
+    assert matches
+    nams = strobealign.merge_matches_into_nams(matches, index.k, sort=False, is_revcomp=False)
+    assert nams
+    print(nams)
 
 
 def test_index_find():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -37,21 +37,23 @@ def test_indexing_and_hit_finding():
     index = strobealign.StrobemerIndex(refs, index_parameters)
     index.populate()
 
-    # Find NAMs for a single query sequence
+    # Find NAMs for a single query sequence (matches in forward orientation on
+    # the reference)
     query = "TGCGTTTATGGTACGCTGGACTTTGTGGGATACCCTCGCTTTCCTGCTCCTGTTGAGTTTATTGCTGCCG"
     randstrobes = strobealign.randstrobes_query(query, index_parameters)
-
-    for is_revcomp in (0, 1):
-        hits = strobealign.find_hits(randstrobes[is_revcomp], index, use_mcs=False)
-        assert hits
-        for hit in hits:
-            reference_index = index.reference_index(hit.position)
-            ref = refs[reference_index].sequence
-            reference_start = index.get_strobe1_position(hit.position)
-            reference_end = reference_start + index.strobe2_offset(hit.position) + index.k
-            ref_aligned = ref[reference_start:reference_end]
-            query_aligned = query[hit.query_start:hit.query_end]
-            hit.is_partial
+    # For this test, we ignore the randstrobes for the reverse-complemented query
+    randstrobes = randstrobes[0]
+    hits = strobealign.find_hits(randstrobes, index, use_mcs=False)
+    for hit in hits:
+        reference_index = index.reference_index(hit.position)
+        ref = refs[reference_index].sequence
+        reference_start = index.get_strobe1_position(hit.position)
+        assert not hit.is_partial
+        reference_end = reference_start + index.strobe2_offset(hit.position) + index.k
+        ref_aligned = ref[reference_start:reference_end]
+        query_aligned = query[hit.query_start:hit.query_end]
+        assert ref_aligned == query_aligned
+        hit.is_partial
 
 
 def test_index_find():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -25,6 +25,12 @@ def test_index_parameters():
     assert isinstance(params.randstrobe.w_max, int)
 
 
+def test_reverse_complement():
+    assert strobealign.reverse_complement("") == ""
+    assert strobealign.reverse_complement("A") == "T"
+    assert strobealign.reverse_complement("AAAACCCGGT") == "ACCGGGTTTT"
+
+
 def test_indexing_and_hit_finding():
     refs = strobealign.References.from_fasta("tests/phix.fasta")
     index_parameters = strobealign.IndexParameters.from_read_length(100)

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -31,7 +31,7 @@ def test_reverse_complement():
     assert strobealign.reverse_complement("AAAACCCGGT") == "ACCGGGTTTT"
 
 
-def test_indexing_and_hit_finding():
+def test_indexing_and_match_finding():
     refs = strobealign.References.from_fasta("tests/phix.fasta")
     index_parameters = strobealign.IndexParameters.from_read_length(100)
     index = strobealign.StrobemerIndex(refs, index_parameters)
@@ -53,7 +53,8 @@ def test_indexing_and_hit_finding():
         ref_aligned = ref[reference_start:reference_end]
         query_aligned = query[hit.query_start:hit.query_end]
         assert ref_aligned == query_aligned
-        hit.is_partial
+
+    matches = strobealign.hits_to_matches(hits, index)
 
 
 def test_index_find():


### PR DESCRIPTION
The Python bindings were a bit out of date. Previously, strobealign had a single `find_nams` function, but this was split up into `find_hits`, `hits_to_matches` and `merge_matches_into_nams`. The bindings only had the first function. This PR adds the other two.