### PR TITLE
Add option for setting the number of indexing threads

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -21,6 +21,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
 
     // Threading
     args::ValueFlag<int> threads(parser, "INT", "Number of threads [1]", {'t', "threads"});
+    args::ValueFlag<int> indexing_threads(parser, "INT", "Number of threads for indexing [same as -t]", {"ithreads"}, args::Options::Hidden);
     args::ValueFlag<int> chunk_size(parser, "INT", "Number of reads processed by a worker thread at once [10000]", {"chunk-size"}, args::Options::Hidden);
 
     args::Group io(parser, "Input/output:");
@@ -106,6 +107,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
 
     // Threading
     if (threads) { opt.n_threads = args::get(threads); }
+    opt.indexing_threads = indexing_threads ? args::get(indexing_threads) : opt.n_threads;
     if (chunk_size && !trace) { opt.chunk_size = args::get(chunk_size); }
 
     // Input/output

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -9,6 +9,7 @@
 
 struct CommandLineOptions {
     int n_threads { 1 };
+    int indexing_threads{1};
     int chunk_size{10000};
 
     // Input/output

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,7 +208,8 @@ int run_strobealign(int argc, char **argv) {
         << "  Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.randstrobe.w_min << ", " << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.randstrobe.w_max << "]\n";
     logger.debug() << aln_params << '\n';
     logger.debug() << "Rescue level (R): " << map_param.rescue_level << '\n';
-    logger.debug() << "Threads: " << opt.n_threads << std::endl;
+    logger.debug() << "Indexing threads: " << opt.indexing_threads << std::endl;
+    logger.debug() << "Mapping threads: " << opt.n_threads << std::endl;
 
 //    assert(k <= (w/2)*w_min && "k should be smaller than (w/2)*w_min to avoid creating short strobemers");
 
@@ -246,7 +247,7 @@ int run_strobealign(int argc, char **argv) {
         logger.debug() << "Bits used to index buckets: " << index.get_bits() << "\n";
         logger.info() << "Indexing ...\n";
         Timer index_timer;
-        index.populate(opt.f, opt.n_threads);
+        index.populate(opt.f, opt.indexing_threads);
         
         logger.info() << "  Time counting seeds: " << index.stats.elapsed_counting_hashes.count() << " s" <<  std::endl;
         logger.info() << "  Time generating seeds: " << index.stats.elapsed_generating_seeds.count() << " s" <<  std::endl;


### PR DESCRIPTION
This adds the hidden command-line option `--ithreads`, which allows to set a different number of threads for indexing than for mapping/alignment.

This is mainly useful for debugging, for example, when also `--trace` is used: For `--trace`, one should use `--threads 1` because the output of multiple threads will otherwise interleave and not be useful. However, because indexing then also happens with just one thread, it can be a bit annoying to have to wait for that to happen. `--ithreads` solves this.