### PR TITLE
compile fix; initialize alignment struct

### DIFF
--- a/src/sam.hpp
+++ b/src/sam.hpp
@@ -10,14 +10,14 @@
 
 
 struct Alignment {
-    int ref_id;
-    int ref_start;
+    int ref_id{-1};
+    int ref_start{-1};
     Cigar cigar;
-    int edit_distance;
-    int global_ed;
-    int score;
-    int length;
-    bool is_revcomp;
+    int edit_distance{0};
+    int global_ed{-1};
+    int score{0};
+    int length{0};
+    bool is_revcomp{false};
     bool is_unaligned{false};
     // Whether a gapped alignment function was used to obtain this alignment
     // (even if true, the alignment can still be without gaps)


### PR DESCRIPTION
```
$ g++ --version
g++ (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

```
[ 25%] Building CXX object CMakeFiles/salib.dir/src/aln.cpp.o
In file included from /home/sj/strobealign/src/aln.hpp:10,
                 from /home/sj/strobealign/src/aln.cpp:1:
/home/sj/strobealign/src/sam.hpp: In function ‘Alignment {anonymous}::extend_seed(const Aligner&, const Nam&, const References&, const Read&, bool)’:
/home/sj/strobealign/src/sam.hpp:12:8: error: ‘alignment.Alignment::ref_id’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   12 | struct Alignment {
      |        ^~~~~~~~~
/home/sj/strobealign/src/aln.cpp:255:23: note: ‘alignment.Alignment::ref_id’ was declared here
  255 |             Alignment alignment;
      |                       ^~~~~~~~~
In file included from /home/sj/strobealign/src/aln.hpp:10,
                 from /home/sj/strobealign/src/aln.cpp:1:
/home/sj/strobealign/src/sam.hpp:12:8: error: ‘alignment.Alignment::global_ed’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   12 | struct Alignment {
      |        ^~~~~~~~~
/home/sj/strobealign/src/aln.cpp:255:23: note: ‘alignment.Alignment::global_ed’ was declared here
  255 |             Alignment alignment;
      |                       ^~~~~~~~~
In file included from /home/sj/strobealign/src/aln.hpp:10,
                 from /home/sj/strobealign/src/aln.cpp:1:
/home/sj/strobealign/src/sam.hpp:12:8: error: ‘alignment.Alignment::length’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   12 | struct Alignment {
      |        ^~~~~~~~~
/home/sj/strobealign/src/aln.cpp:255:23: note: ‘alignment.Alignment::length’ was declared here
  255 |             Alignment alignment;
      |                       ^~~~~~~~~
In file included from /home/sj/strobealign/src/aln.hpp:10,
                 from /home/sj/strobealign/src/aln.cpp:1:
/home/sj/strobealign/src/sam.hpp:12:8: error: ‘alignment.Alignment::is_revcomp’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   12 | struct Alignment {
      |        ^~~~~~~~~
/home/sj/strobealign/src/aln.cpp:255:23: note: ‘alignment.Alignment::is_revcomp’ was declared here
  255 |             Alignment alignment;
      |                       ^~~~~~~~~
cc1plus: some warnings being treated as errors
make[2]: *** [CMakeFiles/salib.dir/build.make:167: CMakeFiles/salib.dir/src/aln.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:157: CMakeFiles/salib.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```