### PR TITLE
Adjust chunk size depending on read length

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -22,7 +22,7 @@ CommandLineOptions parse_command_line_arguments(int argc, char **argv) {
     // Threading
     args::ValueFlag<int> threads(parser, "INT", "Number of threads [1]", {'t', "threads"});
     args::ValueFlag<int> indexing_threads(parser, "INT", "Number of threads for indexing [same as -t]", {"ithreads"}, args::Options::Hidden);
-    args::ValueFlag<int> chunk_size(parser, "INT", "Number of reads processed by a worker thread at once [10000]", {"chunk-size"}, args::Options::Hidden);
+    args::ValueFlag<int> chunk_size(parser, "INT", "Number of nucleotides processed by a worker thread at once [1,000,000]", {"chunk-size"}, args::Options::Hidden);
 
     args::Group io(parser, "Input/output:");
     args::ValueFlag<std::string> o(parser, "PATH", "redirect output to file [stdout]", {'o'});

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -9,7 +9,7 @@
 struct CommandLineOptions {
     int n_threads { 1 };
     int indexing_threads{1};
-    int chunk_size{10000};
+    int chunk_size{1000000}; // no. of nucleotides
 
     // Input/output
     std::string output_file_name;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,14 +74,14 @@ bool avx2_enabled() {
 
 InputBuffer get_input_buffer(const CommandLineOptions& opt) {
     if (opt.is_SE) {
-        return InputBuffer(opt.reads_filename1, "", opt.chunk_size, false);
+        return InputBuffer(opt.reads_filename1, "", 1000, false);
     } else if (opt.is_interleaved) {
         if (opt.reads_filename2 != "") {
             throw BadParameter("Cannot specify both --interleaved and specify two read files");
         }
-        return InputBuffer(opt.reads_filename1, "", opt.chunk_size, true);
+        return InputBuffer(opt.reads_filename1, "", 1000, true);
     } else {
-        return InputBuffer(opt.reads_filename1, opt.reads_filename2, opt.chunk_size, false);
+        return InputBuffer(opt.reads_filename1, opt.reads_filename2, 1000, false);
     }
 }
 
@@ -157,6 +157,8 @@ int run_strobealign(int argc, char **argv) {
         opt.r = estimate_read_length(input_buffer);
         logger.info() << "Estimated read length: " << opt.r << " bp\n";
         input_buffer.rewind_reset();
+        input_buffer.set_chunk_size(std::clamp(opt.chunk_size / opt.r, 10, 10000));
+        logger.debug() << "Number of reads per chunk: " << input_buffer.chunk_size() << '\n';
     }
     IndexParameters index_parameters = IndexParameters::from_read_length(
         opt.r,

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -143,11 +143,10 @@ void perform_task(
     const std::string& read_group_id,
     std::vector<double> &abundances
 ) {
-    bool eof = false;
     Aligner aligner{aln_params};
     Chainer chainer{map_param.chaining_params, index.k()};
     std::minstd_rand random_engine;
-    while (!eof) {
+    while (true) {
         std::vector<klibpp::KSeq> records1;
         std::vector<klibpp::KSeq> records2;
         std::vector<klibpp::KSeq> records3;

--- a/src/pc.cpp
+++ b/src/pc.cpp
@@ -78,7 +78,7 @@ size_t InputBuffer::read_records(
     // Acquire a unique lock on the mutex
     std::unique_lock<std::mutex> unique_lock(mtx);
     if (to_read == -1) {
-        to_read = chunk_size;
+        to_read = m_chunk_size;
     }
     if (this->is_interleaved) {
         auto records = ks1->stream().read(to_read*2);

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -25,23 +25,26 @@ public:
     chunk_size(chunk_size),
     is_interleaved(is_interleaved) { }
 
-    std::mutex mtx;
-
-    input_stream_t ks1;
-    input_stream_t ks2;
-    std::optional<klibpp::KSeq> lookahead1;
-    bool finished_reading{false};
-    int chunk_size;
-    size_t chunk_index{0};
-    bool is_interleaved{false};
-
-    void rewind_reset();
     size_t read_records(
         std::vector<klibpp::KSeq> &records1,
         std::vector<klibpp::KSeq> &records2,
         std::vector<klibpp::KSeq> &records3,
         int read_count=-1
     );
+    void rewind_reset();
+
+    bool finished_reading{false};
+
+private:
+    std::mutex mtx;
+
+    input_stream_t ks1;
+    input_stream_t ks2;
+    std::optional<klibpp::KSeq> lookahead1;
+    int chunk_size;
+    size_t chunk_index{0};
+    bool is_interleaved{false};
+
 };
 
 

--- a/src/pc.hpp
+++ b/src/pc.hpp
@@ -22,7 +22,7 @@ public:
     InputBuffer(std::string fname1, std::string fname2, int chunk_size, bool is_interleaved)
     : ks1(fname1 == "" ? nullptr : open_fastq(fname1)),
     ks2(fname2 == "" ? nullptr : open_fastq(fname2)),
-    chunk_size(chunk_size),
+    m_chunk_size(chunk_size),
     is_interleaved(is_interleaved) { }
 
     size_t read_records(
@@ -32,6 +32,8 @@ public:
         int read_count=-1
     );
     void rewind_reset();
+    void set_chunk_size(int chunk_size) { this->m_chunk_size = chunk_size; }
+    int chunk_size() const { return m_chunk_size; }
 
     bool finished_reading{false};
 
@@ -41,7 +43,7 @@ private:
     input_stream_t ks1;
     input_stream_t ks2;
     std::optional<klibpp::KSeq> lookahead1;
-    int chunk_size;
+    int m_chunk_size;
     size_t chunk_index{0};
     bool is_interleaved{false};
 


### PR DESCRIPTION
Let chunk size be in terms of nucleotides, not number of reads

Note that there’s a hidden command-line option `--chunk-size`. This is now re-intepreted as meaning the number of *nucleotides* in a chunk. This way, there are fewer reads in a chunk if the reads are longer.

This avoids the problem that we do not use all input threads for small input
datasets with long reads (if the input had 50000 reads, we would use at most
5 threads, for example).

Experiments suggest that the chunk size can be relatively small without
adding too much overhead. Even for 100 nt reads and a chunk size of 1 read,
mapping is just a couple of percent slower than with bigger chunk sizes.