### PR TITLE
Enable some optimizations even for debug/dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ assert_cmd = "2.0.16"
 predicates = "3.1.3"
 temp-file = "0.1.9"
 
+[profile.dev]
+opt-level = 1
+
 [profile.release]
 codegen-units = 1
 lto = true


### PR DESCRIPTION
By default, the dev profile (which is the one that is chosen if you just run `cargo run` or `cargo build` without setting a profile) does not enable optimizations. The motivation is probably that enabling optimizations slows down the compiler, and because compiling Rust code is already relatively slow, the developer shouldn’t need to wait that much during development.

However, strobealign gets really slow when compiled without optimizations, which makes using the program really annoying when calling it repeatedly to debug something. For example, indexing the fruit fly genome takes 2 seconds with the "release" profile but 19 seconds when using the "dev" profile.

By enabling some light optimizations even in the "dev" profile, compile times don’t increase that much, but indexing runtime goes down to 2.5 seconds.

Some measurements:

Profile | Compile time (cold cache) | Compile time (warm cache) | Fruit fly indexing time
-|-|-|-
`release` | 19 s | 16 s | 2 s
`dev` w/opt-level = 1 | 11 s | 1.1 s | 2.5 s
`dev` w/opt-level = 0 | 6.5 s | 0.7 s | 19 s

The compiler caches compilation results. Relevant compile times during development are the ones using a warm cache. (I measured cold cache compilation times by deleting the `target/` folder.)