### PR TITLE
Add command-line option for setting the MCS strategy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(salib STATIC ${SOURCES}
   src/refs.cpp
   src/fastq.cpp
   src/cmdline.cpp
+  src/mcsstrategy.cpp
   src/index.cpp
   src/indexparameters.cpp
   src/sam.cpp

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -1053,7 +1053,7 @@ std::vector<Nam> get_nams(
     for (int is_revcomp : {0, 1}) {
         int total_hits1, partial_hits1;
         bool sorting_needed1;
-        std::tie(total_hits1, partial_hits1, sorting_needed1, hits[is_revcomp]) = find_hits(query_randstrobes[is_revcomp], index, map_param.use_mcs);
+        std::tie(total_hits1, partial_hits1, sorting_needed1, hits[is_revcomp]) = find_hits(query_randstrobes[is_revcomp], index, map_param.mcs_strategy);
         sorting_needed = sorting_needed || sorting_needed1;
         total_hits += total_hits1;
         partial_hits += partial_hits1;
@@ -1072,7 +1072,7 @@ std::vector<Nam> get_nams(
         int n_rescue_hits{0};
         int n_partial_hits{0};
         for (int is_revcomp : {0, 1}) {
-            auto [n_rescue_hits_oriented, n_partial_hits_oriented, matches_map] = find_matches_rescue(query_randstrobes[is_revcomp], index, map_param.rescue_cutoff, map_param.use_mcs);
+            auto [n_rescue_hits_oriented, n_partial_hits_oriented, matches_map] = find_matches_rescue(query_randstrobes[is_revcomp], index, map_param.rescue_cutoff, map_param.mcs_strategy);
             merge_matches_into_nams(matches_map, index.k(), true, is_revcomp, nams);
             n_rescue_hits += n_rescue_hits_oriented;
             n_partial_hits += n_partial_hits_oriented;

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -12,7 +12,7 @@
 #include "insertsizedistribution.hpp"
 #include "statistics.hpp"
 #include "nam.hpp"
-
+#include "mcsstrategy.hpp"
 
 enum class OutputFormat {
     SAM,
@@ -36,7 +36,7 @@ struct MappingParameters {
     int rescue_level { 2 };
     int max_tries { 20 };
     int rescue_cutoff;
-    bool use_mcs{false};  // multi-context seeds
+    McsStrategy mcs_strategy{McsStrategy::Rescue};
     OutputFormat output_format {OutputFormat::SAM};
     CigarOps cigar_ops{CigarOps::M};
     bool output_unmapped { true };

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -3,6 +3,7 @@
 #include <args.hxx>
 #include "arguments.hpp"
 #include "version.hpp"
+#include "mcsstrategy.hpp"
 
 class Version {};
 
@@ -63,8 +64,12 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     args::ValueFlag<int> max_ref_gap(parser, "INT", "Collinear chaining skip distance, how far on the reference do we allow anchors to chain [10000]", {"sg"});
     args::ValueFlag<float> matches_weight(parser, "FLOAT", "Weight given to the number of anchors for the final score of chains [0.01]", {"mw"});
 
+    std::unordered_map<std::string, McsStrategy> mcs_map{
+        {"rescue", McsStrategy::Rescue},
+        {"always", McsStrategy::Always},
+    };
     args::Group search(parser, "Search parameters:");
-    args::Flag mcs(parser, "mcs", "Use extended multi-context seed mode for finding hits. Slightly more accurate, but slower", {"mcs"});
+    args::MapFlag mcs(parser, "mcs", "How multi-context seeds are used. Allowed: 'rescue' (default), 'always'", {"mcs"}, mcs_map);
     args::ValueFlag<float> f(parser, "FLOAT", "Top fraction of repetitive strobemers to filter out from sampling [0.0002]", {'f'});
     args::ValueFlag<float> S(parser, "FLOAT", "Try candidate sites with mapping score at least S of maximum mapping score [0.5]", {'S'});
     args::ValueFlag<int> M(parser, "INT", "Maximum number of mapping sites to try [20]", {'M'});
@@ -151,7 +156,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     if (matches_weight) { opt.matches_weight = args::get(matches_weight); }
 
     // Search parameters
-    if (mcs) { opt.mcs = args::get(mcs); }
+    if (mcs) { opt.mcs_strategy = args::get(mcs); }
     if (f) { opt.f = args::get(f); }
     if (S) { opt.dropoff_threshold = args::get(S); }
     if (M) { opt.max_tries = args::get(M); }

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -67,9 +67,10 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     std::unordered_map<std::string, McsStrategy> mcs_map{
         {"rescue", McsStrategy::Rescue},
         {"always", McsStrategy::Always},
+        {"off", McsStrategy::Off},
     };
     args::Group search(parser, "Search parameters:");
-    args::MapFlag mcs(parser, "mcs", "How multi-context seeds are used. Allowed: 'rescue' (default), 'always'", {"mcs"}, mcs_map);
+    args::MapFlag mcs(parser, "mcs", "How multi-context seeds are used. Allowed: 'rescue' (default), 'always', 'off'", {"mcs"}, mcs_map);
     args::ValueFlag<float> f(parser, "FLOAT", "Top fraction of repetitive strobemers to filter out from sampling [0.0002]", {'f'});
     args::ValueFlag<float> S(parser, "FLOAT", "Try candidate sites with mapping score at least S of maximum mapping score [0.5]", {'S'});
     args::ValueFlag<int> M(parser, "INT", "Maximum number of mapping sites to try [20]", {'M'});

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -68,9 +68,10 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
         {"rescue", McsStrategy::Rescue},
         {"always", McsStrategy::Always},
         {"off", McsStrategy::Off},
+        {"first-strobe", McsStrategy::FirstStrobe},
     };
     args::Group search(parser, "Search parameters:");
-    args::MapFlag mcs(parser, "mcs", "How multi-context seeds are used. Allowed: 'rescue' (default), 'always', 'off'", {"mcs"}, mcs_map);
+    args::MapFlag mcs(parser, "mcs", "How multi-context seeds are used. Allowed: 'rescue' (default), 'always', 'off', 'first-strobe'", {"mcs"}, mcs_map);
     args::ValueFlag<float> f(parser, "FLOAT", "Top fraction of repetitive strobemers to filter out from sampling [0.0002]", {'f'});
     args::ValueFlag<float> S(parser, "FLOAT", "Try candidate sites with mapping score at least S of maximum mapping score [0.5]", {'S'});
     args::ValueFlag<int> M(parser, "INT", "Maximum number of mapping sites to try [20]", {'M'});

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <utility>
 
+#include "mcsstrategy.hpp"
+
 struct CommandLineOptions {
     int n_threads { 1 };
     int chunk_size{10000};
@@ -66,7 +68,7 @@ struct CommandLineOptions {
     float matches_weight { 0.01 };
 
     // Search parameters
-    bool mcs { false };
+    McsStrategy mcs_strategy { McsStrategy::Rescue };
     float f { 0.0002 };
     float dropoff_threshold { 0.5 };
     int max_tries { 20 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,7 +183,7 @@ int run_strobealign(int argc, char **argv) {
     map_param.dropoff_threshold = opt.dropoff_threshold;
     map_param.rescue_level = opt.rescue_level;
     map_param.max_tries = opt.max_tries;
-    map_param.use_mcs = opt.mcs;
+    map_param.mcs_strategy = opt.mcs_strategy;
     map_param.output_format = (
             opt.is_abundance_out ? OutputFormat::Abundance :
             opt.is_sam_out ? OutputFormat::SAM :
@@ -231,7 +231,7 @@ int run_strobealign(int argc, char **argv) {
     }
 
     logger.debug() << "Auxiliary hash length: " << opt.aux_len << "\n";
-    logger.info() << "Using multi-context seeds: " << (map_param.use_mcs ? "yes" : "no") << '\n';
+    logger.info() << "Multi-context seed strategy: " << map_param.mcs_strategy << '\n';
     StrobemerIndex index(references, index_parameters, opt.bits);
     if (opt.use_index) {
         // Read the index from a file

--- a/src/mcsstrategy.cpp
+++ b/src/mcsstrategy.cpp
@@ -1,0 +1,8 @@
+#include "mcsstrategy.hpp"
+
+std::ostream& operator<<(std::ostream& os, const McsStrategy& mcs_strategy) {
+    if (mcs_strategy == McsStrategy::Always) { os <<  "always"; }
+    else if (mcs_strategy == McsStrategy::Rescue) { os << "rescue"; }
+
+    return os;
+}

--- a/src/mcsstrategy.hpp
+++ b/src/mcsstrategy.hpp
@@ -13,8 +13,11 @@ enum class McsStrategy {
     // query, no hits were generated, do partial lookups of each strobemer.
     Rescue,
 
-    // Do full lookups only
+    // Do full lookups only.
     Off,
+
+    // Do partial lookups only, that is, use only the first strobe.
+    FirstStrobe,
 };
 
 std::ostream& operator<<(std::ostream& os, const McsStrategy& mcs_strategy);

--- a/src/mcsstrategy.hpp
+++ b/src/mcsstrategy.hpp
@@ -1,0 +1,19 @@
+#ifndef STROBEALIGN_MCSSTRATEGY_HPP
+#define STROBEALIGN_MCSSTRATEGY_HPP
+
+#include <sstream>
+
+// Different ways in which multi-context seeds (MCS) are used
+enum class McsStrategy {
+    // For each strobemer, do a full lookup. If that did not generate a hit,
+    // try a partial lookup.
+    Always,
+
+    // For each strobemer, do a full lookup. If after processing the entire
+    // query, no hits were generated, do partial lookups of each strobemer.
+    Rescue,
+};
+
+std::ostream& operator<<(std::ostream& os, const McsStrategy& mcs_strategy);
+
+#endif

--- a/src/mcsstrategy.hpp
+++ b/src/mcsstrategy.hpp
@@ -12,6 +12,9 @@ enum class McsStrategy {
     // For each strobemer, do a full lookup. If after processing the entire
     // query, no hits were generated, do partial lookups of each strobemer.
     Rescue,
+
+    // Do full lookups only
+    Off,
 };
 
 std::ostream& operator<<(std::ostream& os, const McsStrategy& mcs_strategy);

--- a/src/nam.hpp
+++ b/src/nam.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include "index.hpp"
 #include "randstrobes.hpp"
+#include "mcsstrategy.hpp"
 
 struct Hit {
     size_t position;
@@ -59,14 +60,14 @@ std::ostream& operator<<(std::ostream& os, const Nam& nam);
 std::tuple<int, int, bool, std::vector<Hit>> find_hits(
     const std::vector<QueryRandstrobe>& query_randstrobes,
     const StrobemerIndex& index,
-    bool use_mcs
+    McsStrategy mcs_strategy
 );
 
 std::tuple<int, int, robin_hood::unordered_map<unsigned int, std::vector<Match>>> find_matches_rescue(
     const std::vector<QueryRandstrobe>& query_randstrobes,
     const StrobemerIndex& index,
     unsigned int rescue_cutoff,
-    bool use_mcs
+    McsStrategy mcs_strategy
 );
 
 void merge_matches_into_nams(

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -190,10 +190,17 @@ NB_MODULE(strobealign_extension, m_) {
     m.def("reverse_complement", &reverse_complement);
     m.def("randstrobes_query", &randstrobes_query);
 
-    m.def("find_hits", [](const std::vector<QueryRandstrobe>& query_randstrobes, const StrobemerIndex& index, bool use_mcs) -> std::vector<Hit> {
-        auto [total_hits, partial_hits, sorting_needed, hits] = find_hits(query_randstrobes, index, use_mcs);
+    nb::enum_<McsStrategy>(m, "McsStrategy")
+        .value("Always", McsStrategy::Always)
+        .value("Rescue", McsStrategy::Rescue)
+        .value("Off", McsStrategy::Off)
+        .value("FirstStrobe", McsStrategy::FirstStrobe)
+        .export_values();
+
+    m.def("find_hits", [](const std::vector<QueryRandstrobe>& query_randstrobes, const StrobemerIndex& index, McsStrategy mcs_strategy) -> std::vector<Hit> {
+        auto [total_hits, partial_hits, sorting_needed, hits] = find_hits(query_randstrobes, index, mcs_strategy);
         return hits;
-    }, nb::arg("query_randstrobes"), nb::arg("index"), nb::arg("use_mcs"));
+    }, nb::arg("query_randstrobes"), nb::arg("index"), nb::arg("mcs_strategy"));
 
     m.def("hits_to_matches", [](const std::vector<Hit>& hits, const StrobemerIndex& index) -> std::unordered_map<unsigned int, std::vector<Match>> {
         auto rhmap = hits_to_matches(hits, index);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -120,7 +120,7 @@ diff tests/phix.se.sam multiblock.sam
 rm multiblock.fastq.gz multiblock.sam
 
 # Single-end PAF with multi-context seeds
-strobealign --mcs -x tests/phix.fasta tests/phix.1.fastq | tail -n 11 > phix.mcs.se.paf
+strobealign --mcs=always -x tests/phix.fasta tests/phix.1.fastq | tail -n 11 > phix.mcs.se.paf
 diff tests/phix.mcs.se.paf phix.mcs.se.paf
 rm phix.mcs.se.paf
 

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -43,7 +43,7 @@ def test_indexing_and_match_finding():
     randstrobes = strobealign.randstrobes_query(query, index_parameters)
     # For this test, we ignore the randstrobes for the reverse-complemented query
     randstrobes = randstrobes[0]
-    hits = strobealign.find_hits(randstrobes, index, use_mcs=False)
+    hits = strobealign.find_hits(randstrobes, index, mcs_strategy=strobealign.McsStrategy.Off)
     for hit in hits:
         reference_index = index.reference_index(hit.position)
         ref = refs[reference_index].sequence


### PR DESCRIPTION
This changes how the command-line option `--mcs` works: Instead of it being a flag that is either set or not (`--mcs` given or not), this is now an option that accepts one of four values:
- `--mcs=rescue` is the same as what we do now (do full lookup for each strobemer and then if there are no hits for a query, try partial lookup)
- `--mcs=always` is the same as what we currently do when `--mcs` is given: Do a full lookup for each strobemer and try partial lookup if that did not generate a hit.
- `--mcs=off` is new and turns off MCS, that is, it makes strobealign always do a full lookup.
- `--mcs=first-strobe` is also new and forces strobealign to only do partial lookups

This allows us to use a single strobealign binary for the benchmarks that then just gets run with different command-line options, which I think is cleaner.

This is not ready for merging because the merge base is the 'chaining' branch. Also, the Python bindings need to be fixed. But we should be able to use it for the benchmarks.