### PR TITLE
Fix out-of-bounds memory access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Strobealign Changelog
 
+## development version
+
+* #497: Fix a crash on macOS (ARM) and possible undefined behavior on Linux.
+
 ## v0.16.0 (2025-04-11)
 
 * #476: Improve accuracy by enabling (by default) a variant of multi-context

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -124,14 +124,19 @@ struct StrobemerIndex {
     }
 
     bool is_filtered_forward(bucket_index_t position) const {
+        assert(position < randstrobes.size());
         return get_hash(position) == get_hash(position + filter_cutoff);
     }
 
     bool is_filtered(bucket_index_t position, randstrobe_hash_t hash_revcomp) const {
+        assert(position < randstrobes.size());
         if (is_filtered_forward(position)) {
             return true;
         }
         bucket_index_t position_revcomp = find_full(hash_revcomp);
+        if (position_revcomp == end()) {
+            return false;
+        }
         if (is_filtered_forward(position_revcomp)) {
             return true;
         }
@@ -141,14 +146,19 @@ struct StrobemerIndex {
     }
 
     bool is_partial_filtered_forward(bucket_index_t position) const {
+        assert(position < randstrobes.size());
         return get_main_hash(position) == get_main_hash(position + partial_filter_cutoff);
     }
 
     bool is_partial_filtered(bucket_index_t position, randstrobe_hash_t hash_revcomp) const {
+        assert(position < randstrobes.size());
         if (is_partial_filtered_forward(position)) {
             return true;
         }
         bucket_index_t position_revcomp = find_partial(hash_revcomp);
+        if (position_revcomp == end()) {
+            return false;
+        }
         if (is_partial_filtered_forward(position_revcomp)) {
             return true;
         }


### PR DESCRIPTION
`find_partial` and `find_full` can return the special value `end()`, which indicates that the hash was not found. We need to check for this value before using it as an index into the randstrobes vector.

This fixes a crash on macOS.