### PR TITLE
Change the meaning of the -l and -u command-line parameters

### DIFF
--- a/src/arguments.hpp
+++ b/src/arguments.hpp
@@ -6,7 +6,6 @@
 struct SeedingArguments {
     SeedingArguments(args::ArgumentParser& parser)
         : parser(parser)
-        //n{parser, "INT", "Number of strobes [2]", {'n'}}
         , r{parser, "INT",
             "Mean read length. This parameter is estimated from the first 500 "
             "records in each read file. No need to set this explicitly unless you have a reason.", {'r'}}
@@ -14,9 +13,9 @@ struct SeedingArguments {
             "Maximum seed length. Defaults to r - 50. For reasonable values on -l and -u, "
             "the seed length distribution is usually determined by parameters l and u. "
             "Then, this parameter is only active in regions where syncmers are very sparse.", {'m'}}
-        , k{parser, "INT", "Strobe length, has to be below 32. [20]", {'k'}}
-        , l{parser, "INT", "Lower syncmer offset from k/(k-s+1). Start sample second syncmer k/(k-s+1) + l syncmers downstream [0]", {'l'}}
-        , u{parser, "INT", "Upper syncmer offset from k/(k-s+1). End sample second syncmer k/(k-s+1) + u syncmers downstream [7]", {'u'}}
+        , k{parser, "INT", "Syncmer (strobe) length, has to be below 32. [20]", {'k'}}
+        , l{parser, "INT", "Start of sampling window for second syncmer (i.e., second syncmer must be at least l syncmers downstream). [5]", {'l'}}
+        , u{parser, "INT", "End of sampling window for second syncmer (i.e., second syncmer must be at most u syncmers downstream). [11]", {'u'}}
         , c{parser, "INT", "Bitcount length between 2 and 63. [8]", {'c'}}
         , s{parser, "INT",
             "Submer size used for creating syncmers [k-4]. Only even numbers on k-s allowed. "

--- a/src/cmdline.hpp
+++ b/src/cmdline.hpp
@@ -45,9 +45,9 @@ struct CommandLineOptions {
     bool c_set { false };
     int max_seed_len;
     int k { 20 };
-    int l { 0 };
-    int u { 7 };
     int s { 16 };
+    int l { 5 };
+    int u { 11 };
     int c { 8 };
     int aux_len{17};
 

--- a/src/dumpstrobes.cpp
+++ b/src/dumpstrobes.cpp
@@ -101,7 +101,7 @@ int run_dumpstrobes(int argc, char **argv) {
     }
 
     // Seeding
-    int r{150}, k{20}, s{16}, c{8}, l{1}, u{7}, aux_len{17};
+    int r{150}, k{20}, s{16}, c{8}, l{5}, u{11}, aux_len{17};
     int max_seed_len{};
 
     bool k_set{false}, s_set{false}, c_set{false}, max_seed_len_set{false}, l_set{false}, u_set{false};

--- a/src/indexparameters.hpp
+++ b/src/indexparameters.hpp
@@ -60,7 +60,7 @@ private:
             throw BadParameter("maximum seed length (-m <max_dist>) is larger than 255");
         }
         if (w_min > w_max) {
-            throw BadParameter("w_min is greater than w_max (choose different -l/-u parameters)");
+            throw BadParameter("l is greater than u");
         }
         if (aux_len > 63) {
             throw BadParameter("aux_len is larger than 63");
@@ -77,11 +77,14 @@ public:
 
     static const int DEFAULT = std::numeric_limits<int>::min();
 
-    IndexParameters(size_t canonical_read_length, int k, int s, int l, int u, uint64_t q, int max_dist, int aux_len)
+    IndexParameters(size_t canonical_read_length, int k, int s, int w_min, int w_max, uint64_t q, int max_dist, int aux_len)
         : canonical_read_length(canonical_read_length)
         , syncmer(k, s)
-        , randstrobe(q, max_dist, std::max(0, k / (k - s + 1) + l), k / (k - s + 1) + u, ~0ul << (9 + aux_len))
+        , randstrobe(q, max_dist, w_min, w_max, ~0ul << (9 + aux_len))
     {
+        if (w_min < 0 || w_max < 0) {
+            throw BadParameter("Neither l nor u can be negative");
+        }
         verify(aux_len);
     }
 
@@ -99,7 +102,7 @@ public:
     }
 
     static IndexParameters from_read_length(
-        int read_length, int k = DEFAULT, int s = DEFAULT, int l = DEFAULT, int u = DEFAULT, int c = DEFAULT, int max_seed_len = DEFAULT, int aux_len = DEFAULT);
+        int read_length, int k = DEFAULT, int s = DEFAULT, int w_min = DEFAULT, int w_max = DEFAULT, int c = DEFAULT, int max_seed_len = DEFAULT, int aux_len = DEFAULT);
     static IndexParameters read(std::istream& os);
     std::string filename_extension() const;
     void write(std::ostream& os) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -200,12 +200,19 @@ int run_strobealign(int argc, char **argv) {
     map_param.chaining_params.max_ref_gap = opt.max_ref_gap;
     map_param.chaining_params.matches_weight = opt.matches_weight;
     map_param.verify();
-
-    logger.debug() << index_parameters << '\n';
-    logger.debug()
-        << "  Maximum seed length: " << index_parameters.randstrobe.max_dist + index_parameters.syncmer.k << '\n'
-        << "  Expected [w_min, w_max] in #syncmers: [" << index_parameters.randstrobe.w_min << ", " << index_parameters.randstrobe.w_max << "]\n"
-        << "  Expected [w_min, w_max] in #nucleotides: [" << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.randstrobe.w_min << ", " << (index_parameters.syncmer.k - index_parameters.syncmer.s + 1) * index_parameters.randstrobe.w_max << "]\n";
+    {
+        int k = index_parameters.syncmer.k;
+        int s = index_parameters.syncmer.s;
+        int l = index_parameters.randstrobe.w_min;
+        int u = index_parameters.randstrobe.w_max;
+        int d = k - s + 1;
+        logger.debug() << index_parameters << '\n';
+        logger.debug()
+            << "  Maximum seed length: " << index_parameters.randstrobe.max_dist + index_parameters.syncmer.k << '\n'
+            << "  Syncmers are on average sampled every k - s + 1 = " << d << " nucleotides\n"
+            << "  Sampling window for second syncmer (in syncmers): [" << l << ", " << u << "]\n"
+            << "  Sampling window for second syncmer (in nucleotides): [" << d * l << ", " << d * u << "]\n";
+    }
     logger.debug() << aln_params << '\n';
     logger.debug() << "Rescue level (R): " << map_param.rescue_level << '\n';
     logger.debug() << "Indexing threads: " << opt.indexing_threads << std::endl;

--- a/tests/test_indexparameters.cpp
+++ b/tests/test_indexparameters.cpp
@@ -8,8 +8,8 @@ TEST_CASE("test IndexParameters constructor") {
     int k = 22;
     int s = 18;
 
-    int l = 2;
-    int u = 12;
+    int l = 6;
+    int u = 16;
     unsigned w_min = 6;
     unsigned w_max = 16;
     int max_dist = 180;


### PR DESCRIPTION
They are now used to directly set w_min and w_max instead of the previous (confusing) interpretation.

The names `w_min` and `w_max` are still used in the code at the moment, mostly in order to avoid doing too many things at the same time, but also because `w_min` and `w_max` is a bit clearer than `l` and `u`.

Note that this will be confusing for existing scripts; they need to be adjusted.

- [x] Changelog entry