### PR TITLE
More detailed randstrobe lookup statistics

### DIFF
--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -638,7 +638,6 @@ void output_aligned_pairs(
     auto [mapq1, mapq2] = joint_mapq_from_high_scores(high_scores);
     auto best_aln_pair = high_scores[0];
 
-
     // append both alignments to string here
     if (max_secondary == 0) {
         Alignment alignment1 = best_aln_pair.alignment1;

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -288,21 +288,19 @@ std::vector<Nam> Chainer::get_chains(
     Timer hits_timer;
 
     int total_hits = 0;
-    int partial_hits = 0;
+
     std::array<std::vector<Hit>, 2> hits;
     for (int is_revcomp : {0, 1}) {
-        int total_hits1, partial_hits1;
+        int total_hits1;
         bool sorting_needed1;
-        std::tie(total_hits1, partial_hits1, sorting_needed1, hits[is_revcomp]) =
+        HitsDetails hits_details1;
+        std::tie(hits_details1, total_hits1, sorting_needed1, hits[is_revcomp]) =
             find_hits(query_randstrobes[is_revcomp], index, map_param.mcs_strategy);
         total_hits += total_hits1;
-        partial_hits += partial_hits1;
+        details.hits += hits_details1;
     }
     int nonrepetitive_hits = hits[0].size() + hits[1].size();
     float nonrepetitive_fraction = total_hits > 0 ? ((float) nonrepetitive_hits) / ((float) total_hits) : 1.0;
-
-    statistics.n_hits += nonrepetitive_hits;
-    statistics.n_partial_hits += partial_hits;
     statistics.time_hit_finding += hits_timer.duration();
 
     std::vector<Nam> chains;
@@ -316,11 +314,11 @@ std::vector<Nam> Chainer::get_chains(
         // Rescue if requested and needed
         if (map_param.rescue_level > 1 && (nonrepetitive_hits == 0 || nonrepetitive_fraction < 0.7)) {
             Timer rescue_timer;
-            auto [n_rescue_hits, n_partial_hits] = find_anchors_rescue(
+            auto [n_hits, n_partial_hits] = find_anchors_rescue(
                 query_randstrobes[is_revcomp], index, map_param.rescue_cutoff, map_param.mcs_strategy, anchors
             );
-            statistics.n_rescue_hits += n_rescue_hits;
-            statistics.n_partial_hits += n_partial_hits;
+            statistics.n_rescue_hits += n_hits;
+            statistics.n_rescue_partial_hits += n_partial_hits;
             details.rescue_nams += chains.size();
             details.nam_rescue = true;
             statistics.tot_time_rescue += rescue_timer.duration();

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -287,18 +287,15 @@ std::vector<Nam> Chainer::get_chains(
 ) const {
     Timer hits_timer;
 
-    int total_hits = 0;
-
     std::array<std::vector<Hit>, 2> hits;
     for (int is_revcomp : {0, 1}) {
-        int total_hits1;
         bool sorting_needed1;
         HitsDetails hits_details1;
-        std::tie(hits_details1, total_hits1, sorting_needed1, hits[is_revcomp]) =
+        std::tie(hits_details1, sorting_needed1, hits[is_revcomp]) =
             find_hits(query_randstrobes[is_revcomp], index, map_param.mcs_strategy);
-        total_hits += total_hits1;
         details.hits += hits_details1;
     }
+    uint total_hits = details.hits.total_hits();
     int nonrepetitive_hits = hits[0].size() + hits[1].size();
     float nonrepetitive_fraction = total_hits > 0 ? ((float) nonrepetitive_hits) / ((float) total_hits) : 1.0;
     statistics.time_hit_finding += hits_timer.duration();

--- a/src/hits.cpp
+++ b/src/hits.cpp
@@ -4,7 +4,7 @@
  * Find a query’s hits, ignoring randstrobes that occur too often in the
  * reference (have a count above filter_cutoff).
  */
-std::tuple<HitsDetails, int, bool, std::vector<Hit>> find_hits(
+std::tuple<HitsDetails, bool, std::vector<Hit>> find_hits(
     const std::vector<QueryRandstrobe>& query_randstrobes,
     const StrobemerIndex& index,
     McsStrategy mcs_strategy
@@ -29,9 +29,8 @@ std::tuple<HitsDetails, int, bool, std::vector<Hit>> find_hits(
                 details.partial_not_found++;
             }
         }
-        uint partial_hits = details.partial_filtered + details.partial_found;
 
-        return {details, partial_hits, sorting_needed, hits};
+        return {details, sorting_needed, hits};
     }
 
     for (const auto &q : query_randstrobes) {
@@ -82,7 +81,7 @@ std::tuple<HitsDetails, int, bool, std::vector<Hit>> find_hits(
         sorting_needed = true;
     }
 
-    uint total_hits = details.partial_filtered + details.partial_found + details.full_filtered + details.full_found;
+    assert(details.full_found + details.partial_found == hits.size());
 
-    return {details, total_hits, sorting_needed, hits};
+    return {details, sorting_needed, hits};
 }

--- a/src/hits.cpp
+++ b/src/hits.cpp
@@ -30,7 +30,7 @@ std::tuple<int, int, bool, std::vector<Hit>> find_hits(
             }
         }
 
-        return {total_hits, partial_hits, sorting_needed, hits};
+        return {partial_hits, partial_hits, sorting_needed, hits};
     }
 
     for (const auto &q : query_randstrobes) {

--- a/src/hits.cpp
+++ b/src/hits.cpp
@@ -3,10 +3,8 @@
 /*
  * Find a query’s hits, ignoring randstrobes that occur too often in the
  * reference (have a count above filter_cutoff).
- *
- * Return the fraction of nonrepetitive hits (those not above the filter_cutoff threshold)
  */
-std::tuple<int, int, bool, std::vector<Hit>> find_hits(
+std::tuple<HitsDetails, int, bool, std::vector<Hit>> find_hits(
     const std::vector<QueryRandstrobe>& query_randstrobes,
     const StrobemerIndex& index,
     McsStrategy mcs_strategy
@@ -15,60 +13,76 @@ std::tuple<int, int, bool, std::vector<Hit>> find_hits(
     // does not have to re-sort
     bool sorting_needed{mcs_strategy == McsStrategy::Always || mcs_strategy == McsStrategy::FirstStrobe};
     std::vector<Hit> hits;
-    int total_hits = 0;
-    int partial_hits = 0;
+    HitsDetails details;
 
     if (mcs_strategy == McsStrategy::FirstStrobe) {
         for (const auto &q : query_randstrobes) {
             size_t partial_position = index.find_partial(q.hash);
             if (partial_position != index.end()) {
-                partial_hits++;
                 if (index.is_partial_filtered(partial_position, q.hash_revcomp)) {
+                    details.partial_filtered++;
                     continue;
                 }
+                details.partial_found++;
                 hits.push_back(Hit{partial_position, q.start, q.start + index.k(), true});
+            } else {
+                details.partial_not_found++;
             }
         }
+        uint partial_hits = details.partial_filtered + details.partial_found;
 
-        return {partial_hits, partial_hits, sorting_needed, hits};
+        return {details, partial_hits, sorting_needed, hits};
     }
 
     for (const auto &q : query_randstrobes) {
         size_t position = index.find_full(q.hash);
         if (position != index.end()) {
-            total_hits++;
             if (index.is_filtered(position, q.hash_revcomp)) {
+                details.full_filtered++;
                 continue;
             }
+            details.full_found++;
             hits.push_back(Hit{position, q.start, q.end, false});
-        } else if (mcs_strategy == McsStrategy::Always) {
-            size_t partial_pos = index.find_partial(q.hash);
-            if (partial_pos != index.end()) {
-                total_hits++;
-                if (index.is_partial_filtered(partial_pos, q.hash_revcomp)) {
-                    continue;
+        } else {
+            details.full_not_found++;
+            if (mcs_strategy == McsStrategy::Always) {
+                size_t partial_pos = index.find_partial(q.hash);
+                if (partial_pos != index.end()) {
+                    if (index.is_partial_filtered(partial_pos, q.hash_revcomp)) {
+                        details.partial_filtered++;
+                        continue;
+                    }
+                    details.partial_found++;
+                    hits.push_back(Hit{partial_pos, q.start, q.start + index.k(), true});
+                } else {
+                    details.partial_not_found++;
                 }
-                partial_hits++;
-                hits.push_back(Hit{partial_pos, q.start, q.start + index.k(), true});
             }
         }
     }
+    if (mcs_strategy == McsStrategy::Always) {
+        assert(details.full_not_found == details.partial_not_found + details.partial_filtered + details.partial_found);
+    }
 
     // Rescue using partial hits
-    if (mcs_strategy == McsStrategy::Rescue && total_hits == 0) {
+    if (mcs_strategy == McsStrategy::Rescue && details.full_filtered + details.full_found == 0) {
         for (const auto &q : query_randstrobes) {
             size_t partial_pos = index.find_partial(q.hash);
             if (partial_pos != index.end()) {
-                total_hits++;
                 if (index.is_partial_filtered(partial_pos, q.hash_revcomp)) {
+                    details.partial_filtered++;
                     continue;
                 }
-                partial_hits++;
+                details.partial_found++;
                 hits.push_back(Hit{partial_pos, q.start, q.start + index.k(), true});
+            } else {
+                details.partial_not_found++;
             }
         }
         sorting_needed = true;
     }
 
-    return {total_hits, partial_hits, sorting_needed, hits};
+    uint total_hits = details.partial_filtered + details.partial_found + details.full_filtered + details.full_found;
+
+    return {details, total_hits, sorting_needed, hits};
 }

--- a/src/hits.hpp
+++ b/src/hits.hpp
@@ -19,9 +19,30 @@ struct Hit {
     bool is_partial;
 };
 
+struct HitsDetails {
+    uint full_not_found{0};
+    uint full_filtered{0};  // found but filtered
+    uint full_found{0};  // found and not filtered (becomes a hit)
+
+    uint partial_not_found{0};
+    uint partial_filtered{0};
+    uint partial_found{0};
+
+    HitsDetails& operator+=(const HitsDetails& other) {
+        full_not_found += other.full_not_found;
+        full_filtered += other.full_filtered;
+        full_found += other.full_found;
+        partial_not_found += other.partial_not_found;
+        partial_filtered += other.partial_filtered;
+        partial_found += other.partial_found;
+
+        return *this;
+    }
+};
+
 std::ostream& operator<<(std::ostream& os, const Hit& hit);
 
-std::tuple<int, int, bool, std::vector<Hit>> find_hits(
+std::tuple<HitsDetails, int, bool, std::vector<Hit>> find_hits(
     const std::vector<QueryRandstrobe>& query_randstrobes,
     const StrobemerIndex& index,
     McsStrategy mcs_strategy

--- a/src/hits.hpp
+++ b/src/hits.hpp
@@ -9,9 +9,7 @@
 #include "index.hpp"
 #include "mcsstrategy.hpp"
 
-/* A Hit is the result of successfully looking up a strobemer in the index
- *
- */
+// A Hit is the result of successfully looking up a strobemer in the index
 struct Hit {
     size_t position;
     size_t query_start;
@@ -22,11 +20,15 @@ struct Hit {
 struct HitsDetails {
     uint full_not_found{0};
     uint full_filtered{0};  // found but filtered
-    uint full_found{0};  // found and not filtered (becomes a hit)
+    uint full_found{0};  // found and not filtered
 
     uint partial_not_found{0};
     uint partial_filtered{0};
     uint partial_found{0};
+
+    uint total_hits() const {
+        return partial_filtered + partial_found + full_filtered + full_found;
+    }
 
     HitsDetails& operator+=(const HitsDetails& other) {
         full_not_found += other.full_not_found;
@@ -42,7 +44,7 @@ struct HitsDetails {
 
 std::ostream& operator<<(std::ostream& os, const Hit& hit);
 
-std::tuple<HitsDetails, int, bool, std::vector<Hit>> find_hits(
+std::tuple<HitsDetails, bool, std::vector<Hit>> find_hits(
     const std::vector<QueryRandstrobe>& query_randstrobes,
     const StrobemerIndex& index,
     McsStrategy mcs_strategy

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,24 +363,38 @@ int run_strobealign(int argc, char **argv) {
     }
 
     logger.debug()
-        << "Number of reads:                 " << std::setw(12) << statistics.n_reads << std::endl
-        << "Number of randstrobes:           " << std::setw(12) << statistics.n_randstrobes
-        << "  Per read: " << std::setw(7) << static_cast<float>(statistics.n_randstrobes) / statistics.n_reads << std::endl
-        << "Number of partial hits:          " << std::setw(12) << statistics.n_partial_hits << '\n'
-        << "Number of non-rescue hits:       " << std::setw(12) << statistics.n_hits
-        << "  Per read: " << std::setw(7) << static_cast<float>(statistics.n_hits) / statistics.n_reads << std::endl
-        << "Number of non-rescue chains:     " << std::setw(12) << statistics.n_nams
-        << "  Per read: " << std::setw(7) << static_cast<float>(statistics.n_nams) / statistics.n_reads << std::endl
-        << "Number of chain rescue attempts: " << std::setw(12) << statistics.nam_rescue << std::endl
-        << "Number of rescue hits:           " << std::setw(12) << statistics.n_rescue_hits
-        << "  Per rescue attempt: " << std::setw(7) << static_cast<float>(statistics.n_rescue_hits) / statistics.nam_rescue << std::endl
-        << "Number of rescue chains:         " << std::setw(12) << statistics.n_rescue_nams
-        << "  Per rescue attempt: " << std::setw(7) << static_cast<float>(statistics.n_rescue_nams) / statistics.nam_rescue << std::endl;
-    logger.info()
+        << std::setprecision(1)
+        << "\n# Statistics\n"
+        << "\n"
+        << "Reads:                                   " << std::setw(12) << statistics.n_reads << std::endl
+        << "\n## Randstrobe lookup (without rescue)\n\n"
+        << "Randstrobes                              " << std::setw(12) << statistics.n_randstrobes
+        << "    100.0 %   Per read: " << std::setw(7) << static_cast<float>(statistics.n_randstrobes) / statistics.n_reads << std::endl
+        << "  Full randstrobe found                  " << std::setw(12) << statistics.hits.full_found
+            << std::setw(9) << static_cast<float>(statistics.hits.full_found) / statistics.n_randstrobes * 100 << " %\n"
+        << "  Full randstrobe found but filtered     " << std::setw(12) << statistics.hits.full_filtered
+            << std::setw(9) << static_cast<float>(statistics.hits.full_filtered) / statistics.n_randstrobes * 100 << " %\n"
+        << "  Full randstrobe not found              " << std::setw(12) << statistics.hits.full_not_found
+            << std::setw(9) << static_cast<float>(statistics.hits.full_not_found) / statistics.n_randstrobes * 100 << " %\n"
+        << "    Partial randstrobe found             " << std::setw(12) << statistics.hits.partial_found
+            << std::setw(9) << static_cast<float>(statistics.hits.partial_found) / statistics.n_randstrobes * 100 << " %\n"
+        << "    Partial randstrobe found but filtered" << std::setw(12) << statistics.hits.partial_filtered
+            << std::setw(9) << static_cast<float>(statistics.hits.partial_filtered) / statistics.n_randstrobes * 100 << " %\n"
+        << "    Partial randstrobe not found         " << std::setw(12) << statistics.hits.partial_not_found
+            << std::setw(9) << static_cast<float>(statistics.hits.partial_not_found) / statistics.n_randstrobes * 100 << " %\n"
+        << "\nFound chains:                            " << std::setw(12) << statistics.n_nams
+        << "              Per read: " << std::setw(7) << static_cast<float>(statistics.n_nams) / statistics.n_reads << std::endl
+        << "\n## Rescue (-R)\n\n"
+        << "Rescue attempts:        " << std::setw(12) << statistics.nam_rescue << std::endl
+        << "Rescue hits:            " << std::setw(12) << statistics.n_rescue_hits << std::endl
+        << "Rescued chains:         " << std::setw(12) << statistics.n_rescue_nams << std::endl
+        << "\n## Other\n\n"
         << "Total mapping sites tried: " << statistics.tried_alignment << std::endl
         << "Total calls to ssw: " << statistics.tot_aligner_calls << std::endl
         << "Inconsistent NAM ends: " << statistics.inconsistent_nams << std::endl
         << "Mates rescued by alignment: " << statistics.tot_rescued << std::endl
+        << std::endl;
+    logger.info()
         << "Total time mapping: " << map_align_timer.elapsed() << " s." << std::endl
         << "Total time reading read-file(s): " << statistics.tot_read_file.count() / opt.n_threads << " s." << std::endl
         << "Total time creating strobemers: " << statistics.tot_construct_strobemers.count() / opt.n_threads << " s." << std::endl

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -287,21 +287,19 @@ std::vector<Nam> get_nams(
     Details& details,
     const MappingParameters &map_param
 ) {
-    // Find NAMs
+    // Find hits
     Timer hits_timer;
 
-    int total_hits = 0;
     bool sorting_needed = false;
     std::array<std::vector<Hit>, 2> hits;
     for (int is_revcomp : {0, 1}) {
-        int total_hits1;
         bool sorting_needed1;
         HitsDetails hits_details1;
-        std::tie(hits_details1, total_hits1, sorting_needed1, hits[is_revcomp]) = find_hits(query_randstrobes[is_revcomp], index, map_param.mcs_strategy);
+        std::tie(hits_details1, sorting_needed1, hits[is_revcomp]) = find_hits(query_randstrobes[is_revcomp], index, map_param.mcs_strategy);
         sorting_needed = sorting_needed || sorting_needed1;
-        total_hits += total_hits1;
         details.hits += hits_details1;
     }
+    uint total_hits = details.hits.total_hits();
     int nonrepetitive_hits = hits[0].size() + hits[1].size();
     float nonrepetitive_fraction = total_hits > 0 ? ((float) nonrepetitive_hits) / ((float) total_hits) : 1.0;
     statistics.time_hit_finding += hits_timer.duration();

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -291,21 +291,19 @@ std::vector<Nam> get_nams(
     Timer hits_timer;
 
     int total_hits = 0;
-    int partial_hits = 0;
     bool sorting_needed = false;
     std::array<std::vector<Hit>, 2> hits;
     for (int is_revcomp : {0, 1}) {
-        int total_hits1, partial_hits1;
+        int total_hits1;
         bool sorting_needed1;
-        std::tie(total_hits1, partial_hits1, sorting_needed1, hits[is_revcomp]) = find_hits(query_randstrobes[is_revcomp], index, map_param.mcs_strategy);
+        HitsDetails hits_details1;
+        std::tie(hits_details1, total_hits1, sorting_needed1, hits[is_revcomp]) = find_hits(query_randstrobes[is_revcomp], index, map_param.mcs_strategy);
         sorting_needed = sorting_needed || sorting_needed1;
         total_hits += total_hits1;
-        partial_hits += partial_hits1;
+        details.hits += hits_details1;
     }
     int nonrepetitive_hits = hits[0].size() + hits[1].size();
     float nonrepetitive_fraction = total_hits > 0 ? ((float) nonrepetitive_hits) / ((float) total_hits) : 1.0;
-    statistics.n_hits += nonrepetitive_hits;
-    statistics.n_partial_hits += partial_hits;
     statistics.time_hit_finding += hits_timer.duration();
 
     std::vector<Nam> nams;
@@ -315,10 +313,10 @@ std::vector<Nam> get_nams(
         Timer rescue_timer;
         nams.clear();
         for (int is_revcomp : {0, 1}) {
-            auto [n_rescue_hits, n_partial_hits, matches_map] = find_matches_rescue(query_randstrobes[is_revcomp], index, map_param.rescue_cutoff, map_param.mcs_strategy);
+            auto [n_hits, n_partial_hits, matches_map] = find_matches_rescue(query_randstrobes[is_revcomp], index, map_param.rescue_cutoff, map_param.mcs_strategy);
             merge_matches_into_nams(matches_map, index.k(), true, is_revcomp, nams);
-            statistics.n_rescue_hits += n_rescue_hits;
-            statistics.n_partial_hits += n_partial_hits;
+            statistics.n_rescue_hits += n_hits;
+            statistics.n_rescue_partial_hits += n_partial_hits;
         }
         details.rescue_nams = nams.size();
         details.nam_rescue = true;

--- a/src/python/strobealign.cpp
+++ b/src/python/strobealign.cpp
@@ -198,7 +198,7 @@ NB_MODULE(strobealign_extension, m_) {
         .export_values();
 
     m.def("find_hits", [](const std::vector<QueryRandstrobe>& query_randstrobes, const StrobemerIndex& index, McsStrategy mcs_strategy) -> std::vector<Hit> {
-        auto [total_hits, partial_hits, sorting_needed, hits] = find_hits(query_randstrobes, index, mcs_strategy);
+        auto [hits_details, sorting_needed, hits] = find_hits(query_randstrobes, index, mcs_strategy);
         return hits;
     }, nb::arg("query_randstrobes"), nb::arg("index"), nb::arg("mcs_strategy"));
 

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -4,6 +4,8 @@
 #include <chrono>
 #include <cstdint>
 
+#include "hits.hpp"
+
 /* Details about aligning a single or paired-end read */
 struct Details {
     bool nam_rescue{false}; // find_nams_rescue() was needed
@@ -15,6 +17,8 @@ struct Details {
     uint32_t gapped{0};  // No. of gapped alignments computed (in get_alignment)
     uint32_t best_alignments{0}; // No. of best alignments with same score
 
+    HitsDetails hits;
+
     Details& operator+=(const Details& other) {
         nam_rescue = nam_rescue || other.nam_rescue;
         nams += other.nams;
@@ -24,6 +28,7 @@ struct Details {
         tried_alignment += other.tried_alignment;
         gapped += other.gapped;
         best_alignments += other.best_alignments;
+        hits += other.hits;
         return *this;
     }
 };
@@ -39,9 +44,8 @@ struct AlignmentStatistics {
 
     uint64_t n_reads{0};
     uint64_t n_randstrobes{0};
-    uint64_t n_hits{0}; // non-rescue hits
-    uint64_t n_partial_hits{0}; // partial hits are counted twice (also reported as part of n_hits or n_rescue_hits)
     uint64_t n_rescue_hits{0};
+    uint64_t n_rescue_partial_hits{0};
     uint64_t n_nams{0};
     uint64_t n_rescue_nams{0};
     uint64_t tot_aligner_calls{0};
@@ -49,6 +53,8 @@ struct AlignmentStatistics {
     uint64_t tried_alignment{0};
     uint64_t inconsistent_nams{0};
     uint64_t nam_rescue{0};
+
+    HitsDetails hits;
 
     AlignmentStatistics operator+=(const AlignmentStatistics& other) {
         this->tot_read_file += other.tot_read_file;
@@ -60,9 +66,8 @@ struct AlignmentStatistics {
         this->tot_extend += other.tot_extend;
         this->n_reads += other.n_reads;
         this->n_randstrobes += other.n_randstrobes;
-        this->n_hits += other.n_hits;
-        this->n_partial_hits += other.n_partial_hits;
         this->n_rescue_hits += other.n_rescue_hits;
+        this->n_rescue_partial_hits += other.n_rescue_partial_hits;
         this->n_nams += other.n_nams;
         this->n_rescue_nams += other.n_rescue_nams;
         this->tot_aligner_calls += other.tot_aligner_calls;
@@ -70,6 +75,7 @@ struct AlignmentStatistics {
         this->tried_alignment += other.tried_alignment;
         this->inconsistent_nams += other.inconsistent_nams;
         this->nam_rescue += other.nam_rescue;
+        this->hits += other.hits;
         return *this;
     }
 
@@ -80,6 +86,7 @@ struct AlignmentStatistics {
         this->tot_rescued += details.mate_rescue;
         this->tried_alignment += details.tried_alignment;
         this->inconsistent_nams += details.inconsistent_nams;
+        this->hits += details.hits;
 
         return *this;
     }

--- a/tests/compare-baseline.sh
+++ b/tests/compare-baseline.sh
@@ -68,7 +68,7 @@ if ! test -f ${baseline_bam}; then
     mv ${srcdir}/build/strobealign ${baseline_binary}
     rm -rf "${srcdir}"
   fi
-  ${baseline_binary} ${strobealign_options} ${ref} ${reads[@]} | samtools view -o ${baseline_bam}
+  ${baseline_binary} -v ${strobealign_options} ${ref} ${reads[@]} | samtools view -o ${baseline_bam}
 fi
 
 # Run strobealign. This recompiles from scratch to ensure we use consistent
@@ -77,7 +77,7 @@ builddir=$(mktemp -p . -d build.XXXXXXX)
 cmake . -B ${builddir} ${cmake_options}
 make -s -j 4 -C ${builddir} strobealign
 set -x
-${builddir}/strobealign ${strobealign_options} ${ref} ${reads[@]} | samtools view -o head.bam
+${builddir}/strobealign -v ${strobealign_options} ${ref} ${reads[@]} | samtools view -o head.bam
 rm -rf ${builddir}
 
 # Do the actual comparison


### PR DESCRIPTION
During our last meeting, a question about the number of partial hits came up that was hard to answer with our current log output.

This PR adds more detailed statistics (within `find_hits`) that track all six possible outcomes when looking up randstrobes in the index. When looking up a full randstrobe, we have three different outcomes:
- The randstrobe was found but filtered (because it is repetitive)
- The randstrobe was found and not filtered
- The randstrobe was not found

If the randstrobe was not found and when using MCS, we also do partial lookups and again have the same three cases (found but filtered, found and not filtered, not found).

Only the non-rescue lookups are reported in this way. Since rescue lookups work a bit differently, I haven’t changed their numbers, only moved where they are reported to the end to a separate section.

## Example output

### Before
```
Number of reads:                       500000
Number of randstrobes:              134788142  Per read:  269.58
Number of partial hits:              63041960
Number of non-rescue hits:          131844817  Per read:  263.69
Number of non-rescue chains:         58483204  Per read:  116.97
Number of chain rescue attempts:        11371
Number of rescue hits:                2116452  Per rescue attempt:  186.13
Number of rescue chains:               374936  Per rescue attempt:   32.97
Total mapping sites tried: 0
Total calls to ssw: 0
Inconsistent NAM ends: 0
Mates rescued by alignment: 0
```

### After
```
# Statistics

Reads:                                         500000

## Randstrobe lookup (without rescue)

Randstrobes                                 134788142    100.0 %   Per read:   269.6
  Full randstrobe found                      69445290     51.5 %
  Full randstrobe found but filtered          1920404      1.4 %
  Full randstrobe not found                  63422448     47.1 %
    Partial randstrobe found                 62399527     46.3 %
    Partial randstrobe found but filtered     1022917      0.8 %
    Partial randstrobe not found                    4      0.0 %

Found chains:                                58483204              Per read:   117.0

## Rescue (-R)

Rescue attempts:               11371
Rescue hits:                 2116452
Rescued chains:               374936

## Other

Total mapping sites tried: 0
Total calls to ssw: 0
Inconsistent NAM ends: 0
Mates rescued by alignment: 0
```
