### PR TITLE
Add a missing include

### DIFF
--- a/src/randstrobes.hpp
+++ b/src/randstrobes.hpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <string_view>
 #include <inttypes.h>
+#include <array>
 
 #include "indexparameters.hpp"
 


### PR DESCRIPTION
Depending on the toolchain, it seems that the `<array>` header sometimes is already included some other way, which is why this was not noticed before.