### PR TITLE
Attempt to measure runtime quicker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "fastant"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e825441bfb2d831c47c97d05821552db8832479f44c571b97fededbf0099c07"
+dependencies = [
+ "small_ctor",
+ "web-time",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +281,16 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -578,6 +604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "small_ctor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88414a5ca1f85d82cc34471e975f0f74f6aa54c40f062efa42c0080e7f763f81"
+
+[[package]]
 name = "strobealign"
 version = "0.18.0-alpha"
 dependencies = [
@@ -585,6 +617,7 @@ dependencies = [
  "block-aligner",
  "cc",
  "clap",
+ "fastant",
  "fastrand",
  "flate2",
  "log",
@@ -684,6 +717,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ flate2 = { version = "1.0", features = ["zlib-rs"]}
 thiserror = "2.0.11"
 rayon = "1.11.0"
 mimalloc = "0.1.48"
+fastant = "0.1.11"
 [target.'cfg(target_arch = "wasm32-wasi")'.dependencies]
 block-aligner = { version = "0.5", features = ["simd_wasm"] }
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use fastant::Instant;
 
 use log::trace;
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,3 +1,4 @@
+use fastant::Instant;
 use std::cmp::{Reverse, min};
 use std::fmt::{Display, Formatter};
 use std::fs::File;
@@ -6,7 +7,6 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Instant;
 
 use log::{debug, trace};
 use rayon;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use fastant::Instant;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::fs::File;
@@ -5,7 +6,6 @@ use std::io::{BufReader, BufWriter, IsTerminal, Write};
 use std::process::{ExitCode, exit};
 use std::sync::mpsc::{Receiver, Sender, channel, sync_channel};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
 use std::{env, io, thread, time};
 
 use clap::Parser;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1,8 +1,8 @@
+use fastant::Instant;
 use std::cmp::{Reverse, min};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::mem;
-use std::time::Instant;
 
 use fastrand::Rng;
 use memchr::memmem;

--- a/src/nam.rs
+++ b/src/nam.rs
@@ -1,5 +1,5 @@
+use fastant::Instant;
 use std::fmt::{Display, Formatter};
-use std::time::Instant;
 
 use fastrand::Rng;
 use log::Level::Trace;


### PR DESCRIPTION
This should probably not be merged, but I wanted to report this somewhere.

When profiling strobealign on my laptop, I noticed that measuring elapsed time (by calling `std::time::Instant::now()` and `std::time::Instant::elapsed()`) took up about 5% of the total runtime. On x86, it is possible to measure elapsed time using a special machine instruction (RDTSC) that reads out the TSC (Time Stamp Counter) register, which is very fast.

The [fastant crate](https://crates.io/crates/fastant) provides a drop-in replacement for `std::time::Instant` that measures time in that way.

This PR replaces all uses of `std::time::Instant` with `fastant::time::Instant`.

Now the weird part: On my laptop, this made strobealign about 5% faster, but on my desktop PC, I measure no difference at all (both have similar CPUs). Even the profiler output is clearly different.

`std::time::Instant::now()` [is documented to use `clock_gettime`](https://doc.rust-lang.org/std/time/struct.Instant.html#underlying-system-calls), which is part of the C library. My hypothesis is that on my desktop PC, `clock_gettime` actually uses `RDTSC` and is therefore fast, but that the laptop uses a slower implementation. I’ll need to check this when I have access to the laptop again.