### PR TITLE
Tune clang-format settings a bit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,22 @@
 ---
-Language:        Cpp
-BasedOnStyle:  Chromium
+Language: Cpp
+BasedOnStyle: Chromium
 AlignAfterOpenBracket: BlockIndent
-IndentWidth:     4
-ColumnLimit:     110
-ReflowComments:  false
+AlignOperands: DontAlign
+BinPackArguments: false
+IndentWidth: 4
+ColumnLimit: 110
+ReflowComments: false
 BreakConstructorInitializers: BeforeComma
 BreakInheritanceList: BeforeComma
 SpaceAfterCStyleCast: true
 SpaceInEmptyBlock: true
+AccessModifierOffset: -2
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterControlStatement: MultiLine
+AllowShortBlocksOnASingleLine: Empty
+AlignTrailingComments:
+    Kind: Never
 
 # Possibly configure IncludeCategories


### PR DESCRIPTION
We’re not actually using clang-format, yet (PR #266 is unmerged), but there is a `.clang-format` file in the repository already. This updates that file so that anyone who wants to format new files with it (such as the upcoming `chain.cpp`) can use it and get it formatted the way we would like it.