### PR TITLE
Fix is_partial_filtered function

### DIFF
--- a/src/index.hpp
+++ b/src/index.hpp
@@ -148,19 +148,7 @@ struct StrobemerIndex {
 
     bool is_partial_filtered(bucket_index_t position, randstrobe_hash_t hash_revcomp) const {
         assert(position < randstrobes.size());
-        if (is_partial_filtered_forward(position)) {
-            return true;
-        }
-        bucket_index_t position_revcomp = find_partial(hash_revcomp);
-        if (position_revcomp == end()) {
-            return false;
-        }
-        if (is_partial_filtered_forward(position_revcomp)) {
-            return true;
-        }
-        size_t count = get_count_partial(position) + get_count_partial(position_revcomp);
-
-        return count > filter_cutoff;
+        return is_partial_filtered_forward(position);
     }
 
     unsigned int get_strobe1_position(bucket_index_t position) const {


### PR DESCRIPTION
As pointed out by @ksahlin

I would like to get this in independently of the other changes we are currently working on. It improves accuracy for `--mcs=first-strobe`, not for `--mcs=always`.
* [ends-se-accuracy.pdf](https://github.com/user-attachments/files/22881468/ends-se-accuracy.pdf)
* [ends-se-time.pdf](https://github.com/user-attachments/files/22881469/ends-se-time.pdf)

Is-new-baseline: yes