### PR TITLE
Fix for trying the best scoring anchor heuristic.

### DIFF
--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -35,7 +35,7 @@ impl Default for ChainingParameters {
             diag_diff_penalty: 0.1,
             gap_length_penalty: 0.05,
             valid_score_threshold: 0.7,
-            max_ref_gap: 10000,
+            max_ref_gap: 1000,
             matches_weight: 0.01,
         }
     }
@@ -128,7 +128,7 @@ impl Chainer {
                     let dq = ai.query_start - aj.query_start;
                     let dr = ai.ref_start - aj.ref_start;
 
-                    if dr > 0 {
+                    if dr < self.parameters.max_ref_gap && dr > 0 {
                         let score = self.compute_score_cached(dq, dr);
                         let new_score = dp[best_index] + score;
                         if new_score > dp[i] {


### PR DESCRIPTION
This is a small fix for a recently added heuristic, we (I) forgot to check the reference gap between the best scoring anchor inside heuristic, this lead to the possibility of very long deletions inside chains.

This is related to an odd behavior observed by @marcelm on the rust piecewise extension branch, which caused a crash when using blockaligner by calling a ~30bp vs ~16 000bp alignment. The blockaligner crash will be handled in the rust piecewise branch. This odd alignment was caused by the creation of a chain that should not have been created, which this PR fixes.

I also went ahead and reduced the default maximum allowed reference gap to 1 000bp, which was suggested by @ksahlin to prevent huge deletions inside chains even further.