### PR TITLE
Missing cstdint header

### DIFF
--- a/ext/zstr/src/zstr.hpp
+++ b/ext/zstr/src/zstr.hpp
@@ -14,6 +14,7 @@
 #include <zlib.h>
 #include <memory>
 #include <iostream>
+#include <cstdint>
 #include "strict_fstream.hpp"
 
 #if defined(__GNUC__) && !defined(__clang__)


### PR DESCRIPTION
fix: g++ 15.1.1