### PR TITLE
Add a --trace command-line option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ include(ExternalProject)
 
 option(ENABLE_AVX "Enable AVX2 support" OFF)
 option(PYTHON_BINDINGS "Build Python bindings" OFF)
-option(TRACE "Highly verbose debugging output" OFF)
 
 find_package(ZLIB)
 find_package(Threads)

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -9,8 +9,12 @@
 #include "nam.hpp"
 #include "paf.hpp"
 #include "aligner.hpp"
+#include "logger.hpp"
 
 using namespace klibpp;
+
+static Logger& logger = Logger::get();
+
 
 namespace {
 
@@ -1092,13 +1096,13 @@ std::vector<Nam> get_nams(
     shuffle_top_nams(nams, random_engine);
     statistics.tot_sort_nams += nam_sort_timer.duration();
 
-#ifdef TRACE
-    std::cerr << "Query: " << record.name << '\n';
-    std::cerr << "Found " << nams.size() << " NAMs\n";
-    for (const auto& nam : nams) {
-        std::cerr << "- " << nam << '\n';
+    if (logger.level() <= LOG_TRACE) {
+        logger.trace() << "Query: " << record.name << '\n';
+        logger.trace() << "Found " << nams.size() << " NAMs\n";
+        for (const auto& nam : nams) {
+            logger.trace() << "- " << nam << '\n';
+        }
     }
-#endif
 
     return nams;
 }
@@ -1123,9 +1127,7 @@ void align_or_map_paired(
 
     for (size_t is_r1 : {0, 1}) {
         const auto& record = is_r1 == 0 ? record1 : record2;
-#ifdef TRACE
-        std::cerr << "R" << is_r1 + 1 << '\n';
-#endif
+        logger.trace() << "R" << is_r1 + 1 << '\n';
         nams_pair[is_r1] = get_nams(record, index, statistics, details[is_r1], map_param, index_parameters, random_engine);
     }
 

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -25,6 +25,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::Group io(parser, "Input/output:");
     args::ValueFlag<std::string> o(parser, "PATH", "redirect output to file [stdout]", {'o'});
     args::Flag v(parser, "v", "Verbose output", {'v'});
+    args::Flag trace(parser, "trace", "Highly verbose debugging output", {"trace"}, args::Options::Hidden);
     args::Flag no_progress(parser, "no-progress", "Disable progress report (enabled by default if output is a terminal)", {"no-progress"});
     args::Flag x(parser, "x", "Only map reads, no base level alignment (produces PAF file)", {'x'});
     args::Flag aemb(parser, "aemb", "Output the estimated abundance value of contigs, the format of output file is: contig_id \t abundance_value", {"aemb"});
@@ -89,11 +90,12 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
 
     // Threading
     if (threads) { opt.n_threads = args::get(threads); }
-    if (chunk_size) { opt.chunk_size = args::get(chunk_size); }
+    if (chunk_size && !trace) { opt.chunk_size = args::get(chunk_size); }
 
     // Input/output
     if (o) { opt.output_file_name = args::get(o); opt.write_to_stdout = false; }
     if (v) { opt.verbose = true; }
+    if (trace) { opt.trace = true; }
     if (no_progress) { opt.show_progress = false; }
     if (x) { opt.is_sam_out = false; }
     if (index_statistics) { opt.logfile_name = args::get(index_statistics); }

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -7,18 +7,13 @@
 
 struct CommandLineOptions {
     int n_threads { 1 };
-    int chunk_size {
-#ifdef TRACE
-        1
-#else
-        10000
-#endif
-    };
+    int chunk_size{10000};
 
     // Input/output
     std::string output_file_name;
     bool write_to_stdout { true };
     bool verbose { false };
+    bool trace { false };
     bool show_progress { true };
     std::string logfile_name { "" };
     bool only_gen_index { false };

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -6,24 +6,24 @@
 
 
 /*
-
 Very simple logging.
 
 Usage:
 
-logger = Logger::get();  // returns the logging singleton
-logger.set_level(LOG_INFO);
-logger.info() << "info message" << std::endl; // printed
-logger.debug() << "debug message" << std::endl; // not printed
+    logger = Logger::get();  // returns the logging singleton
+    logger.set_level(LOG_INFO);
+    logger.info() << "info message" << std::endl; // printed
+    logger.debug() << "debug message" << std::endl; // not printed
 
 */
 
 
 enum LOG_LEVELS {
-    LOG_DEBUG = 1,
-    LOG_INFO = 2,
-    LOG_WARNING = 3,
-    LOG_ERROR = 4,
+    LOG_TRACE = 1,
+    LOG_DEBUG = 2,
+    LOG_INFO = 3,
+    LOG_WARNING = 4,
+    LOG_ERROR = 5,
 };
 
 class Logger;
@@ -49,7 +49,9 @@ public:
     Logger(Logger const&) = delete;
     void operator=(Logger const&) = delete;
 
-    void set_level(int level) { this->level = level; }
+    void set_level(int level) { this->_level = level; }
+    int level() const { return this->_level; }
+    LogStream& trace() { return _trace; }
     LogStream& debug() { return _debug; }
     LogStream& info() { return _info; }
     LogStream& warning() { return _warning; }
@@ -57,15 +59,17 @@ public:
 
 private:
     Logger()
-        : level(LOG_WARNING)
+        : _level(LOG_WARNING)
         , _os(std::cerr)
+        , _trace(LogStream(LOG_TRACE, *this))
         , _debug(LogStream(LOG_DEBUG, *this))
         , _info(LogStream(LOG_INFO, *this))
         , _warning(LogStream(LOG_WARNING, *this))
         , _error(LogStream(LOG_ERROR, *this))
     { }
-    int level;
+    int _level;
     std::ostream& _os;
+    LogStream _trace;
     LogStream _debug;
     LogStream _info;
     LogStream _warning;
@@ -77,7 +81,7 @@ private:
 
 template <typename T>
 LogStream& LogStream::operator<<(const T& val) {
-    if (level >= logger.level) {
+    if (level >= logger._level) {
         logger._os << val;
     }
     return *this;
@@ -85,7 +89,7 @@ LogStream& LogStream::operator<<(const T& val) {
 
 // This overload is required for supporting std::endl
 inline LogStream& LogStream::operator<<(std::ostream& (*f)(std::ostream&)) {
-    if (level >= logger.level) {
+    if (level >= logger._level) {
         f(logger._os);
     }
     return *this;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,7 +133,13 @@ void show_progress_until_done(std::vector<int>& worker_done, std::vector<Alignme
 int run_strobealign(int argc, char **argv) {
     auto opt = parse_command_line_arguments(argc, argv);
 
-    logger.set_level(opt.verbose ? LOG_DEBUG : LOG_INFO);
+    if (opt.trace) {
+        logger.set_level(LOG_TRACE);
+    } else if (opt.verbose) {
+        logger.set_level(LOG_DEBUG);
+    } else {
+        logger.set_level(LOG_INFO);
+    }
     logger.info() << std::setprecision(2) << std::fixed;
     logger.info() << "This is strobealign " << version_string() << '\n';
     logger.debug() << "Build type: " << CMAKE_BUILD_TYPE << '\n';


### PR DESCRIPTION
To get highly verbose trace output (which prints all NAMs found for each read), we previously needed to re-run cmake with `-DTRACE` and then re-compile strobealign.

This PR adds a command-line option `--trace` instead (it’s currently hidden in the `--help` output), which is a lot more convenient.

I originally made this a compile-time option because I wanted to avoid the runtime overhead when tracing is not requested, but this doesn’t make sense because the overhead should be just a couple of cycles per query. (I was thinking of Python, where this is more relevant.)