### PR TITLE
Determine anchor orientation prior to chaining

### DIFF
--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -356,7 +356,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_start,
                 hit.query_end,
                 index,
-                hit.position
+                hit.position,
             );
         }
     }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -322,7 +322,7 @@ fn add_to_anchors_partial(
 ) {
     let forward_hash = index.get_hash_partial_forward(position);
     for pos in position..index.randstrobes.len() {
-        //Filter out partial lookups with different orientation
+        // Filter out partial lookups with different orientation
         if index.get_hash_partial_forward(pos) != forward_hash {
             break;
         }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -290,7 +290,7 @@ fn add_to_anchors_full(
 ) {
     let mut min_length_diff = usize::MAX;
     let canonical_hash = index.randstrobes[position].canonical_hash();
-    for randstrobe in index.randstrobes[position..].iter() {
+    for randstrobe in &index.randstrobes[position..] {
         if randstrobe.canonical_hash() != canonical_hash {
             break;
         }
@@ -319,10 +319,9 @@ fn add_to_anchors_partial(
     query_start: usize,
     index: &StrobemerIndex,
     position: usize,
-    query_hash: u64,
+    query_canonicity: u8,
 ) {
     let hash = index.get_hash_partial(position);
-    let query_canonicity = index.query_canonicity_partial(query_hash);
     for pos in position..index.randstrobes.len() {
         if index.get_hash_partial(pos) != hash {
             break;
@@ -350,7 +349,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
             continue;
         }
         if hit.is_partial {
-            add_to_anchors_partial(&mut anchors, hit.query_start, index, hit.position, hit.hash);
+            add_to_anchors_partial(&mut anchors, hit.query_start, index, hit.position, hit.query_canonicity);
         } else {
             add_to_anchors_full(
                 &mut anchors,

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -344,8 +344,8 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
             continue;
         }
         if hit.is_partial {
-            if let Some(position) = hit.forward_position {
-                add_to_anchors_partial(&mut anchors, hit.query_start, index, position);
+            if let Some(forward_position) = index.get_partial_forward_from(hit.hash, hit.position) {
+                add_to_anchors_partial(&mut anchors, hit.query_start, index, forward_position);
             }
         } else {
             add_to_anchors_full(
@@ -353,7 +353,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_start,
                 hit.query_end,
                 index,
-                hit.forward_position.unwrap(),
+                hit.position,
             );
         }
     }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -291,30 +291,29 @@ fn add_to_anchors_full(
     query_canonicity: u8,
 ) {
     let mut min_length_diff = usize::MAX;
-    let canonical_query_hash = index.randstrobes[position].hash() | ((query_canonicity as u64) << 8);
-    let start_pos = index.find_canonical(canonical_query_hash, position, forward_count)
-        .unwrap_or(position);
-    let canonical_hash = index.randstrobes[start_pos].canonical_hash();
-    for randstrobe in &index.randstrobes[start_pos..] {
-        if randstrobe.canonical_hash() != canonical_hash {
-            break;
-        }
-        let ref_start = randstrobe.position();
-        let ref_end = ref_start + randstrobe.strobe2_offset() + index.k();
-        let length_diff = (query_end - query_start).abs_diff(ref_end - ref_start);
-        if length_diff <= min_length_diff {
-            let ref_id = randstrobe.reference_index();
-            anchors.push(Anchor {
-                ref_id,
-                ref_start,
-                query_start,
-            });
-            anchors.push(Anchor {
-                ref_id,
-                ref_start: ref_end - index.k(),
-                query_start: query_end - index.k(),
-            });
-            min_length_diff = length_diff;
+    let canonical_query_hash = StrobemerIndex::apply_canonicity(index.randstrobes[position].hash(), query_canonicity);
+    if let Some(start_pos) = index.find_canonical(canonical_query_hash, position, forward_count) {
+        for randstrobe in &index.randstrobes[start_pos..] {
+            if randstrobe.canonical_hash() != canonical_query_hash {
+                break;
+            }
+            let ref_start = randstrobe.position();
+            let ref_end = ref_start + randstrobe.strobe2_offset() + index.k();
+            let length_diff = (query_end - query_start).abs_diff(ref_end - ref_start);
+            if length_diff <= min_length_diff {
+                let ref_id = randstrobe.reference_index();
+                anchors.push(Anchor {
+                    ref_id,
+                    ref_start,
+                    query_start,
+                });
+                anchors.push(Anchor {
+                    ref_id,
+                    ref_start: ref_end - index.k(),
+                    query_start: query_end - index.k(),
+                });
+                min_length_diff = length_diff;
+            }
         }
     }
 }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -287,13 +287,18 @@ fn add_to_anchors_full(
     query_end: usize,
     index: &StrobemerIndex,
     position: usize,
+    query_canonicity: u8
 ) {
     let mut min_length_diff = usize::MAX;
-    let canonical_hash = index.randstrobes[position].canonical_hash();
-    for randstrobe in &index.randstrobes[position..] {
-        if randstrobe.canonical_hash() != canonical_hash {
+    let canonical_hash = index.randstrobes[position].hash() ^ ((query_canonicity as u64) << 8);
+    for pos in position..index.randstrobes.len() {
+        if index.randstrobes[pos].canonical_hash() > canonical_hash {
             break;
         }
+        if index.randstrobes[pos].canonical_hash() < canonical_hash {
+            continue;
+        }
+        let randstrobe = &index.randstrobes[pos];
         let ref_start = randstrobe.position();
         let ref_end = ref_start + randstrobe.strobe2_offset() + index.k();
         let length_diff = (query_end - query_start).abs_diff(ref_end - ref_start);
@@ -363,6 +368,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_end,
                 index,
                 hit.position,
+                hit.query_canonicity
             );
         }
     }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -287,12 +287,16 @@ fn add_to_anchors_full(
     query_end: usize,
     index: &StrobemerIndex,
     position: usize,
+    query_hash: u64,
 ) {
     let mut min_length_diff = usize::MAX;
     let hash = index.randstrobes[position].hash();
-    for randstrobe in &index.randstrobes[position..] {
+    for (i, randstrobe) in index.randstrobes[position..].iter().enumerate() {
         if randstrobe.hash() != hash {
             break;
+        }
+        if !index.canonicity_matches(query_hash, position + i) {
+            continue;
         }
         let ref_start = randstrobe.position();
         let ref_end = ref_start + randstrobe.strobe2_offset() + index.k();
@@ -319,11 +323,15 @@ fn add_to_anchors_partial(
     query_start: usize,
     index: &StrobemerIndex,
     position: usize,
+    query_hash: u64,
 ) {
     let hash = index.get_hash_partial(position);
     for pos in position..index.randstrobes.len() {
         if index.get_hash_partial(pos) != hash {
             break;
+        }
+        if !index.canonicity_matches_partial(query_hash, pos) {
+            continue;
         }
         let randstrobe = &index.randstrobes[pos];
         let ref_id = randstrobe.reference_index();
@@ -344,7 +352,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
             continue;
         }
         if hit.is_partial {
-            add_to_anchors_partial(&mut anchors, hit.query_start, index, hit.position);
+            add_to_anchors_partial(&mut anchors, hit.query_start, index, hit.position, hit.hash);
         } else {
             add_to_anchors_full(
                 &mut anchors,
@@ -352,6 +360,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_end,
                 index,
                 hit.position,
+                hit.hash,
             );
         }
     }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -287,16 +287,12 @@ fn add_to_anchors_full(
     query_end: usize,
     index: &StrobemerIndex,
     position: usize,
-    query_hash: u64,
 ) {
     let mut min_length_diff = usize::MAX;
-    let hash = index.randstrobes[position].hash();
-    for (i, randstrobe) in index.randstrobes[position..].iter().enumerate() {
-        if randstrobe.hash() != hash {
+    let canonical_hash = index.randstrobes[position].canonical_hash();
+    for randstrobe in index.randstrobes[position..].iter() {
+        if randstrobe.canonical_hash() != canonical_hash {
             break;
-        }
-        if !index.canonicity_matches(query_hash, position + i) {
-            continue;
         }
         let ref_start = randstrobe.position();
         let ref_end = ref_start + randstrobe.strobe2_offset() + index.k();
@@ -326,11 +322,13 @@ fn add_to_anchors_partial(
     query_hash: u64,
 ) {
     let hash = index.get_hash_partial(position);
+    let query_canonicity = index.query_canonicity_partial(query_hash);
     for pos in position..index.randstrobes.len() {
         if index.get_hash_partial(pos) != hash {
             break;
         }
-        if !index.canonicity_matches_partial(query_hash, pos) {
+        let entry_canonicity = index.randstrobes[pos].canonicity_bit();
+        if entry_canonicity != query_canonicity {
             continue;
         }
         let randstrobe = &index.randstrobes[pos];
@@ -359,8 +357,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_start,
                 hit.query_end,
                 index,
-                hit.position,
-                hit.hash,
+                hit.position
             );
         }
     }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -288,13 +288,14 @@ fn add_to_anchors_full(
     index: &StrobemerIndex,
     position: usize,
     forward_count: Option<usize>,
-    query_canonicity: u8,
+    query_orientation: u8,
 ) {
     let mut min_length_diff = usize::MAX;
-    let canonical_query_hash = StrobemerIndex::apply_canonicity(index.randstrobes[position].hash(), query_canonicity);
-    if let Some(start_pos) = index.find_canonical(canonical_query_hash, position, forward_count) {
+    let directed_query_hash =
+        StrobemerIndex::apply_orientation(index.randstrobes[position].hash(), query_orientation);
+    if let Some(start_pos) = index.get_full_directed(directed_query_hash, position, forward_count) {
         for randstrobe in &index.randstrobes[start_pos..] {
-            if randstrobe.canonical_hash() != canonical_query_hash {
+            if randstrobe.directed_hash() != directed_query_hash {
                 break;
             }
             let ref_start = randstrobe.position();
@@ -323,15 +324,15 @@ fn add_to_anchors_partial(
     query_start: usize,
     index: &StrobemerIndex,
     position: usize,
-    query_canonicity: u8,
+    query_orientation: u8,
 ) {
     let hash = index.get_hash_partial(position);
     for pos in position..index.randstrobes.len() {
         if index.get_hash_partial(pos) != hash {
             break;
         }
-        let entry_canonicity = index.randstrobes[pos].canonicity_bit();
-        if entry_canonicity != query_canonicity {
+        let entry_orientation = index.randstrobes[pos].orientation_partial();
+        if entry_orientation != query_orientation {
             continue;
         }
         let randstrobe = &index.randstrobes[pos];
@@ -358,7 +359,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_start,
                 index,
                 hit.position,
-                hit.query_canonicity,
+                hit.query_orientation,
             );
         } else {
             add_to_anchors_full(
@@ -368,7 +369,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 index,
                 hit.position,
                 hit.forward_count,
-                hit.query_canonicity,
+                hit.query_orientation,
             );
         }
     }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -349,7 +349,13 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
             continue;
         }
         if hit.is_partial {
-            add_to_anchors_partial(&mut anchors, hit.query_start, index, hit.position, hit.query_canonicity);
+            add_to_anchors_partial(
+                &mut anchors,
+                hit.query_start,
+                index,
+                hit.position,
+                hit.query_canonicity,
+            );
         } else {
             add_to_anchors_full(
                 &mut anchors,

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -287,34 +287,29 @@ fn add_to_anchors_full(
     query_end: usize,
     index: &StrobemerIndex,
     position: usize,
-    forward_count: Option<usize>,
-    query_orientation: u8,
 ) {
     let mut min_length_diff = usize::MAX;
-    let directed_query_hash =
-        StrobemerIndex::apply_orientation(index.randstrobes[position].hash(), query_orientation);
-    if let Some(start_pos) = index.get_full_directed(directed_query_hash, position, forward_count) {
-        for randstrobe in &index.randstrobes[start_pos..] {
-            if randstrobe.directed_hash() != directed_query_hash {
-                break;
-            }
-            let ref_start = randstrobe.position();
-            let ref_end = ref_start + randstrobe.strobe2_offset() + index.k();
-            let length_diff = (query_end - query_start).abs_diff(ref_end - ref_start);
-            if length_diff <= min_length_diff {
-                let ref_id = randstrobe.reference_index();
-                anchors.push(Anchor {
-                    ref_id,
-                    ref_start,
-                    query_start,
-                });
-                anchors.push(Anchor {
-                    ref_id,
-                    ref_start: ref_end - index.k(),
-                    query_start: query_end - index.k(),
-                });
-                min_length_diff = length_diff;
-            }
+    let forward_hash = index.randstrobes[position].hash();
+    for randstrobe in &index.randstrobes[position..] {
+        if randstrobe.hash() != forward_hash {
+            break;
+        }
+        let ref_start = randstrobe.position();
+        let ref_end = ref_start + randstrobe.strobe2_offset() + index.k();
+        let length_diff = (query_end - query_start).abs_diff(ref_end - ref_start);
+        if length_diff <= min_length_diff {
+            let ref_id = randstrobe.reference_index();
+            anchors.push(Anchor {
+                ref_id,
+                ref_start,
+                query_start,
+            });
+            anchors.push(Anchor {
+                ref_id,
+                ref_start: ref_end - index.k(),
+                query_start: query_end - index.k(),
+            });
+            min_length_diff = length_diff;
         }
     }
 }
@@ -324,16 +319,11 @@ fn add_to_anchors_partial(
     query_start: usize,
     index: &StrobemerIndex,
     position: usize,
-    query_orientation: u8,
 ) {
-    let hash = index.get_hash_partial(position);
+    let forward_hash = index.get_hash_partial_forward(position);
     for pos in position..index.randstrobes.len() {
-        if index.get_hash_partial(pos) != hash {
+        if index.get_hash_partial_forward(pos) != forward_hash {
             break;
-        }
-        let entry_orientation = index.randstrobes[pos].orientation_partial();
-        if entry_orientation != query_orientation {
-            continue;
         }
         let randstrobe = &index.randstrobes[pos];
         let ref_id = randstrobe.reference_index();
@@ -354,13 +344,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
             continue;
         }
         if hit.is_partial {
-            add_to_anchors_partial(
-                &mut anchors,
-                hit.query_start,
-                index,
-                hit.position,
-                hit.query_orientation,
-            );
+            add_to_anchors_partial(&mut anchors, hit.query_start, index, hit.position);
         } else {
             add_to_anchors_full(
                 &mut anchors,
@@ -368,8 +352,6 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_end,
                 index,
                 hit.position,
-                hit.forward_count,
-                hit.query_orientation,
             );
         }
     }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -322,6 +322,7 @@ fn add_to_anchors_partial(
 ) {
     let forward_hash = index.get_hash_partial_forward(position);
     for pos in position..index.randstrobes.len() {
+        //Filter out partial lookups with different orientation
         if index.get_hash_partial_forward(pos) != forward_hash {
             break;
         }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -344,14 +344,16 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
             continue;
         }
         if hit.is_partial {
-            add_to_anchors_partial(&mut anchors, hit.query_start, index, hit.position);
+            if let Some(position) = hit.forward_position {
+                add_to_anchors_partial(&mut anchors, hit.query_start, index, position);
+            }
         } else {
             add_to_anchors_full(
                 &mut anchors,
                 hit.query_start,
                 hit.query_end,
                 index,
-                hit.position,
+                hit.forward_position.unwrap(),
             );
         }
     }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -287,18 +287,18 @@ fn add_to_anchors_full(
     query_end: usize,
     index: &StrobemerIndex,
     position: usize,
-    query_canonicity: u8
+    forward_count: Option<usize>,
+    query_canonicity: u8,
 ) {
     let mut min_length_diff = usize::MAX;
-    let canonical_hash = index.randstrobes[position].hash() ^ ((query_canonicity as u64) << 8);
-    for pos in position..index.randstrobes.len() {
-        if index.randstrobes[pos].canonical_hash() > canonical_hash {
+    let canonical_query_hash = index.randstrobes[position].hash() | ((query_canonicity as u64) << 8);
+    let start_pos = index.find_canonical(canonical_query_hash, position, forward_count)
+        .unwrap_or(position);
+    let canonical_hash = index.randstrobes[start_pos].canonical_hash();
+    for randstrobe in &index.randstrobes[start_pos..] {
+        if randstrobe.canonical_hash() != canonical_hash {
             break;
         }
-        if index.randstrobes[pos].canonical_hash() < canonical_hash {
-            continue;
-        }
-        let randstrobe = &index.randstrobes[pos];
         let ref_start = randstrobe.position();
         let ref_end = ref_start + randstrobe.strobe2_offset() + index.k();
         let length_diff = (query_end - query_start).abs_diff(ref_end - ref_start);
@@ -368,7 +368,8 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_end,
                 index,
                 hit.position,
-                hit.query_canonicity
+                hit.forward_count,
+                hit.query_canonicity,
             );
         }
     }

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -129,15 +129,21 @@ fn find_all_hits(
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
             if let Some(full_pos) = index.get_full(randstrobe.hash) {
-                let (is_filtered, forward_count) =
-                    index.is_too_frequent_with_forward_count(full_pos, filter_cutoff, randstrobe.hash_revcomp);
+                let (is_filtered, forward_count) = index.is_too_frequent_with_forward_count(
+                    full_pos,
+                    filter_cutoff,
+                    randstrobe.hash_revcomp,
+                );
                 if is_filtered {
                     hits_details.full_filtered += 1;
                 } else {
                     hits_details.full_found += 1;
                 }
-                if let Some(position) = index.find_canonical(randstrobe.hash, full_pos, forward_count) {
-                    let canonicity = ((randstrobe.hash >> crate::index::STROBE2_OFFSET_BITS) & 0x3) as u8;
+                if let Some(position) =
+                    index.find_canonical(randstrobe.hash, full_pos, forward_count)
+                {
+                    let canonicity =
+                        ((randstrobe.hash >> crate::index::STROBE2_OFFSET_BITS) & 0x3) as u8;
                     let hit = Hit {
                         position,
                         query_start: randstrobe.start,

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -16,7 +16,7 @@ pub struct Hit {
     pub hash_revcomp: u64,
     pub is_partial: bool,
     pub is_filtered: bool,
-    pub query_canonicity: u8,
+    pub query_orientation: u8,
     pub forward_count: Option<usize>,
 }
 
@@ -97,7 +97,8 @@ fn rescue_least_frequent(
         let (cnt, fwd_count) = if hits[i].is_partial {
             (index.get_count_partial(hits[i].position), None)
         } else {
-            let (total, fwd) = index.get_count_full_with_forward(hits[i].position, hits[i].hash_revcomp);
+            let (total, fwd) =
+                index.get_count_full_with_forward(hits[i].position, hits[i].hash_revcomp);
             (total, Some(fwd))
         };
         if rescue_threshold.is_none() || cnt <= rescue_threshold.unwrap() {
@@ -152,7 +153,7 @@ fn find_all_hits(
                     is_partial: false,
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
-                    query_canonicity: StrobemerIndex::query_canonicity(randstrobe.hash),
+                    query_orientation: StrobemerIndex::query_orientation(randstrobe.hash),
                     forward_count,
                 };
                 hits.push(hit);
@@ -173,7 +174,9 @@ fn find_all_hits(
                             is_partial: true,
                             is_filtered,
                             hash_revcomp: randstrobe.hash_revcomp,
-                            query_canonicity: StrobemerIndex::query_canonicity_partial(randstrobe.hash),
+                            query_orientation: StrobemerIndex::query_orientation_partial(
+                                randstrobe.hash,
+                            ),
                             forward_count: None,
                         };
                         hits.push(hit);
@@ -213,7 +216,7 @@ fn find_all_hits(
                     is_partial: true,
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
-                    query_canonicity: StrobemerIndex::query_canonicity_partial(randstrobe.hash),
+                    query_orientation: StrobemerIndex::query_orientation_partial(randstrobe.hash),
                     forward_count: None,
                 };
                 hits.push(hit);

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -17,6 +17,7 @@ pub struct Hit {
     pub is_partial: bool,
     pub is_filtered: bool,
     pub query_canonicity: u8,
+    pub forward_count: Option<usize>,
 }
 
 /// Aggregate statistics resulting from looking up all strobemers of a single
@@ -90,16 +91,17 @@ fn rescue_least_frequent(
 ) -> usize {
     let mut rescued = 0;
 
-    // Index and hit count
+    // Index, hit count, and forward count
     let mut hit_counts = vec![];
     for i in start..end {
-        let cnt = if hits[i].is_partial {
-            index.get_count_partial(hits[i].position)
+        let (cnt, fwd_count) = if hits[i].is_partial {
+            (index.get_count_partial(hits[i].position), None)
         } else {
-            index.get_count_full(hits[i].position, hits[i].hash_revcomp)
+            let (total, fwd) = index.get_count_full_with_forward(hits[i].position, hits[i].hash_revcomp);
+            (total, Some(fwd))
         };
         if rescue_threshold.is_none() || cnt <= rescue_threshold.unwrap() {
-            hit_counts.push((i, cnt));
+            hit_counts.push((i, cnt, fwd_count));
         }
     }
 
@@ -107,9 +109,12 @@ fn rescue_least_frequent(
     hit_counts.sort_by_key(|hc| hc.1);
 
     // Take up to num_to_rescue lowest count
-    for &(hit_index, _cnt) in hit_counts.iter().take(to_rescue) {
+    for &(hit_index, _cnt, fwd_count) in hit_counts.iter().take(to_rescue) {
         rescued += hits[hit_index].is_filtered as usize;
         hits[hit_index].is_filtered = false;
+        if hits[hit_index].forward_count.is_none() {
+            hits[hit_index].forward_count = fwd_count;
+        }
     }
 
     rescued
@@ -129,21 +134,25 @@ fn find_all_hits(
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
             if let Some(position) = index.get_full(randstrobe.hash) {
-                let is_filtered = index.is_too_frequent(position, filter_cutoff, randstrobe.hash_revcomp);
-                // let canonical_pos = index.find_canonical(randstrobe.hash, position, forward_count);
+                let (is_filtered, forward_count) = index.is_too_frequent_with_forward_count(
+                    position,
+                    filter_cutoff,
+                    randstrobe.hash_revcomp,
+                );
                 if is_filtered {
                     hits_details.full_filtered += 1;
                 } else {
                     hits_details.full_found += 1;
                 }
                 let hit = Hit {
-                    position: position,
+                    position,
                     query_start: randstrobe.start,
                     query_end: randstrobe.end,
                     is_partial: false,
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
                     query_canonicity: index.query_canonicity(randstrobe.hash),
+                    forward_count,
                 };
                 hits.push(hit);
             } else {
@@ -164,6 +173,7 @@ fn find_all_hits(
                             is_filtered,
                             hash_revcomp: randstrobe.hash_revcomp,
                             query_canonicity: index.query_canonicity_partial(randstrobe.hash),
+                            forward_count: None,
                         };
                         hits.push(hit);
                     } else {
@@ -203,6 +213,7 @@ fn find_all_hits(
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
                     query_canonicity: index.query_canonicity_partial(randstrobe.hash),
+                    forward_count: None,
                 };
                 hits.push(hit);
             } else {

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -129,31 +129,23 @@ fn find_all_hits(
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
             if let Some(position) = index.get_full(randstrobe.hash) {
-                let (is_filtered, forward_count) = index.is_too_frequent_with_forward_count(
-                    position,
-                    filter_cutoff,
-                    randstrobe.hash_revcomp,
-                );
+                let is_filtered = index.is_too_frequent(position, filter_cutoff, randstrobe.hash_revcomp);
+                // let canonical_pos = index.find_canonical(randstrobe.hash, position, forward_count);
                 if is_filtered {
                     hits_details.full_filtered += 1;
                 } else {
                     hits_details.full_found += 1;
                 }
-                if let Some(canonical_pos) =
-                    index.find_canonical(randstrobe.hash, position, forward_count)
-                {
-                    let canonicity = index.randstrobes[canonical_pos].canonicity_bits();
-                    let hit = Hit {
-                        position: canonical_pos,
-                        query_start: randstrobe.start,
-                        query_end: randstrobe.end,
-                        is_partial: false,
-                        is_filtered,
-                        hash_revcomp: randstrobe.hash_revcomp,
-                        query_canonicity: canonicity,
-                    };
-                    hits.push(hit);
-                }
+                let hit = Hit {
+                    position: position,
+                    query_start: randstrobe.start,
+                    query_end: randstrobe.end,
+                    is_partial: false,
+                    is_filtered,
+                    hash_revcomp: randstrobe.hash_revcomp,
+                    query_canonicity: index.query_canonicity(randstrobe.hash),
+                };
+                hits.push(hit);
             } else {
                 hits_details.full_not_found += 1;
                 if mcs_strategy == McsStrategy::Always {

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -128,17 +128,16 @@ fn find_all_hits(
 
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
-            let (full_pos, canon_pos) = index.get_full_and_canonical(randstrobe.hash);
-            if let Some(count_position) = full_pos {
-                let is_filtered =
-                    index.is_too_frequent(count_position, filter_cutoff, randstrobe.hash_revcomp);
+            if let Some(full_pos) = index.get_full(randstrobe.hash) {
+                let (is_filtered, forward_count) =
+                    index.is_too_frequent_with_forward_count(full_pos, filter_cutoff, randstrobe.hash_revcomp);
                 if is_filtered {
                     hits_details.full_filtered += 1;
                 } else {
                     hits_details.full_found += 1;
                 }
-
-                if let Some(position) = canon_pos {
+                if let Some(position) = index.find_canonical(randstrobe.hash, full_pos, forward_count) {
+                    let canonicity = ((randstrobe.hash >> crate::index::STROBE2_OFFSET_BITS) & 0x3) as u8;
                     let hit = Hit {
                         position,
                         query_start: randstrobe.start,
@@ -146,7 +145,7 @@ fn find_all_hits(
                         is_partial: false,
                         is_filtered,
                         hash_revcomp: randstrobe.hash_revcomp,
-                        query_canonicity: index.query_canonicity(randstrobe.hash)
+                        query_canonicity: canonicity,
                     };
                     hits.push(hit);
                 }

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -138,7 +138,7 @@ fn find_all_hits(
                     hits_details.full_found += 1;
                 }
                 let hit = Hit {
-                    position: position,
+                    position,
                     query_start: randstrobe.start,
                     query_end: randstrobe.end,
                     is_partial: false,

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -12,7 +12,7 @@ use crate::seeding::QueryRandstrobe;
 pub struct Hit {
     pub query_start: usize,
     pub query_end: usize,
-    pub position: usize,
+    pub forward_position: Option<usize>,
     pub undirected_position: Option<usize>,
     pub hash_revcomp: u64,
     pub is_partial: bool,
@@ -93,10 +93,10 @@ fn rescue_least_frequent(
     // Index and hit count
     let mut hit_counts = vec![];
     for i in start..end {
-        let cnt = if let Some(undirected_pos) = hits[i].undirected_position {
-            index.get_count_partial(undirected_pos)
+        let cnt = if hits[i].is_partial {
+            index.get_count_partial(hits[i].undirected_position.unwrap())
         } else {
-            index.get_count_full(hits[i].position, hits[i].hash_revcomp)
+            index.get_count_full(hits[i].forward_position.unwrap(), hits[i].hash_revcomp)
         };
         if rescue_threshold.is_none() || cnt <= rescue_threshold.unwrap() {
             hit_counts.push((i, cnt));
@@ -137,7 +137,7 @@ fn find_all_hits(
                     hits_details.full_found += 1;
                 }
                 let hit = Hit {
-                    position,
+                    forward_position: Some(position),
                     undirected_position: None,
                     query_start: randstrobe.start,
                     query_end: randstrobe.end,
@@ -152,27 +152,21 @@ fn find_all_hits(
                     if let Some(undirected_pos) = index.get_partial(randstrobe.hash) {
                         let is_filtered =
                             index.is_too_frequent_partial(undirected_pos, filter_cutoff);
-                        if let Some(position) =
-                            index.get_partial_forward_from(randstrobe.hash, undirected_pos)
-                        {
-                            if is_filtered {
-                                hits_details.partial_filtered += 1;
-                            } else {
-                                hits_details.partial_found += 1;
-                            }
-                            let hit = Hit {
-                                position,
-                                undirected_position: Some(undirected_pos),
-                                query_start: randstrobe.start,
-                                query_end: randstrobe.start + index.k(),
-                                is_partial: true,
-                                is_filtered,
-                                hash_revcomp: randstrobe.hash_revcomp,
-                            };
-                            hits.push(hit);
+                        if is_filtered {
+                            hits_details.partial_filtered += 1;
                         } else {
-                            hits_details.partial_not_found += 1;
+                            hits_details.partial_found += 1;
                         }
+                        let hit = Hit {
+                            forward_position: index.get_partial_forward_from(randstrobe.hash, undirected_pos),
+                            undirected_position: Some(undirected_pos),
+                            query_start: randstrobe.start,
+                            query_end: randstrobe.start + index.k(),
+                            is_partial: true,
+                            is_filtered,
+                            hash_revcomp: randstrobe.hash_revcomp,
+                        };
+                        hits.push(hit);
                     } else {
                         hits_details.partial_not_found += 1;
                     }
@@ -196,28 +190,23 @@ fn find_all_hits(
     {
         for randstrobe in query_randstrobes {
             if let Some(undirected_pos) = index.get_partial(randstrobe.hash) {
-                let is_filtered = index.is_too_frequent_partial(undirected_pos, filter_cutoff);
-                if let Some(position) =
-                    index.get_partial_forward_from(randstrobe.hash, undirected_pos)
-                {
-                    if is_filtered {
-                        hits_details.partial_filtered += 1;
-                    } else {
-                        hits_details.partial_found += 1;
-                    }
-                    let hit = Hit {
-                        position,
-                        undirected_position: Some(undirected_pos),
-                        query_start: randstrobe.start,
-                        query_end: randstrobe.start + index.k(),
-                        is_partial: true,
-                        is_filtered,
-                        hash_revcomp: randstrobe.hash_revcomp,
-                    };
-                    hits.push(hit);
+                let is_filtered =
+                    index.is_too_frequent_partial(undirected_pos, filter_cutoff);
+                if is_filtered {
+                    hits_details.partial_filtered += 1;
                 } else {
-                    hits_details.partial_not_found += 1;
+                    hits_details.partial_found += 1;
                 }
+                let hit = Hit {
+                    forward_position: index.get_partial_forward_from(randstrobe.hash, undirected_pos),
+                    undirected_position: Some(undirected_pos),
+                    query_start: randstrobe.start,
+                    query_end: randstrobe.start + index.k(),
+                    is_partial: true,
+                    is_filtered,
+                    hash_revcomp: randstrobe.hash_revcomp,
+                };
+                hits.push(hit);
             } else {
                 hits_details.partial_not_found += 1;
             }
@@ -308,10 +297,10 @@ pub fn find_hits(
         );
         trace!("querypos count (p=partial, F=filtered)");
         for hit in &hits {
-            let cnt = if let Some(undirected_pos) = hit.undirected_position {
-                index.get_count_partial(undirected_pos)
+            let cnt = if hit.is_partial {
+                index.get_count_partial(hit.undirected_position.unwrap())
             } else {
-                index.get_count_full(hit.position, hit.hash_revcomp)
+                index.get_count_full(hit.forward_position.unwrap(), hit.hash_revcomp)
             };
             trace!(
                 "{:6} {}{:6} {}",

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -13,11 +13,10 @@ pub struct Hit {
     pub query_start: usize,
     pub query_end: usize,
     pub position: usize,
+    pub undirected_position: Option<usize>,
     pub hash_revcomp: u64,
     pub is_partial: bool,
     pub is_filtered: bool,
-    pub query_orientation: u8,
-    pub forward_count: Option<usize>,
 }
 
 /// Aggregate statistics resulting from looking up all strobemers of a single
@@ -91,18 +90,16 @@ fn rescue_least_frequent(
 ) -> usize {
     let mut rescued = 0;
 
-    // Index, hit count, and forward count
+    // Index and hit count
     let mut hit_counts = vec![];
     for i in start..end {
-        let (cnt, fwd_count) = if hits[i].is_partial {
-            (index.get_count_partial(hits[i].position), None)
+        let cnt = if let Some(undirected_pos) = hits[i].undirected_position {
+            index.get_count_partial(undirected_pos)
         } else {
-            let (total, fwd) =
-                index.get_count_full_with_forward(hits[i].position, hits[i].hash_revcomp);
-            (total, Some(fwd))
+            index.get_count_full(hits[i].position, hits[i].hash_revcomp)
         };
         if rescue_threshold.is_none() || cnt <= rescue_threshold.unwrap() {
-            hit_counts.push((i, cnt, fwd_count));
+            hit_counts.push((i, cnt));
         }
     }
 
@@ -110,12 +107,9 @@ fn rescue_least_frequent(
     hit_counts.sort_by_key(|hc| hc.1);
 
     // Take up to num_to_rescue lowest count
-    for &(hit_index, _cnt, fwd_count) in hit_counts.iter().take(to_rescue) {
+    for &(hit_index, _cnt) in hit_counts.iter().take(to_rescue) {
         rescued += hits[hit_index].is_filtered as usize;
         hits[hit_index].is_filtered = false;
-        if hits[hit_index].forward_count.is_none() {
-            hits[hit_index].forward_count = fwd_count;
-        }
     }
 
     rescued
@@ -134,13 +128,9 @@ fn find_all_hits(
 
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
-            //Save forward count to find canonical hash later
-            if let Some(position) = index.get_full(randstrobe.hash) {
-                let (is_filtered, forward_count) = index.is_too_frequent_with_forward_count(
-                    position,
-                    filter_cutoff,
-                    randstrobe.hash_revcomp,
-                );
+            if let Some(position) = index.get_full_forward(randstrobe.hash) {
+                let is_filtered =
+                    index.is_too_frequent(position, filter_cutoff, randstrobe.hash_revcomp);
                 if is_filtered {
                     hits_details.full_filtered += 1;
                 } else {
@@ -148,38 +138,41 @@ fn find_all_hits(
                 }
                 let hit = Hit {
                     position,
+                    undirected_position: None,
                     query_start: randstrobe.start,
                     query_end: randstrobe.end,
                     is_partial: false,
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
-                    query_orientation: StrobemerIndex::query_orientation(randstrobe.hash),
-                    forward_count,
                 };
                 hits.push(hit);
             } else {
                 hits_details.full_not_found += 1;
                 if mcs_strategy == McsStrategy::Always {
-                    if let Some(position) = index.get_partial(randstrobe.hash) {
-                        let is_filtered = index.is_too_frequent_partial(position, filter_cutoff);
-                        if is_filtered {
-                            hits_details.partial_filtered += 1;
+                    if let Some(undirected_pos) = index.get_partial(randstrobe.hash) {
+                        let is_filtered =
+                            index.is_too_frequent_partial(undirected_pos, filter_cutoff);
+                        if let Some(position) =
+                            index.get_partial_forward_from(randstrobe.hash, undirected_pos)
+                        {
+                            if is_filtered {
+                                hits_details.partial_filtered += 1;
+                            } else {
+                                hits_details.partial_found += 1;
+                            }
+                            let hit = Hit {
+                                position,
+                                undirected_position: Some(undirected_pos),
+                                query_start: randstrobe.start,
+                                query_end: randstrobe.start + index.k(),
+                                is_partial: true,
+                                is_filtered,
+                                hash_revcomp: randstrobe.hash_revcomp,
+                            };
+                            hits.push(hit);
                         } else {
-                            hits_details.partial_found += 1;
+                            hits_details.partial_not_found += 1;
                         }
-                        let hit = Hit {
-                            position,
-                            query_start: randstrobe.start,
-                            query_end: randstrobe.start + index.k(),
-                            is_partial: true,
-                            is_filtered,
-                            hash_revcomp: randstrobe.hash_revcomp,
-                            query_orientation: StrobemerIndex::query_orientation_partial(
-                                randstrobe.hash,
-                            ),
-                            forward_count: None,
-                        };
-                        hits.push(hit);
                     } else {
                         hits_details.partial_not_found += 1;
                     }
@@ -202,24 +195,29 @@ fn find_all_hits(
             && hits_details.full_filtered + hits_details.full_found == 0)
     {
         for randstrobe in query_randstrobes {
-            if let Some(position) = index.get_partial(randstrobe.hash) {
-                let is_filtered = index.is_too_frequent_partial(position, filter_cutoff);
-                if is_filtered {
-                    hits_details.partial_filtered += 1;
+            if let Some(undirected_pos) = index.get_partial(randstrobe.hash) {
+                let is_filtered = index.is_too_frequent_partial(undirected_pos, filter_cutoff);
+                if let Some(position) =
+                    index.get_partial_forward_from(randstrobe.hash, undirected_pos)
+                {
+                    if is_filtered {
+                        hits_details.partial_filtered += 1;
+                    } else {
+                        hits_details.partial_found += 1;
+                    }
+                    let hit = Hit {
+                        position,
+                        undirected_position: Some(undirected_pos),
+                        query_start: randstrobe.start,
+                        query_end: randstrobe.start + index.k(),
+                        is_partial: true,
+                        is_filtered,
+                        hash_revcomp: randstrobe.hash_revcomp,
+                    };
+                    hits.push(hit);
                 } else {
-                    hits_details.partial_found += 1;
+                    hits_details.partial_not_found += 1;
                 }
-                let hit = Hit {
-                    position,
-                    query_start: randstrobe.start,
-                    query_end: randstrobe.start + index.k(),
-                    is_partial: true,
-                    is_filtered,
-                    hash_revcomp: randstrobe.hash_revcomp,
-                    query_orientation: StrobemerIndex::query_orientation_partial(randstrobe.hash),
-                    forward_count: None,
-                };
-                hits.push(hit);
             } else {
                 hits_details.partial_not_found += 1;
             }
@@ -310,8 +308,8 @@ pub fn find_hits(
         );
         trace!("querypos count (p=partial, F=filtered)");
         for hit in &hits {
-            let cnt = if hit.is_partial {
-                index.get_count_partial(hit.position)
+            let cnt = if let Some(undirected_pos) = hit.undirected_position {
+                index.get_count_partial(undirected_pos)
             } else {
                 index.get_count_full(hit.position, hit.hash_revcomp)
             };

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -128,25 +128,27 @@ fn find_all_hits(
 
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
-            if let Some(position) = index.get_full(randstrobe.hash) {
+            if let Some(count_position) = index.get_full(randstrobe.hash) {
                 let is_filtered =
-                    index.is_too_frequent(position, filter_cutoff, randstrobe.hash_revcomp);
+                    index.is_too_frequent(count_position, filter_cutoff, randstrobe.hash_revcomp);
                 if is_filtered {
                     hits_details.full_filtered += 1;
                 } else {
                     hits_details.full_found += 1;
                 }
 
-                let hit = Hit {
-                    position,
-                    query_start: randstrobe.start,
-                    query_end: randstrobe.end,
-                    is_partial: false,
-                    is_filtered,
-                    hash_revcomp: randstrobe.hash_revcomp,
-                    hash: randstrobe.hash,
-                };
-                hits.push(hit);
+                if let Some(position) = index.get_full_with_canonicity(randstrobe.hash) {
+                    let hit = Hit {
+                        position,
+                        query_start: randstrobe.start,
+                        query_end: randstrobe.end,
+                        is_partial: false,
+                        is_filtered,
+                        hash_revcomp: randstrobe.hash_revcomp,
+                        hash: randstrobe.hash,
+                    };
+                    hits.push(hit);
+                }
             } else {
                 hits_details.full_not_found += 1;
                 if mcs_strategy == McsStrategy::Always {

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -14,6 +14,7 @@ pub struct Hit {
     pub query_end: usize,
     pub position: usize,
     pub hash_revcomp: u64,
+    pub hash: u64,
     pub is_partial: bool,
     pub is_filtered: bool,
 }
@@ -143,6 +144,7 @@ fn find_all_hits(
                     is_partial: false,
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
+                    hash: randstrobe.hash,
                 };
                 hits.push(hit);
             } else {
@@ -162,6 +164,7 @@ fn find_all_hits(
                             is_partial: true,
                             is_filtered,
                             hash_revcomp: randstrobe.hash_revcomp,
+                            hash: randstrobe.hash,
                         };
                         hits.push(hit);
                     } else {
@@ -200,6 +203,7 @@ fn find_all_hits(
                     is_partial: true,
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
+                    hash: randstrobe.hash,
                 };
                 hits.push(hit);
             } else {

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -128,9 +128,9 @@ fn find_all_hits(
 
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
-            if let Some(full_pos) = index.get_full(randstrobe.hash) {
+            if let Some(position) = index.get_full(randstrobe.hash) {
                 let (is_filtered, forward_count) = index.is_too_frequent_with_forward_count(
-                    full_pos,
+                    position,
                     filter_cutoff,
                     randstrobe.hash_revcomp,
                 );
@@ -139,13 +139,12 @@ fn find_all_hits(
                 } else {
                     hits_details.full_found += 1;
                 }
-                if let Some(position) =
-                    index.find_canonical(randstrobe.hash, full_pos, forward_count)
+                if let Some(canonical_pos) =
+                    index.find_canonical(randstrobe.hash, position, forward_count)
                 {
-                    let canonicity =
-                        ((randstrobe.hash >> crate::index::STROBE2_OFFSET_BITS) & 0x3) as u8;
+                    let canonicity = index.randstrobes[canonical_pos].canonicity_bits();
                     let hit = Hit {
-                        position,
+                        position: canonical_pos,
                         query_start: randstrobe.start,
                         query_end: randstrobe.end,
                         is_partial: false,

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -150,6 +150,7 @@ fn find_all_hits(
             } else {
                 hits_details.full_not_found += 1;
                 if mcs_strategy == McsStrategy::Always {
+                    // Perform partial lookup in both directions for later use in rescue
                     if let Some(undirected_pos) = index.get_partial(randstrobe.hash) {
                         let is_filtered =
                             index.is_too_frequent_partial(undirected_pos, filter_cutoff);
@@ -190,6 +191,7 @@ fn find_all_hits(
             && hits_details.full_filtered + hits_details.full_found == 0)
     {
         for randstrobe in query_randstrobes {
+            // Perform partial lookup in both directions for later use in rescue
             if let Some(undirected_pos) = index.get_partial(randstrobe.hash) {
                 let is_filtered = index.is_too_frequent_partial(undirected_pos, filter_cutoff);
                 if is_filtered {

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -133,6 +133,7 @@ fn find_all_hits(
 
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
+            //Save forward count to find canonical hash later
             if let Some(position) = index.get_full(randstrobe.hash) {
                 let (is_filtered, forward_count) = index.is_too_frequent_with_forward_count(
                     position,
@@ -151,7 +152,7 @@ fn find_all_hits(
                     is_partial: false,
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
-                    query_canonicity: index.query_canonicity(randstrobe.hash),
+                    query_canonicity: StrobemerIndex::query_canonicity(randstrobe.hash),
                     forward_count,
                 };
                 hits.push(hit);
@@ -172,7 +173,7 @@ fn find_all_hits(
                             is_partial: true,
                             is_filtered,
                             hash_revcomp: randstrobe.hash_revcomp,
-                            query_canonicity: index.query_canonicity_partial(randstrobe.hash),
+                            query_canonicity: StrobemerIndex::query_canonicity_partial(randstrobe.hash),
                             forward_count: None,
                         };
                         hits.push(hit);
@@ -212,7 +213,7 @@ fn find_all_hits(
                     is_partial: true,
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
-                    query_canonicity: index.query_canonicity_partial(randstrobe.hash),
+                    query_canonicity: StrobemerIndex::query_canonicity_partial(randstrobe.hash),
                     forward_count: None,
                 };
                 hits.push(hit);

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -12,8 +12,9 @@ use crate::seeding::QueryRandstrobe;
 pub struct Hit {
     pub query_start: usize,
     pub query_end: usize,
-    pub forward_position: Option<usize>,
-    pub undirected_position: Option<usize>,
+    //Forward position for full hashes, undirected for partial
+    pub position: usize,
+    pub hash: u64,
     pub hash_revcomp: u64,
     pub is_partial: bool,
     pub is_filtered: bool,
@@ -94,9 +95,9 @@ fn rescue_least_frequent(
     let mut hit_counts = vec![];
     for i in start..end {
         let cnt = if hits[i].is_partial {
-            index.get_count_partial(hits[i].undirected_position.unwrap())
+            index.get_count_partial(hits[i].position)
         } else {
-            index.get_count_full(hits[i].forward_position.unwrap(), hits[i].hash_revcomp)
+            index.get_count_full(hits[i].position, hits[i].hash_revcomp)
         };
         if rescue_threshold.is_none() || cnt <= rescue_threshold.unwrap() {
             hit_counts.push((i, cnt));
@@ -137,12 +138,12 @@ fn find_all_hits(
                     hits_details.full_found += 1;
                 }
                 let hit = Hit {
-                    forward_position: Some(position),
-                    undirected_position: None,
+                    position: position,
                     query_start: randstrobe.start,
                     query_end: randstrobe.end,
                     is_partial: false,
                     is_filtered,
+                    hash: randstrobe.hash,
                     hash_revcomp: randstrobe.hash_revcomp,
                 };
                 hits.push(hit);
@@ -158,12 +159,12 @@ fn find_all_hits(
                             hits_details.partial_found += 1;
                         }
                         let hit = Hit {
-                            forward_position: index.get_partial_forward_from(randstrobe.hash, undirected_pos),
-                            undirected_position: Some(undirected_pos),
+                            position: undirected_pos,
                             query_start: randstrobe.start,
                             query_end: randstrobe.start + index.k(),
                             is_partial: true,
                             is_filtered,
+                            hash: randstrobe.hash,
                             hash_revcomp: randstrobe.hash_revcomp,
                         };
                         hits.push(hit);
@@ -190,20 +191,19 @@ fn find_all_hits(
     {
         for randstrobe in query_randstrobes {
             if let Some(undirected_pos) = index.get_partial(randstrobe.hash) {
-                let is_filtered =
-                    index.is_too_frequent_partial(undirected_pos, filter_cutoff);
+                let is_filtered = index.is_too_frequent_partial(undirected_pos, filter_cutoff);
                 if is_filtered {
                     hits_details.partial_filtered += 1;
                 } else {
                     hits_details.partial_found += 1;
                 }
                 let hit = Hit {
-                    forward_position: index.get_partial_forward_from(randstrobe.hash, undirected_pos),
-                    undirected_position: Some(undirected_pos),
+                    position: undirected_pos,
                     query_start: randstrobe.start,
                     query_end: randstrobe.start + index.k(),
                     is_partial: true,
                     is_filtered,
+                    hash: randstrobe.hash,
                     hash_revcomp: randstrobe.hash_revcomp,
                 };
                 hits.push(hit);
@@ -298,9 +298,9 @@ pub fn find_hits(
         trace!("querypos count (p=partial, F=filtered)");
         for hit in &hits {
             let cnt = if hit.is_partial {
-                index.get_count_partial(hit.undirected_position.unwrap())
+                index.get_count_partial(hit.position)
             } else {
-                index.get_count_full(hit.forward_position.unwrap(), hit.hash_revcomp)
+                index.get_count_full(hit.position, hit.hash_revcomp)
             };
             trace!(
                 "{:6} {}{:6} {}",

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -128,7 +128,8 @@ fn find_all_hits(
 
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
-            if let Some(count_position) = index.get_full(randstrobe.hash) {
+            let (full_pos, canon_pos) = index.get_full_and_canonical(randstrobe.hash);
+            if let Some(count_position) = full_pos {
                 let is_filtered =
                     index.is_too_frequent(count_position, filter_cutoff, randstrobe.hash_revcomp);
                 if is_filtered {
@@ -137,7 +138,7 @@ fn find_all_hits(
                     hits_details.full_found += 1;
                 }
 
-                if let Some(position) = index.get_full_with_canonicity(randstrobe.hash) {
+                if let Some(position) = canon_pos {
                     let hit = Hit {
                         position,
                         query_start: randstrobe.start,

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -14,9 +14,9 @@ pub struct Hit {
     pub query_end: usize,
     pub position: usize,
     pub hash_revcomp: u64,
-    pub hash: u64,
     pub is_partial: bool,
     pub is_filtered: bool,
+    pub query_canonicity: u8,
 }
 
 /// Aggregate statistics resulting from looking up all strobemers of a single
@@ -146,7 +146,7 @@ fn find_all_hits(
                         is_partial: false,
                         is_filtered,
                         hash_revcomp: randstrobe.hash_revcomp,
-                        hash: randstrobe.hash,
+                        query_canonicity: index.query_canonicity(randstrobe.hash)
                     };
                     hits.push(hit);
                 }
@@ -167,7 +167,7 @@ fn find_all_hits(
                             is_partial: true,
                             is_filtered,
                             hash_revcomp: randstrobe.hash_revcomp,
-                            hash: randstrobe.hash,
+                            query_canonicity: index.query_canonicity_partial(randstrobe.hash),
                         };
                         hits.push(hit);
                     } else {
@@ -206,7 +206,7 @@ fn find_all_hits(
                     is_partial: true,
                     is_filtered,
                     hash_revcomp: randstrobe.hash_revcomp,
-                    hash: randstrobe.hash,
+                    query_canonicity: index.query_canonicity_partial(randstrobe.hash),
                 };
                 hits.push(hit);
             } else {

--- a/src/index.rs
+++ b/src/index.rs
@@ -465,29 +465,30 @@ impl<'a> StrobemerIndex<'a> {
         self.get_masked(hash, REF_RANDSTROBE_HASH_MASK)
     }
 
-    /// Single lookup returning both the ref-masked position and the
-    /// canonical-masked position.
-    pub fn get_full_and_canonical(
-        &self,
-        hash: RandstrobeHash,
-    ) -> (Option<usize>, Option<usize>) {
-        let Some(ref_pos) = self.get_full(hash) else {
-            return (None, None);
-        };
-
+    /// Search for the canonical hash within the range [start, start + count).
+    /// Returns the position of the first match, or None.
+    pub fn find_canonical(&self, hash: RandstrobeHash, start: usize, count: usize) -> Option<usize> {
         let canon_masked = hash & CANONICAL_HASH_MASK;
-        let ref_masked = hash & REF_RANDSTROBE_HASH_MASK;
-        let mut i = ref_pos;
-        while i < self.randstrobes.len()
-            && self.randstrobes[i].hash_offset & REF_RANDSTROBE_HASH_MASK == ref_masked
-        {
-            if self.randstrobes[i].hash_offset & CANONICAL_HASH_MASK == canon_masked {
-                return (Some(ref_pos), Some(i));
+        const MAX_LINEAR_SEARCH: usize = 4;
+        let bucket = &self.randstrobes[start..start + count];
+        if bucket.len() < MAX_LINEAR_SEARCH {
+            for (i, rs) in bucket.iter().enumerate() {
+                if rs.hash_offset & CANONICAL_HASH_MASK == canon_masked {
+                    return Some(start + i);
+                }
+                if rs.hash_offset & CANONICAL_HASH_MASK > canon_masked {
+                    return None;
+                }
             }
-            i += 1;
+            return None;
         }
 
-        (Some(ref_pos), None)
+        let pos = custom_partition_point(bucket, |h| h.hash_offset & CANONICAL_HASH_MASK < canon_masked);
+        if pos < bucket.len() && bucket[pos].hash_offset & CANONICAL_HASH_MASK == canon_masked {
+            Some(start + pos)
+        } else {
+            None
+        }
     }
 
     /// Find the first entry that matches the main hash
@@ -592,20 +593,30 @@ impl<'a> StrobemerIndex<'a> {
     }
 
     pub fn is_too_frequent(&self, position: usize, cutoff: usize, hash_revcomp: u64) -> bool {
+        self.is_too_frequent_with_forward_count(position, cutoff, hash_revcomp).0
+    }
+
+    /// Returns (is_filtered, forward_count) so the caller can reuse the
+    /// forward count without a second lookup.
+    pub fn is_too_frequent_with_forward_count(
+        &self,
+        position: usize,
+        cutoff: usize,
+        hash_revcomp: u64,
+    ) -> (bool, usize) {
         if self.is_too_frequent_forward(position, cutoff) {
-            return true;
+            return (true, 0);
         }
+        let forward_count = self.get_count_full_forward(position);
         if let Some(position_revcomp) = self.get_full(hash_revcomp) {
             if self.is_too_frequent_forward(position_revcomp, cutoff) {
-                return true;
+                return (true, forward_count);
             }
-            let count = self.get_count_full_forward(position)
-                + self.get_count_full_forward(position_revcomp);
-
-            return count > cutoff;
+            let total = forward_count + self.get_count_full_forward(position_revcomp);
+            return (total > cutoff, forward_count);
         }
 
-        false
+        (false, forward_count)
     }
 
     pub fn is_too_frequent_forward_partial(&self, position: usize, cutoff: usize) -> bool {

--- a/src/index.rs
+++ b/src/index.rs
@@ -856,7 +856,7 @@ mod tests {
             for (sf, sr) in syncmers_forward.iter().zip(syncmers_reverse.iter()) {
                 assert_eq!(sf.hash(), sr.hash());
                 assert_eq!(sf.position, sr.position);
-                assert_ne!(sf.is_canonical(), sr.is_canonical());
+                assert_ne!(sf.is_forward(), sr.is_forward());
             }
         }
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -469,6 +469,31 @@ impl<'a> StrobemerIndex<'a> {
         self.get_masked(hash, CANONICAL_HASH_MASK)
     }
 
+    /// Single lookup returning both the ref-masked position and the
+    /// canonical-masked position.
+    pub fn get_full_and_canonical(
+        &self,
+        hash: RandstrobeHash,
+    ) -> (Option<usize>, Option<usize>) {
+        let Some(ref_pos) = self.get_full(hash) else {
+            return (None, None);
+        };
+
+        let canon_masked = hash & CANONICAL_HASH_MASK;
+        let ref_masked = hash & REF_RANDSTROBE_HASH_MASK;
+        let mut i = ref_pos;
+        while i < self.randstrobes.len()
+            && self.randstrobes[i].hash_offset & REF_RANDSTROBE_HASH_MASK == ref_masked
+        {
+            if self.randstrobes[i].hash_offset & CANONICAL_HASH_MASK == canon_masked {
+                return (Some(ref_pos), Some(i));
+            }
+            i += 1;
+        }
+
+        (Some(ref_pos), None)
+    }
+
     /// Find the first entry that matches the main hash
     pub fn get_partial(&self, hash: RandstrobeHash) -> Option<usize> {
         self.get_masked(hash, self.parameters.randstrobe.main_hash_mask)

--- a/src/index.rs
+++ b/src/index.rs
@@ -134,8 +134,8 @@ impl RefRandstrobe {
         ((self.hash_offset >> STROBE2_OFFSET_BITS) & 0x3) as u8
     }
 
-    pub fn canonicity_matches(&self, query_hash: u64) -> bool {
-        ((query_hash >> STROBE2_OFFSET_BITS) & 0x3) as u8 == self.canonicity_bits()
+    pub fn canonicity_bit(&self) -> u8 {
+        ((self.hash_offset >> STROBE2_OFFSET_BITS) & 0x2) as u8
     }
 }
 
@@ -591,6 +591,16 @@ impl<'a> StrobemerIndex<'a> {
     pub fn is_too_frequent_partial(&self, position: usize, cutoff: usize) -> bool {
         self.is_too_frequent_forward_partial(position, cutoff)
     }
+
+    pub fn canonicity_matches(&self, hash: RandstrobeHash, position: usize) -> bool {
+        let query_canonicity = ((hash >> STROBE2_OFFSET_BITS) & 0x3) as u8;
+        self.randstrobes[position].canonicity_bits() == query_canonicity
+    }
+
+    pub fn canonicity_matches_partial(&self, hash: RandstrobeHash, position: usize) -> bool {
+        let query_canonicity = ((hash >> STROBE2_OFFSET_BITS) & 0x2) as u8;
+        self.randstrobes[position].canonicity_bit() == query_canonicity
+    }
 }
 
 const STI_FILE_FORMAT_VERSION: u32 = 7;
@@ -899,11 +909,9 @@ mod tests {
         assert_eq!(ref_randstrobe.canonicity_bits(), 0b11);
         assert_eq!(ref_randstrobe.strobe2_offset(), 5);
         assert_eq!(ref_randstrobe.hash(), 0xABCD_u64 << 10);
-        assert!(ref_randstrobe.canonicity_matches(hash_both));
 
         let hash_none: u64 = (0xABCD_u64 << 10) | (0b00 << STROBE2_OFFSET_BITS);
         let ref_randstrobe2 = RefRandstrobe::new(hash_none, 0, 100, 5);
         assert_eq!(ref_randstrobe2.canonicity_bits(), 0b00);
-        assert!(!ref_randstrobe2.canonicity_matches(hash_both));
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -496,7 +496,7 @@ impl<'a> StrobemerIndex<'a> {
     }
 
     /// Find index of first entry in randstrobe table that has the given
-    /// hash value masked by the `hash_mask`.
+    /// hash value masked by the `hash_mask`
     pub fn get_masked(&self, hash: RandstrobeHash, hash_mask: RandstrobeHash) -> Option<usize> {
         let masked_hash = hash & hash_mask;
         const MAX_LINEAR_SEARCH: usize = 4;

--- a/src/index.rs
+++ b/src/index.rs
@@ -93,14 +93,25 @@ impl Display for IndexCreationStatistics {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Default, Clone)]
 #[repr(C)]
 pub struct RefRandstrobe {
-    /// packed representation of the hash and the strobe offset
+    /// Packed representation of the hash and the strobe offset.  
+    /// Has the following layout
+    /// `<strobe1 hash><strobe1 orientation bit><strobe2 hash><strobe2 orientation bit><strobe2 offset from strobe1>`
+    ///
+    /// [`RandstrobeParameters::partial_orientation_pos`] specifies the position of strobe1 orientation bit in the layout  
+    /// [`RandstrobeParameters::forward_main_hash_mask`] is the mask for strobe1 hash (without the orientation bit)  
+    /// [`RandstrobeParameters::main_hash_mask`] is the mask for strobe1 hash which includes the orientation bit  
+    /// [`REF_RANDSTROBE_HASH_MASK`] is the mask for strobe1 and strobe2 hashes (including their orientations)  
+    /// The [`STROBE2_OFFSET_BITS`] constant specifies the number of bits reserved for the offset  
     hash_offset: u64,
     position: u32,
     ref_index: u32,
 }
 
+/// Mask for the part of the randstrobe hash that includes individual strobe hashes and orientations
 pub const REF_RANDSTROBE_HASH_MASK: u64 = 0xFFFFFFFFFFFFFF00;
+/// Number of bits reserved for offset between first and second strobe
 pub const STROBE2_OFFSET_BITS: u32 = 8;
+/// Mask for the part of the randstrobe hash that includes the offset between first and second strobe
 pub const STROBE2_OFFSET_MASK: u64 = (1u64 << STROBE2_OFFSET_BITS) - 1;
 pub const REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES: usize = u32::MAX as usize;
 
@@ -448,11 +459,12 @@ impl<'a> StrobemerIndex<'a> {
         debug_assert_eq!(n, randstrobes.len());
     }
 
+    // Find the first entry that matches the forwald full hash (including orientation bits)
     pub fn get_full_forward(&self, hash: RandstrobeHash) -> Option<usize> {
         self.get_masked(hash, REF_RANDSTROBE_HASH_MASK)
     }
 
-    /// Find the first entry that matches the undirected main hash
+    /// Find the first entry that matches the undirected main hash (without orientation bit)
     pub fn get_partial(&self, hash: RandstrobeHash) -> Option<usize> {
         self.get_masked(hash, self.parameters.randstrobe.main_hash_mask)
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -491,8 +491,8 @@ impl<'a> StrobemerIndex<'a> {
         let top_n = (hash >> (64 - self.bits)) as usize;
         let position_start =
             start_position.unwrap_or(self.randstrobe_start_indices[top_n] as usize);
-        let position_end = self.randstrobe_start_indices[top_n + 1] as usize;
-        let bucket = &self.randstrobes[position_start..position_end];
+        let position_end = self.randstrobe_start_indices[top_n + 1];
+        let bucket = &self.randstrobes[position_start as usize..position_end as usize];
         if bucket.is_empty() {
             return None;
         } else if bucket.len() < MAX_LINEAR_SEARCH {
@@ -507,9 +507,9 @@ impl<'a> StrobemerIndex<'a> {
             return None;
         }
 
-        let pos = custom_partition_point(bucket, |h| h.hash_offset & hash_mask < masked_hash);
+        let pos = custom_partition_point(bucket, |h| h.hash() & hash_mask < masked_hash);
         if pos < bucket.len() && bucket[pos].hash() & hash_mask == masked_hash {
-            Some(position_start + pos)
+            Some(position_start as usize + pos)
         } else {
             None
         }

--- a/src/index.rs
+++ b/src/index.rs
@@ -842,9 +842,9 @@ mod tests {
             }
             assert_eq!(syncmers_forward.len(), syncmers_reverse.len());
             for (sf, sr) in syncmers_forward.iter().zip(syncmers_reverse.iter()) {
-                assert_eq!(sf.hash, sr.hash);
+                assert_eq!(sf.hash(), sr.hash());
                 assert_eq!(sf.position, sr.position);
-                assert_ne!(sf.is_canonical, sr.is_canonical);
+                assert_ne!(sf.is_canonical(), sr.is_canonical());
             }
         }
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -99,15 +99,14 @@ pub struct RefRandstrobe {
     ref_index: u32,
 }
 
-pub const UNDIRECTED_HASH_MASK: u64 = 0xFFFFFFFFFFFFFC00;
-pub const DIRECTED_HASH_MASK: u64 = 0xFFFFFFFFFFFFFF00;
+pub const REF_RANDSTROBE_HASH_MASK: u64 = 0xFFFFFFFFFFFFFF00;
 pub const STROBE2_OFFSET_BITS: u32 = 8;
 pub const STROBE2_OFFSET_MASK: u64 = (1u64 << STROBE2_OFFSET_BITS) - 1;
 pub const REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES: usize = u32::MAX as usize;
 
 impl RefRandstrobe {
     fn new(hash: RandstrobeHash, ref_index: u32, position: u32, offset: u8) -> Self {
-        let hash_offset = (hash & !STROBE2_OFFSET_MASK) | (offset as u64);
+        let hash_offset = (hash & REF_RANDSTROBE_HASH_MASK) | (offset as u64);
         RefRandstrobe {
             hash_offset,
             position,
@@ -116,11 +115,7 @@ impl RefRandstrobe {
     }
 
     pub fn hash(&self) -> RandstrobeHash {
-        self.hash_offset & UNDIRECTED_HASH_MASK
-    }
-
-    pub fn directed_hash(&self) -> RandstrobeHash {
-        self.hash_offset & DIRECTED_HASH_MASK
+        self.hash_offset & REF_RANDSTROBE_HASH_MASK
     }
 
     pub fn position(&self) -> usize {
@@ -133,14 +128,6 @@ impl RefRandstrobe {
 
     pub fn strobe2_offset(&self) -> usize {
         (self.hash_offset & STROBE2_OFFSET_MASK) as usize
-    }
-
-    pub fn orientation_full(&self) -> u8 {
-        ((self.hash_offset >> STROBE2_OFFSET_BITS) & 0x3) as u8
-    }
-
-    pub fn orientation_partial(&self) -> u8 {
-        ((self.hash_offset >> STROBE2_OFFSET_BITS) & 0x2) as u8
     }
 }
 
@@ -461,65 +448,59 @@ impl<'a> StrobemerIndex<'a> {
         debug_assert_eq!(n, randstrobes.len());
     }
 
-    pub fn get_full(&self, hash: RandstrobeHash) -> Option<usize> {
-        self.get_masked(hash, UNDIRECTED_HASH_MASK)
+    pub fn get_full_forward(&self, hash: RandstrobeHash) -> Option<usize> {
+        self.get_masked(hash, REF_RANDSTROBE_HASH_MASK)
     }
 
-    /// Search for the directed hash within the range [start, start + count).
-    pub fn get_full_directed(
-        &self,
-        hash: RandstrobeHash,
-        start: usize,
-        count: Option<usize>,
-    ) -> Option<usize> {
-        let count = count.unwrap_or_else(|| self.get_count_full_forward(start));
-        let directed_masked = hash & DIRECTED_HASH_MASK;
-        const MAX_LINEAR_SEARCH: usize = 4;
-        let bucket = &self.randstrobes[start..start + count];
-        if bucket.len() < MAX_LINEAR_SEARCH {
-            for (i, rs) in bucket.iter().enumerate() {
-                if rs.hash_offset & DIRECTED_HASH_MASK == directed_masked {
-                    return Some(start + i);
-                }
-                if rs.hash_offset & DIRECTED_HASH_MASK > directed_masked {
-                    return None;
-                }
-            }
-            return None;
-        }
-
-        let pos = custom_partition_point(bucket, |h| {
-            h.hash_offset & DIRECTED_HASH_MASK < directed_masked
-        });
-        if pos < bucket.len() && bucket[pos].hash_offset & DIRECTED_HASH_MASK == directed_masked {
-            Some(start + pos)
-        } else {
-            None
-        }
-    }
-
-    /// Find the first entry that matches the main hash
+    /// Find the first entry that matches the undirected main hash
     pub fn get_partial(&self, hash: RandstrobeHash) -> Option<usize> {
         self.get_masked(hash, self.parameters.randstrobe.main_hash_mask)
     }
 
+    /// Find the first entry matching the forward main hash
+    pub fn get_partial_forward(&self, hash: RandstrobeHash) -> Option<usize> {
+        self.get_masked(hash, self.parameters.randstrobe.forward_main_hash_mask)
+    }
+
+    /// Find the first entry matching the forward main hash, starting from
+    /// the undirected main position
+    pub fn get_partial_forward_from(
+        &self,
+        hash: RandstrobeHash,
+        undirected_position: usize,
+    ) -> Option<usize> {
+        self.get_masked_from(
+            hash,
+            self.parameters.randstrobe.forward_main_hash_mask,
+            Some(undirected_position),
+        )
+    }
+
     /// Find index of first entry in randstrobe table that has the given
-    /// hash value masked by the `hash_mask`
-    pub fn get_masked(&self, hash: RandstrobeHash, hash_mask: RandstrobeHash) -> Option<usize> {
+    /// hash value masked by the `hash_mask`.
+    /// If `start_position` is provided, search starts from there instead of
+    /// the bucket start.
+    pub fn get_masked_from(
+        &self,
+        hash: RandstrobeHash,
+        hash_mask: RandstrobeHash,
+        start_position: Option<usize>,
+    ) -> Option<usize> {
         let masked_hash = hash & hash_mask;
         const MAX_LINEAR_SEARCH: usize = 4;
         let top_n = (hash >> (64 - self.bits)) as usize;
-        let position_start = self.randstrobe_start_indices[top_n];
-        let position_end = self.randstrobe_start_indices[top_n + 1];
-        let bucket = &self.randstrobes[position_start as usize..position_end as usize];
+        let position_start =
+            start_position.unwrap_or(self.randstrobe_start_indices[top_n] as usize);
+        let position_end = self.randstrobe_start_indices[top_n + 1] as usize;
+        let bucket = &self.randstrobes[position_start..position_end];
         if bucket.is_empty() {
             return None;
         } else if bucket.len() < MAX_LINEAR_SEARCH {
             for (pos, randstrobe) in bucket.iter().enumerate() {
-                if randstrobe.hash_offset & hash_mask == masked_hash {
+                if randstrobe.hash() & hash_mask == masked_hash {
                     return Some(position_start as usize + pos);
                 }
-                if randstrobe.hash_offset & hash_mask > masked_hash {
+                if randstrobe.hash() & hash_mask > masked_hash {
                     return None;
                 }
             }
@@ -527,11 +508,15 @@ impl<'a> StrobemerIndex<'a> {
         }
 
         let pos = custom_partition_point(bucket, |h| h.hash_offset & hash_mask < masked_hash);
-        if pos < bucket.len() && bucket[pos].hash_offset & hash_mask == masked_hash {
-            Some(position_start as usize + pos)
+        if pos < bucket.len() && bucket[pos].hash() & hash_mask == masked_hash {
+            Some(position_start + pos)
         } else {
             None
         }
+    }
+
+    pub fn get_masked(&self, hash: RandstrobeHash, hash_mask: RandstrobeHash) -> Option<usize> {
+        self.get_masked_from(hash, hash_mask, None)
     }
 
     pub fn k(&self) -> usize {
@@ -542,6 +527,10 @@ impl<'a> StrobemerIndex<'a> {
         self.randstrobes[position].hash() & self.parameters.randstrobe.main_hash_mask
     }
 
+    pub fn get_hash_partial_forward(&self, position: usize) -> RandstrobeHash {
+        self.randstrobes[position].hash_offset & self.parameters.randstrobe.forward_main_hash_mask
+    }
+
     pub fn strobe_extent_partial(&self, position: usize) -> (usize, usize) {
         let p = self.randstrobes[position].position;
 
@@ -550,26 +539,17 @@ impl<'a> StrobemerIndex<'a> {
 
     /// Count number of hits for the randstrobe *and* its "reverse complement"
     pub fn get_count_full(&self, position: usize, hash_revcomp: u64) -> usize {
-        self.get_count_full_with_forward(position, hash_revcomp).0
-    }
-
-    /// Returns forward count with the full count for later use
-    pub fn get_count_full_with_forward(
-        &self,
-        position: usize,
-        hash_revcomp: u64,
-    ) -> (usize, usize) {
-        let forward_count = self.get_count_full_forward(position);
-        let reverse_count = if let Some(position_revcomp) = self.get_full(hash_revcomp) {
-            self.get_count_full_forward(position_revcomp)
+        let reverse_count;
+        if let Some(position_revcomp) = self.get_full_forward(hash_revcomp) {
+            reverse_count = self.get_count_full_forward(position_revcomp);
         } else {
-            0
-        };
-        (reverse_count + forward_count, forward_count)
+            reverse_count = 0;
+        }
+        reverse_count + self.get_count_full_forward(position)
     }
 
     pub fn get_count_full_forward(&self, position: usize) -> usize {
-        self.get_count(position, UNDIRECTED_HASH_MASK)
+        self.get_count(position, REF_RANDSTROBE_HASH_MASK)
     }
 
     pub fn get_count_partial(&self, position: usize) -> usize {
@@ -609,30 +589,20 @@ impl<'a> StrobemerIndex<'a> {
     }
 
     pub fn is_too_frequent(&self, position: usize, cutoff: usize, hash_revcomp: u64) -> bool {
-        self.is_too_frequent_with_forward_count(position, cutoff, hash_revcomp)
-            .0
-    }
-
-    /// is_too_frequent with the forward count for later use
-    pub fn is_too_frequent_with_forward_count(
-        &self,
-        position: usize,
-        cutoff: usize,
-        hash_revcomp: u64,
-    ) -> (bool, Option<usize>) {
         if self.is_too_frequent_forward(position, cutoff) {
-            return (true, None);
+            return true;
         }
-        let forward_count = self.get_count_full_forward(position);
-        if let Some(position_revcomp) = self.get_full(hash_revcomp) {
+        if let Some(position_revcomp) = self.get_full_forward(hash_revcomp) {
             if self.is_too_frequent_forward(position_revcomp, cutoff) {
-                return (true, Some(forward_count));
+                return true;
             }
-            let total = forward_count + self.get_count_full_forward(position_revcomp);
-            return (total > cutoff, Some(forward_count));
+            let count = self.get_count_full_forward(position)
+                + self.get_count_full_forward(position_revcomp);
+
+            return count > cutoff;
         }
 
-        (false, Some(forward_count))
+        false
     }
 
     pub fn is_too_frequent_forward_partial(&self, position: usize, cutoff: usize) -> bool {
@@ -647,19 +617,6 @@ impl<'a> StrobemerIndex<'a> {
 
     pub fn is_too_frequent_partial(&self, position: usize, cutoff: usize) -> bool {
         self.is_too_frequent_forward_partial(position, cutoff)
-    }
-
-    //Applies orientation to undirected hash
-    pub fn apply_orientation(hash: RandstrobeHash, query_orientation: u8) -> u64 {
-        (hash & UNDIRECTED_HASH_MASK) ^ ((query_orientation as u64) << STROBE2_OFFSET_BITS)
-    }
-
-    pub fn query_orientation(hash: RandstrobeHash) -> u8 {
-        ((hash >> STROBE2_OFFSET_BITS) & 0x3) as u8
-    }
-
-    pub fn query_orientation_partial(hash: RandstrobeHash) -> u8 {
-        ((hash >> STROBE2_OFFSET_BITS) & 0x2) as u8
     }
 }
 
@@ -773,12 +730,15 @@ impl<'a> StrobemerIndex<'a> {
         let main_hash_mask = read_u64(&mut reader)?;
 
         let syncmer_parameters = SyncmerParameters::try_new(k, s)?;
+        let partial_orientation_pos = main_hash_mask.trailing_zeros() - 1;
         let randstrobe_parameters = RandstrobeParameters {
             w_min,
             w_max,
             q,
             max_dist,
             main_hash_mask,
+            forward_main_hash_mask: main_hash_mask | (1u64 << partial_orientation_pos),
+            partial_orientation_pos,
         };
         let sti_parameters = SeedingParameters {
             profile,
@@ -858,7 +818,7 @@ mod tests {
 
     #[test]
     fn test_ref_randstrobe() {
-        let hash: u64 = 0x1234567890ABCDEFu64 & UNDIRECTED_HASH_MASK;
+        let hash: u64 = 0x1234567890ABCDEFu64 & REF_RANDSTROBE_HASH_MASK;
         let ref_index: u32 = (REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES - 1) as u32;
         let offset = 255;
         let position = !0;
@@ -868,7 +828,6 @@ mod tests {
         assert_eq!(rr.position(), position as usize);
         assert_eq!(rr.reference_index(), ref_index as usize);
         assert_eq!(rr.strobe2_offset(), offset as usize);
-        assert_eq!(rr.orientation_full(), 0);
     }
 
     fn syncmers_of(seq: &[u8], parameters: &SyncmerParameters) -> Vec<Syncmer> {
@@ -966,12 +925,14 @@ mod tests {
     fn test_orientation() {
         let hash_both: u64 = (0xABCD_u64 << 10) | (0b11 << STROBE2_OFFSET_BITS);
         let ref_randstrobe = RefRandstrobe::new(hash_both, 0, 100, 5);
-        assert_eq!(ref_randstrobe.orientation_full(), 0b11);
         assert_eq!(ref_randstrobe.strobe2_offset(), 5);
-        assert_eq!(ref_randstrobe.hash(), 0xABCD_u64 << 10);
+        assert_eq!(
+            ref_randstrobe.hash(),
+            (0xABCD_u64 << 10) | (0b11 << STROBE2_OFFSET_BITS)
+        );
 
         let hash_none: u64 = (0xABCD_u64 << 10) | (0b00 << STROBE2_OFFSET_BITS);
         let ref_randstrobe2 = RefRandstrobe::new(hash_none, 0, 100, 5);
-        assert_eq!(ref_randstrobe2.orientation_full(), 0b00);
+        assert_eq!(ref_randstrobe2.hash(), 0xABCD_u64 << 10);
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -470,8 +470,9 @@ impl<'a> StrobemerIndex<'a> {
         &self,
         hash: RandstrobeHash,
         start: usize,
-        count: usize,
+        count: Option<usize>,
     ) -> Option<usize> {
+        let count = count.unwrap_or_else(|| self.get_count_full_forward(start));
         let canon_masked = hash & CANONICAL_HASH_MASK;
         const MAX_LINEAR_SEARCH: usize = 4;
         let bucket = &self.randstrobes[start..start + count];
@@ -549,13 +550,18 @@ impl<'a> StrobemerIndex<'a> {
 
     /// Count number of hits for the randstrobe *and* its "reverse complement"
     pub fn get_count_full(&self, position: usize, hash_revcomp: u64) -> usize {
-        let reverse_count;
-        if let Some(position_revcomp) = self.get_full(hash_revcomp) {
-            reverse_count = self.get_count_full_forward(position_revcomp);
+        self.get_count_full_with_forward(position, hash_revcomp).0
+    }
+
+    /// Returns forward count with the full count to avoid additional lookups
+    pub fn get_count_full_with_forward(&self, position: usize, hash_revcomp: u64) -> (usize, usize) {
+        let forward_count = self.get_count_full_forward(position);
+        let reverse_count = if let Some(position_revcomp) = self.get_full(hash_revcomp) {
+            self.get_count_full_forward(position_revcomp)
         } else {
-            reverse_count = 0;
-        }
-        reverse_count + self.get_count_full_forward(position)
+            0
+        };
+        (reverse_count + forward_count, forward_count)
     }
 
     pub fn get_count_full_forward(&self, position: usize) -> usize {
@@ -603,27 +609,26 @@ impl<'a> StrobemerIndex<'a> {
             .0
     }
 
-    /// Returns (is_filtered, forward_count) so the caller can reuse the
-    /// forward count without a second lookup.
+    /// is_too_frequent with the forward count to avoid additional lookups
     pub fn is_too_frequent_with_forward_count(
         &self,
         position: usize,
         cutoff: usize,
         hash_revcomp: u64,
-    ) -> (bool, usize) {
+    ) -> (bool, Option<usize>) {
         if self.is_too_frequent_forward(position, cutoff) {
-            return (true, 0);
+            return (true, None);
         }
         let forward_count = self.get_count_full_forward(position);
         if let Some(position_revcomp) = self.get_full(hash_revcomp) {
             if self.is_too_frequent_forward(position_revcomp, cutoff) {
-                return (true, forward_count);
+                return (true, Some(forward_count));
             }
             let total = forward_count + self.get_count_full_forward(position_revcomp);
-            return (total > cutoff, forward_count);
+            return (total > cutoff, Some(forward_count));
         }
 
-        (false, forward_count)
+        (false, Some(forward_count))
     }
 
     pub fn is_too_frequent_forward_partial(&self, position: usize, cutoff: usize) -> bool {

--- a/src/index.rs
+++ b/src/index.rs
@@ -553,7 +553,7 @@ impl<'a> StrobemerIndex<'a> {
         self.get_count_full_with_forward(position, hash_revcomp).0
     }
 
-    /// Returns forward count with the full count to avoid additional lookups
+    /// Returns forward count with the full count for later use
     pub fn get_count_full_with_forward(&self, position: usize, hash_revcomp: u64) -> (usize, usize) {
         let forward_count = self.get_count_full_forward(position);
         let reverse_count = if let Some(position_revcomp) = self.get_full(hash_revcomp) {
@@ -609,7 +609,7 @@ impl<'a> StrobemerIndex<'a> {
             .0
     }
 
-    /// is_too_frequent with the forward count to avoid additional lookups
+    /// is_too_frequent with the forward count for later use
     pub fn is_too_frequent_with_forward_count(
         &self,
         position: usize,
@@ -645,11 +645,16 @@ impl<'a> StrobemerIndex<'a> {
         self.is_too_frequent_forward_partial(position, cutoff)
     }
 
-    pub fn query_canonicity(&self, hash: RandstrobeHash) -> u8 {
+    //Applies canonicity to unoriented hash
+    pub fn apply_canonicity(hash: RandstrobeHash, query_canonicity: u8) -> u64 {
+        (hash & REF_RANDSTROBE_HASH_MASK) ^ ((query_canonicity as u64) << 8)
+    }
+
+    pub fn query_canonicity(hash: RandstrobeHash) -> u8 {
         ((hash >> STROBE2_OFFSET_BITS) & 0x3) as u8
     }
 
-    pub fn query_canonicity_partial(&self, hash: RandstrobeHash) -> u8 {
+    pub fn query_canonicity_partial(hash: RandstrobeHash) -> u8 {
         ((hash >> STROBE2_OFFSET_BITS) & 0x2) as u8
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -100,6 +100,7 @@ pub struct RefRandstrobe {
 }
 
 pub const REF_RANDSTROBE_HASH_MASK: u64 = 0xFFFFFFFFFFFFFC00;
+pub const CANONICAL_HASH_MASK: u64 = 0xFFFFFFFFFFFFFF00;
 pub const STROBE2_OFFSET_BITS: u32 = 8;
 pub const STROBE2_OFFSET_MASK: u64 = (1u64 << STROBE2_OFFSET_BITS) - 1;
 pub const REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES: usize = u32::MAX as usize;
@@ -116,6 +117,10 @@ impl RefRandstrobe {
 
     pub fn hash(&self) -> RandstrobeHash {
         self.hash_offset & REF_RANDSTROBE_HASH_MASK
+    }
+
+    pub fn canonical_hash(&self) -> RandstrobeHash {
+        self.hash_offset & CANONICAL_HASH_MASK
     }
 
     pub fn position(&self) -> usize {
@@ -460,13 +465,17 @@ impl<'a> StrobemerIndex<'a> {
         self.get_masked(hash, REF_RANDSTROBE_HASH_MASK)
     }
 
+    pub fn get_full_with_canonicity(&self, hash: RandstrobeHash) -> Option<usize> {
+        self.get_masked(hash, CANONICAL_HASH_MASK)
+    }
+
     /// Find the first entry that matches the main hash
     pub fn get_partial(&self, hash: RandstrobeHash) -> Option<usize> {
         self.get_masked(hash, self.parameters.randstrobe.main_hash_mask)
     }
 
     /// Find index of first entry in randstrobe table that has the given
-    /// hash value masked by the `hash_mask`
+    /// hash value masked by the `hash_mask`.
     pub fn get_masked(&self, hash: RandstrobeHash, hash_mask: RandstrobeHash) -> Option<usize> {
         let masked_hash = hash & hash_mask;
         const MAX_LINEAR_SEARCH: usize = 4;
@@ -478,18 +487,18 @@ impl<'a> StrobemerIndex<'a> {
             return None;
         } else if bucket.len() < MAX_LINEAR_SEARCH {
             for (pos, randstrobe) in bucket.iter().enumerate() {
-                if randstrobe.hash() & hash_mask == masked_hash {
+                if randstrobe.hash_offset & hash_mask == masked_hash {
                     return Some(position_start as usize + pos);
                 }
-                if randstrobe.hash() & hash_mask > masked_hash {
+                if randstrobe.hash_offset & hash_mask > masked_hash {
                     return None;
                 }
             }
             return None;
         }
 
-        let pos = custom_partition_point(bucket, |h| h.hash() & hash_mask < masked_hash);
-        if pos < bucket.len() && bucket[pos].hash() & hash_mask == masked_hash {
+        let pos = custom_partition_point(bucket, |h| h.hash_offset & hash_mask < masked_hash);
+        if pos < bucket.len() && bucket[pos].hash_offset & hash_mask == masked_hash {
             Some(position_start as usize + pos)
         } else {
             None
@@ -592,14 +601,12 @@ impl<'a> StrobemerIndex<'a> {
         self.is_too_frequent_forward_partial(position, cutoff)
     }
 
-    pub fn canonicity_matches(&self, hash: RandstrobeHash, position: usize) -> bool {
-        let query_canonicity = ((hash >> STROBE2_OFFSET_BITS) & 0x3) as u8;
-        self.randstrobes[position].canonicity_bits() == query_canonicity
+    pub fn query_canonicity(&self, hash: RandstrobeHash) -> u8 {
+        ((hash >> STROBE2_OFFSET_BITS) & 0x3) as u8
     }
 
-    pub fn canonicity_matches_partial(&self, hash: RandstrobeHash, position: usize) -> bool {
-        let query_canonicity = ((hash >> STROBE2_OFFSET_BITS) & 0x2) as u8;
-        self.randstrobes[position].canonicity_bit() == query_canonicity
+    pub fn query_canonicity_partial(&self, hash: RandstrobeHash) -> u8 {
+        ((hash >> STROBE2_OFFSET_BITS) & 0x2) as u8
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -466,7 +466,6 @@ impl<'a> StrobemerIndex<'a> {
     }
 
     /// Search for the canonical hash within the range [start, start + count).
-    /// Returns the position of the first match, or None.
     pub fn find_canonical(
         &self,
         hash: RandstrobeHash,

--- a/src/index.rs
+++ b/src/index.rs
@@ -922,17 +922,37 @@ mod tests {
     }
 
     #[test]
-    fn test_orientation() {
-        let hash_both: u64 = (0xABCD_u64 << 10) | (0b11 << STROBE2_OFFSET_BITS);
-        let ref_randstrobe = RefRandstrobe::new(hash_both, 0, 100, 5);
-        assert_eq!(ref_randstrobe.strobe2_offset(), 5);
-        assert_eq!(
-            ref_randstrobe.hash(),
-            (0xABCD_u64 << 10) | (0b11 << STROBE2_OFFSET_BITS)
-        );
+    fn test_partial_orientation() {
+        let references = read_ref("tests/phix.fasta");
+        let seq = &references[0].sequence;
+        let rc_seq = reverse_complement(seq);
+        let rc_references = vec![RefSequence {
+            name: "phix_rc".to_string(),
+            sequence: rc_seq,
+        }];
 
-        let hash_none: u64 = (0xABCD_u64 << 10) | (0b00 << STROBE2_OFFSET_BITS);
-        let ref_randstrobe2 = RefRandstrobe::new(hash_none, 0, 100, 5);
-        assert_eq!(ref_randstrobe2.hash(), 0xABCD_u64 << 10);
+        let parameters = SeedingParameters::new(300);
+
+        let mut fwd_index = StrobemerIndex::new(&references, parameters.clone(), None);
+        fwd_index.populate(0.0000001, 1);
+
+        let mut rc_index = StrobemerIndex::new(&rc_references, parameters.clone(), None);
+        rc_index.populate(0.0000001, 1);
+
+        assert_eq!(fwd_index.randstrobes.len(), rc_index.randstrobes.len());
+
+        // Iterate over fwd index entries and look up each hash in the rc index
+        for i in 0..fwd_index.randstrobes.len() {
+            let fwd_hash = fwd_index.randstrobes[i].hash();
+
+            let rev_pos_result = rc_index.get_partial(fwd_hash);
+            assert!(rev_pos_result.is_some());
+            let rev_pos = rev_pos_result.unwrap();
+
+            let rc_partial_query = fwd_index.randstrobes[i].hash()
+                ^ ((1 as u64) << rc_index.parameters.randstrobe.partial_orientation_pos);
+            let rev_pos_forward = rc_index.get_partial_forward_from(rc_partial_query, rev_pos);
+            assert!(rev_pos_forward.is_some());
+        }
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -465,10 +465,6 @@ impl<'a> StrobemerIndex<'a> {
         self.get_masked(hash, REF_RANDSTROBE_HASH_MASK)
     }
 
-    pub fn get_full_with_canonicity(&self, hash: RandstrobeHash) -> Option<usize> {
-        self.get_masked(hash, CANONICAL_HASH_MASK)
-    }
-
     /// Single lookup returning both the ref-masked position and the
     /// canonical-masked position.
     pub fn get_full_and_canonical(

--- a/src/index.rs
+++ b/src/index.rs
@@ -99,8 +99,8 @@ pub struct RefRandstrobe {
     ref_index: u32,
 }
 
-pub const REF_RANDSTROBE_HASH_MASK: u64 = 0xFFFFFFFFFFFFFC00;
-pub const CANONICAL_HASH_MASK: u64 = 0xFFFFFFFFFFFFFF00;
+pub const UNDIRECTED_HASH_MASK: u64 = 0xFFFFFFFFFFFFFC00;
+pub const DIRECTED_HASH_MASK: u64 = 0xFFFFFFFFFFFFFF00;
 pub const STROBE2_OFFSET_BITS: u32 = 8;
 pub const STROBE2_OFFSET_MASK: u64 = (1u64 << STROBE2_OFFSET_BITS) - 1;
 pub const REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES: usize = u32::MAX as usize;
@@ -116,11 +116,11 @@ impl RefRandstrobe {
     }
 
     pub fn hash(&self) -> RandstrobeHash {
-        self.hash_offset & REF_RANDSTROBE_HASH_MASK
+        self.hash_offset & UNDIRECTED_HASH_MASK
     }
 
-    pub fn canonical_hash(&self) -> RandstrobeHash {
-        self.hash_offset & CANONICAL_HASH_MASK
+    pub fn directed_hash(&self) -> RandstrobeHash {
+        self.hash_offset & DIRECTED_HASH_MASK
     }
 
     pub fn position(&self) -> usize {
@@ -135,11 +135,11 @@ impl RefRandstrobe {
         (self.hash_offset & STROBE2_OFFSET_MASK) as usize
     }
 
-    pub fn canonicity_bits(&self) -> u8 {
+    pub fn orientation_full(&self) -> u8 {
         ((self.hash_offset >> STROBE2_OFFSET_BITS) & 0x3) as u8
     }
 
-    pub fn canonicity_bit(&self) -> u8 {
+    pub fn orientation_partial(&self) -> u8 {
         ((self.hash_offset >> STROBE2_OFFSET_BITS) & 0x2) as u8
     }
 }
@@ -462,26 +462,26 @@ impl<'a> StrobemerIndex<'a> {
     }
 
     pub fn get_full(&self, hash: RandstrobeHash) -> Option<usize> {
-        self.get_masked(hash, REF_RANDSTROBE_HASH_MASK)
+        self.get_masked(hash, UNDIRECTED_HASH_MASK)
     }
 
-    /// Search for the canonical hash within the range [start, start + count).
-    pub fn find_canonical(
+    /// Search for the directed hash within the range [start, start + count).
+    pub fn get_full_directed(
         &self,
         hash: RandstrobeHash,
         start: usize,
         count: Option<usize>,
     ) -> Option<usize> {
         let count = count.unwrap_or_else(|| self.get_count_full_forward(start));
-        let canon_masked = hash & CANONICAL_HASH_MASK;
+        let directed_masked = hash & DIRECTED_HASH_MASK;
         const MAX_LINEAR_SEARCH: usize = 4;
         let bucket = &self.randstrobes[start..start + count];
         if bucket.len() < MAX_LINEAR_SEARCH {
             for (i, rs) in bucket.iter().enumerate() {
-                if rs.hash_offset & CANONICAL_HASH_MASK == canon_masked {
+                if rs.hash_offset & DIRECTED_HASH_MASK == directed_masked {
                     return Some(start + i);
                 }
-                if rs.hash_offset & CANONICAL_HASH_MASK > canon_masked {
+                if rs.hash_offset & DIRECTED_HASH_MASK > directed_masked {
                     return None;
                 }
             }
@@ -489,9 +489,9 @@ impl<'a> StrobemerIndex<'a> {
         }
 
         let pos = custom_partition_point(bucket, |h| {
-            h.hash_offset & CANONICAL_HASH_MASK < canon_masked
+            h.hash_offset & DIRECTED_HASH_MASK < directed_masked
         });
-        if pos < bucket.len() && bucket[pos].hash_offset & CANONICAL_HASH_MASK == canon_masked {
+        if pos < bucket.len() && bucket[pos].hash_offset & DIRECTED_HASH_MASK == directed_masked {
             Some(start + pos)
         } else {
             None
@@ -554,7 +554,11 @@ impl<'a> StrobemerIndex<'a> {
     }
 
     /// Returns forward count with the full count for later use
-    pub fn get_count_full_with_forward(&self, position: usize, hash_revcomp: u64) -> (usize, usize) {
+    pub fn get_count_full_with_forward(
+        &self,
+        position: usize,
+        hash_revcomp: u64,
+    ) -> (usize, usize) {
         let forward_count = self.get_count_full_forward(position);
         let reverse_count = if let Some(position_revcomp) = self.get_full(hash_revcomp) {
             self.get_count_full_forward(position_revcomp)
@@ -565,7 +569,7 @@ impl<'a> StrobemerIndex<'a> {
     }
 
     pub fn get_count_full_forward(&self, position: usize) -> usize {
-        self.get_count(position, REF_RANDSTROBE_HASH_MASK)
+        self.get_count(position, UNDIRECTED_HASH_MASK)
     }
 
     pub fn get_count_partial(&self, position: usize) -> usize {
@@ -645,16 +649,16 @@ impl<'a> StrobemerIndex<'a> {
         self.is_too_frequent_forward_partial(position, cutoff)
     }
 
-    //Applies canonicity to unoriented hash
-    pub fn apply_canonicity(hash: RandstrobeHash, query_canonicity: u8) -> u64 {
-        (hash & REF_RANDSTROBE_HASH_MASK) ^ ((query_canonicity as u64) << 8)
+    //Applies orientation to undirected hash
+    pub fn apply_orientation(hash: RandstrobeHash, query_orientation: u8) -> u64 {
+        (hash & UNDIRECTED_HASH_MASK) ^ ((query_orientation as u64) << STROBE2_OFFSET_BITS)
     }
 
-    pub fn query_canonicity(hash: RandstrobeHash) -> u8 {
+    pub fn query_orientation(hash: RandstrobeHash) -> u8 {
         ((hash >> STROBE2_OFFSET_BITS) & 0x3) as u8
     }
 
-    pub fn query_canonicity_partial(hash: RandstrobeHash) -> u8 {
+    pub fn query_orientation_partial(hash: RandstrobeHash) -> u8 {
         ((hash >> STROBE2_OFFSET_BITS) & 0x2) as u8
     }
 }
@@ -854,7 +858,7 @@ mod tests {
 
     #[test]
     fn test_ref_randstrobe() {
-        let hash: u64 = 0x1234567890ABCDEFu64 & REF_RANDSTROBE_HASH_MASK;
+        let hash: u64 = 0x1234567890ABCDEFu64 & UNDIRECTED_HASH_MASK;
         let ref_index: u32 = (REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES - 1) as u32;
         let offset = 255;
         let position = !0;
@@ -864,7 +868,7 @@ mod tests {
         assert_eq!(rr.position(), position as usize);
         assert_eq!(rr.reference_index(), ref_index as usize);
         assert_eq!(rr.strobe2_offset(), offset as usize);
-        assert_eq!(rr.canonicity_bits(), 0);
+        assert_eq!(rr.orientation_full(), 0);
     }
 
     fn syncmers_of(seq: &[u8], parameters: &SyncmerParameters) -> Vec<Syncmer> {
@@ -959,15 +963,15 @@ mod tests {
     }
 
     #[test]
-    fn test_canonicity_bits() {
+    fn test_orientation() {
         let hash_both: u64 = (0xABCD_u64 << 10) | (0b11 << STROBE2_OFFSET_BITS);
         let ref_randstrobe = RefRandstrobe::new(hash_both, 0, 100, 5);
-        assert_eq!(ref_randstrobe.canonicity_bits(), 0b11);
+        assert_eq!(ref_randstrobe.orientation_full(), 0b11);
         assert_eq!(ref_randstrobe.strobe2_offset(), 5);
         assert_eq!(ref_randstrobe.hash(), 0xABCD_u64 << 10);
 
         let hash_none: u64 = (0xABCD_u64 << 10) | (0b00 << STROBE2_OFFSET_BITS);
         let ref_randstrobe2 = RefRandstrobe::new(hash_none, 0, 100, 5);
-        assert_eq!(ref_randstrobe2.canonicity_bits(), 0b00);
+        assert_eq!(ref_randstrobe2.orientation_full(), 0b00);
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -99,12 +99,14 @@ pub struct RefRandstrobe {
     ref_index: u32,
 }
 
-pub const REF_RANDSTROBE_HASH_MASK: u64 = 0xFFFFFFFFFFFFFF00;
+pub const REF_RANDSTROBE_HASH_MASK: u64 = 0xFFFFFFFFFFFFFC00;
+pub const STROBE2_OFFSET_BITS: u32 = 8;
+pub const STROBE2_OFFSET_MASK: u64 = (1u64 << STROBE2_OFFSET_BITS) - 1;
 pub const REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES: usize = u32::MAX as usize;
 
 impl RefRandstrobe {
     fn new(hash: RandstrobeHash, ref_index: u32, position: u32, offset: u8) -> Self {
-        let hash_offset = (hash & REF_RANDSTROBE_HASH_MASK) | (offset as u64);
+        let hash_offset = (hash & !STROBE2_OFFSET_MASK) | (offset as u64);
         RefRandstrobe {
             hash_offset,
             position,
@@ -125,7 +127,15 @@ impl RefRandstrobe {
     }
 
     pub fn strobe2_offset(&self) -> usize {
-        (self.hash_offset & 0xff) as usize
+        (self.hash_offset & STROBE2_OFFSET_MASK) as usize
+    }
+
+    pub fn canonicity_bits(&self) -> u8 {
+        ((self.hash_offset >> STROBE2_OFFSET_BITS) & 0x3) as u8
+    }
+
+    pub fn canonicity_matches(&self, query_hash: u64) -> bool {
+        ((query_hash >> STROBE2_OFFSET_BITS) & 0x3) as u8 == self.canonicity_bits()
     }
 }
 
@@ -583,7 +593,7 @@ impl<'a> StrobemerIndex<'a> {
     }
 }
 
-const STI_FILE_FORMAT_VERSION: u32 = 6;
+const STI_FILE_FORMAT_VERSION: u32 = 7;
 
 #[derive(Error, Debug)]
 pub enum IndexReadingError {
@@ -788,6 +798,7 @@ mod tests {
         assert_eq!(rr.position(), position as usize);
         assert_eq!(rr.reference_index(), ref_index as usize);
         assert_eq!(rr.strobe2_offset(), offset as usize);
+        assert_eq!(rr.canonicity_bits(), 0);
     }
 
     fn syncmers_of(seq: &[u8], parameters: &SyncmerParameters) -> Vec<Syncmer> {
@@ -812,7 +823,12 @@ mod tests {
             for syncmer_rev in &mut syncmers_reverse {
                 syncmer_rev.position = seq.len() - parameters.k - syncmer_rev.position;
             }
-            assert_eq!(syncmers_forward, syncmers_reverse);
+            assert_eq!(syncmers_forward.len(), syncmers_reverse.len());
+            for (sf, sr) in syncmers_forward.iter().zip(syncmers_reverse.iter()) {
+                assert_eq!(sf.hash, sr.hash);
+                assert_eq!(sf.position, sr.position);
+                assert_ne!(sf.is_canonical, sr.is_canonical);
+            }
         }
     }
 
@@ -874,5 +890,20 @@ mod tests {
                 panic!("Parameters are expected not to match");
             }
         }
+    }
+
+    #[test]
+    fn test_canonicity_bits() {
+        let hash_both: u64 = (0xABCD_u64 << 10) | (0b11 << STROBE2_OFFSET_BITS);
+        let ref_randstrobe = RefRandstrobe::new(hash_both, 0, 100, 5);
+        assert_eq!(ref_randstrobe.canonicity_bits(), 0b11);
+        assert_eq!(ref_randstrobe.strobe2_offset(), 5);
+        assert_eq!(ref_randstrobe.hash(), 0xABCD_u64 << 10);
+        assert!(ref_randstrobe.canonicity_matches(hash_both));
+
+        let hash_none: u64 = (0xABCD_u64 << 10) | (0b00 << STROBE2_OFFSET_BITS);
+        let ref_randstrobe2 = RefRandstrobe::new(hash_none, 0, 100, 5);
+        assert_eq!(ref_randstrobe2.canonicity_bits(), 0b00);
+        assert!(!ref_randstrobe2.canonicity_matches(hash_both));
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -467,7 +467,12 @@ impl<'a> StrobemerIndex<'a> {
 
     /// Search for the canonical hash within the range [start, start + count).
     /// Returns the position of the first match, or None.
-    pub fn find_canonical(&self, hash: RandstrobeHash, start: usize, count: usize) -> Option<usize> {
+    pub fn find_canonical(
+        &self,
+        hash: RandstrobeHash,
+        start: usize,
+        count: usize,
+    ) -> Option<usize> {
         let canon_masked = hash & CANONICAL_HASH_MASK;
         const MAX_LINEAR_SEARCH: usize = 4;
         let bucket = &self.randstrobes[start..start + count];
@@ -483,7 +488,9 @@ impl<'a> StrobemerIndex<'a> {
             return None;
         }
 
-        let pos = custom_partition_point(bucket, |h| h.hash_offset & CANONICAL_HASH_MASK < canon_masked);
+        let pos = custom_partition_point(bucket, |h| {
+            h.hash_offset & CANONICAL_HASH_MASK < canon_masked
+        });
         if pos < bucket.len() && bucket[pos].hash_offset & CANONICAL_HASH_MASK == canon_masked {
             Some(start + pos)
         } else {
@@ -593,7 +600,8 @@ impl<'a> StrobemerIndex<'a> {
     }
 
     pub fn is_too_frequent(&self, position: usize, cutoff: usize, hash_revcomp: u64) -> bool {
-        self.is_too_frequent_with_forward_count(position, cutoff, hash_revcomp).0
+        self.is_too_frequent_with_forward_count(position, cutoff, hash_revcomp)
+            .0
     }
 
     /// Returns (is_filtered, forward_count) so the caller can reuse the

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -782,10 +782,14 @@ fn extend_paired_seeds(
         let mut n_max1 = nams[0][0].clone();
         let mut n_max2 = nams[1][0].clone();
 
-        let consistent_nam1 = reverse_nam_if_needed(&mut n_max1, read1, references, k);
+        let consistent_nam1 = n_max1.is_consistent(read1, references, k);
         details[0].inconsistent_nams += !consistent_nam1 as usize;
-        let consistent_nam2 = reverse_nam_if_needed(&mut n_max2, read2, references, k);
+        let consistent_nam2 = n_max2.is_consistent(read2, references, k);
         details[1].inconsistent_nams += !consistent_nam2 as usize;
+        // let consistent_nam1 = reverse_nam_if_needed(&mut n_max1, read1, references, k);
+        // details[0].inconsistent_nams += !consistent_nam1 as usize;
+        // let consistent_nam2 = reverse_nam_if_needed(&mut n_max2, read2, references, k);
+        // details[1].inconsistent_nams += !consistent_nam2 as usize;
 
         let alignment1 = extend_seed(
             aligner,

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -786,10 +786,6 @@ fn extend_paired_seeds(
         details[0].inconsistent_nams += !consistent_nam1 as usize;
         let consistent_nam2 = n_max2.is_consistent(read2, references, k);
         details[1].inconsistent_nams += !consistent_nam2 as usize;
-        // let consistent_nam1 = reverse_nam_if_needed(&mut n_max1, read1, references, k);
-        // details[0].inconsistent_nams += !consistent_nam1 as usize;
-        // let consistent_nam2 = reverse_nam_if_needed(&mut n_max2, read2, references, k);
-        // details[1].inconsistent_nams += !consistent_nam2 as usize;
 
         let alignment1 = extend_seed(
             aligner,

--- a/src/nam.rs
+++ b/src/nam.rs
@@ -163,9 +163,6 @@ pub fn get_nams_by_chaining(
         for nam in &nams {
             if nam.n_matches > 1 || printed < 10 {
                 trace!("- {}", nam);
-                for anchor in &nam.anchors {
-                    trace!("    {:?}", anchor);
-                }
                 printed += 1;
             }
         }

--- a/src/nam.rs
+++ b/src/nam.rs
@@ -163,6 +163,9 @@ pub fn get_nams_by_chaining(
         for nam in &nams {
             if nam.n_matches > 1 || printed < 10 {
                 trace!("- {}", nam);
+                for anchor in &nam.anchors {
+                    trace!("    {:?}", anchor);
+                }
                 printed += 1;
             }
         }

--- a/src/seeding/mod.rs
+++ b/src/seeding/mod.rs
@@ -53,7 +53,7 @@ pub fn randstrobes_query(seq: &[u8], parameters: &SeedingParameters) -> [Vec<Que
     syncmers.reverse();
     for i in 0..syncmers.len() {
         syncmers[i].position = seq.len() - syncmers[i].position - parameters.syncmer.k;
-        syncmers[i].toggle_canonical();
+        syncmers[i].toggle_orientation();
     }
 
     // Randstrobes cannot be re-used for the reverse complement:

--- a/src/seeding/mod.rs
+++ b/src/seeding/mod.rs
@@ -53,7 +53,7 @@ pub fn randstrobes_query(seq: &[u8], parameters: &SeedingParameters) -> [Vec<Que
     syncmers.reverse();
     for i in 0..syncmers.len() {
         syncmers[i].position = seq.len() - syncmers[i].position - parameters.syncmer.k;
-        syncmers[i].is_canonical = !syncmers[i].is_canonical;
+        syncmers[i].toggle_canonical();
     }
 
     // Randstrobes cannot be re-used for the reverse complement:

--- a/src/seeding/mod.rs
+++ b/src/seeding/mod.rs
@@ -53,6 +53,7 @@ pub fn randstrobes_query(seq: &[u8], parameters: &SeedingParameters) -> [Vec<Que
     syncmers.reverse();
     for i in 0..syncmers.len() {
         syncmers[i].position = seq.len() - syncmers[i].position - parameters.syncmer.k;
+        syncmers[i].is_canonical = !syncmers[i].is_canonical;
     }
 
     // Randstrobes cannot be re-used for the reverse complement:

--- a/src/seeding/parameters.rs
+++ b/src/seeding/parameters.rs
@@ -291,7 +291,7 @@ impl SeedingParameters {
                 "aux length must be less than 64",
             ));
         }
-        self.randstrobe.main_hash_mask = !0u64 << (9 + aux_len);
+        self.randstrobe.main_hash_mask = !0u64 << (10 + aux_len);
 
         Ok(self)
     }
@@ -341,7 +341,7 @@ mod test {
         let w_max = 16;
         let max_dist = 180;
         let q = 255;
-        let main_hash_mask = 0xfffffffffc000000;
+        let main_hash_mask = 0xfffffffff8000000;
         let aux_len = 17;
         let sp = SyncmerParameters::try_new(k, s).unwrap();
         let rp = RandstrobeParameters {

--- a/src/seeding/parameters.rs
+++ b/src/seeding/parameters.rs
@@ -291,7 +291,7 @@ impl SeedingParameters {
                 "aux length must be less than 64",
             ));
         }
-        self.randstrobe.main_hash_mask = !0u64 << (10 + aux_len);
+        self.randstrobe.main_hash_mask = !0u64 << (9 + aux_len);
 
         Ok(self)
     }
@@ -341,15 +341,18 @@ mod test {
         let w_max = 16;
         let max_dist = 180;
         let q = 255;
-        let main_hash_mask = 0xfffffffff8000000;
+        let main_hash_mask: u64 = 0xfffffffffc000000;
         let aux_len = 17;
         let sp = SyncmerParameters::try_new(k, s).unwrap();
+        let partial_orientation_pos = main_hash_mask.trailing_zeros() - 1;
         let rp = RandstrobeParameters {
             w_min,
             w_max,
             q,
             max_dist,
             main_hash_mask,
+            forward_main_hash_mask: main_hash_mask | (1u64 << partial_orientation_pos),
+            partial_orientation_pos,
         };
         let seeding_parameters = SeedingParameters::new(250)
             .with_k_s(Some(k), Some(s))

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -81,12 +81,8 @@ impl Randstrobe {
         let is_forward1 = strobe1.is_forward() as u64;
         let is_forward2 = strobe2.is_forward() as u64;
         Randstrobe {
-            hash: Randstrobe::hash(strobe1.hash(), strobe2.hash(), parameters)
-                ^ (is_forward1 << parameters.partial_orientation_pos)
-                ^ (is_forward2 << STROBE2_OFFSET_BITS),
-            hash_revcomp: Randstrobe::hash(strobe2.hash(), strobe1.hash(), parameters)
-                ^ ((is_forward2 ^ 1) << parameters.partial_orientation_pos)
-                ^ ((is_forward1 ^ 1) << STROBE2_OFFSET_BITS),
+            hash: Randstrobe::hash(strobe1.hash(), strobe2.hash(), is_forward1, is_forward2, parameters),
+            hash_revcomp: Randstrobe::hash(strobe2.hash(), strobe1.hash(), is_forward1 ^ 1, is_forward2  ^ 1, parameters),
             strobe1_pos: strobe1.position,
             strobe2_pos: strobe2.position,
         }
@@ -101,8 +97,17 @@ impl Randstrobe {
     /// hash. Since entries in the index are sorted by randstrobe hash, this allows
     /// us to search for the main syncmer by masking out the lower bits.
     /// The orientation bit position (between main and aux) is left as zero.
-    pub fn hash(hash1: u64, hash2: u64, parameters: &RandstrobeParameters) -> u64 {
-        ((hash1 & parameters.main_hash_mask) ^ (hash2 & !parameters.forward_main_hash_mask))
+    pub fn hash(
+        hash1: u64,
+        hash2: u64,
+        is_forward1: u64,
+        is_forward2: u64,
+        parameters: &RandstrobeParameters,
+    ) -> u64 {
+        ((hash1 & parameters.main_hash_mask)
+            | (hash2 & !parameters.forward_main_hash_mask)
+            | (is_forward1 << parameters.partial_orientation_pos)
+            | (is_forward2 << STROBE2_OFFSET_BITS))
             & (REF_RANDSTROBE_HASH_MASK << 1)
     }
 }

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -122,6 +122,7 @@ impl<SI: Iterator<Item = Syncmer>> Iterator for RandstrobeIterator<SI> {
             return None;
         }
         let strobe1 = self.syncmers[0];
+        let strobe1_hash = strobe1.hash();
         let max_position = strobe1.position + self.parameters.max_dist as usize;
         let mut min_val = u64::MAX;
         let mut strobe2 = self.syncmers[0]; // Defaults if no nearby syncmer
@@ -131,7 +132,7 @@ impl<SI: Iterator<Item = Syncmer>> Iterator for RandstrobeIterator<SI> {
             if self.syncmers[i].position > max_position {
                 break;
             }
-            let b = (strobe1.hash() ^ self.syncmers[i].hash()) & self.parameters.q;
+            let b = (strobe1_hash ^ self.syncmers[i].hash()) & self.parameters.q;
             let ones = b.count_ones() as u64;
             if ones < min_val {
                 min_val = ones;

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use super::{InvalidSeedingParameter, Syncmer};
-use crate::index::{STROBE2_OFFSET_BITS, UNDIRECTED_HASH_MASK};
+use crate::index::{REF_RANDSTROBE_HASH_MASK, STROBE2_OFFSET_BITS};
 
 pub const DEFAULT_AUX_LEN: u8 = 17;
 
@@ -14,6 +14,12 @@ pub struct RandstrobeParameters {
 
     /// Mask for bits of the hash that represent the main hash
     pub main_hash_mask: u64,
+
+    /// Mask for the main hash including its orientation bit
+    pub forward_main_hash_mask: u64,
+
+    /// Bit position of the partial orientation bit
+    pub partial_orientation_pos: u32,
 }
 
 impl RandstrobeParameters {
@@ -24,12 +30,15 @@ impl RandstrobeParameters {
         max_dist: u8,
         main_hash_mask: u64,
     ) -> Result<Self, InvalidSeedingParameter> {
+        let partial_orientation_pos = main_hash_mask.trailing_zeros() - 1;
         RandstrobeParameters {
             w_min,
             w_max,
             q,
             max_dist,
             main_hash_mask,
+            forward_main_hash_mask: main_hash_mask | (1u64 << partial_orientation_pos),
+            partial_orientation_pos,
         }
         .with_window(Some(w_min), Some(w_max))
     }
@@ -64,16 +73,20 @@ pub struct Randstrobe {
 }
 
 impl Randstrobe {
-    pub fn from_strobes(strobe1: Syncmer, strobe2: Syncmer, main_hash_mask: u64) -> Self {
+    pub fn from_strobes(
+        strobe1: Syncmer,
+        strobe2: Syncmer,
+        parameters: &RandstrobeParameters,
+    ) -> Self {
         let canonical1 = strobe1.is_canonical() as u64;
         let canonical2 = strobe2.is_canonical() as u64;
         Randstrobe {
-            hash: Randstrobe::hash(strobe1.hash(), strobe2.hash(), main_hash_mask)
-                | (canonical1 << (STROBE2_OFFSET_BITS + 1))
-                | (canonical2 << STROBE2_OFFSET_BITS),
-            hash_revcomp: Randstrobe::hash(strobe2.hash(), strobe1.hash(), main_hash_mask)
-                | ((canonical2 ^ 1) << (STROBE2_OFFSET_BITS + 1))
-                | ((canonical1 ^ 1) << STROBE2_OFFSET_BITS),
+            hash: Randstrobe::hash(strobe1.hash(), strobe2.hash(), parameters)
+                ^ (canonical1 << parameters.partial_orientation_pos)
+                ^ (canonical2 << STROBE2_OFFSET_BITS),
+            hash_revcomp: Randstrobe::hash(strobe2.hash(), strobe1.hash(), parameters)
+                ^ ((canonical2 ^ 1) << parameters.partial_orientation_pos)
+                ^ ((canonical1 ^ 1) << STROBE2_OFFSET_BITS),
             strobe1_pos: strobe1.position,
             strobe2_pos: strobe2.position,
         }
@@ -87,8 +100,10 @@ impl Randstrobe {
     /// the main hash and the bottom bits to the bits of the auxiliary
     /// hash. Since entries in the index are sorted by randstrobe hash, this allows
     /// us to search for the main syncmer by masking out the lower bits.
-    pub fn hash(hash1: u64, hash2: u64, main_hash_mask: u64) -> u64 {
-        ((hash1 & main_hash_mask) | (hash2 & !main_hash_mask)) & UNDIRECTED_HASH_MASK
+    /// The orientation bit position (between main and aux) is left as zero.
+    pub fn hash(hash1: u64, hash2: u64, parameters: &RandstrobeParameters) -> u64 {
+        ((hash1 & parameters.main_hash_mask) ^ (hash2 & !parameters.forward_main_hash_mask))
+            & (REF_RANDSTROBE_HASH_MASK << 1)
     }
 }
 
@@ -141,11 +156,7 @@ impl<SI: Iterator<Item = Syncmer>> Iterator for RandstrobeIterator<SI> {
         }
         self.syncmers.pop_front();
 
-        Some(Randstrobe::from_strobes(
-            strobe1,
-            strobe2,
-            self.parameters.main_hash_mask,
-        ))
+        Some(Randstrobe::from_strobes(strobe1, strobe2, &self.parameters))
     }
 }
 

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -65,15 +65,15 @@ pub struct Randstrobe {
 
 impl Randstrobe {
     pub fn from_strobes(strobe1: Syncmer, strobe2: Syncmer, main_hash_mask: u64) -> Self {
-        let canonical1 = strobe1.is_canonical as u64;
-        let canonical2 = strobe2.is_canonical as u64;
+        let canonical1 = strobe1.is_canonical() as u64;
+        let canonical2 = strobe2.is_canonical() as u64;
         Randstrobe {
-            hash: Randstrobe::hash(strobe1.hash, strobe2.hash, main_hash_mask)
+            hash: Randstrobe::hash(strobe1.hash(), strobe2.hash(), main_hash_mask)
                 | (canonical1 << (STROBE2_OFFSET_BITS + 1))
                 | (canonical2 << STROBE2_OFFSET_BITS),
-            hash_revcomp: Randstrobe::hash(strobe2.hash, strobe1.hash, main_hash_mask)
-                | ((1 - canonical2) << (STROBE2_OFFSET_BITS + 1))
-                | ((1 - canonical1) << STROBE2_OFFSET_BITS),
+            hash_revcomp: Randstrobe::hash(strobe2.hash(), strobe1.hash(), main_hash_mask)
+                | ((canonical2 ^ 1) << (STROBE2_OFFSET_BITS + 1))
+                | ((canonical1 ^ 1) << STROBE2_OFFSET_BITS),
             strobe1_pos: strobe1.position,
             strobe2_pos: strobe2.position,
         }
@@ -131,7 +131,7 @@ impl<SI: Iterator<Item = Syncmer>> Iterator for RandstrobeIterator<SI> {
             if self.syncmers[i].position > max_position {
                 break;
             }
-            let b = (strobe1.hash ^ self.syncmers[i].hash) & self.parameters.q;
+            let b = (strobe1.hash() ^ self.syncmers[i].hash()) & self.parameters.q;
             let ones = b.count_ones() as u64;
             if ones < min_val {
                 min_val = ones;

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -78,15 +78,15 @@ impl Randstrobe {
         strobe2: Syncmer,
         parameters: &RandstrobeParameters,
     ) -> Self {
-        let canonical1 = strobe1.is_canonical() as u64;
-        let canonical2 = strobe2.is_canonical() as u64;
+        let is_forward1 = strobe1.is_forward() as u64;
+        let is_forward2 = strobe2.is_forward() as u64;
         Randstrobe {
             hash: Randstrobe::hash(strobe1.hash(), strobe2.hash(), parameters)
-                ^ (canonical1 << parameters.partial_orientation_pos)
-                ^ (canonical2 << STROBE2_OFFSET_BITS),
+                ^ (is_forward1 << parameters.partial_orientation_pos)
+                ^ (is_forward2 << STROBE2_OFFSET_BITS),
             hash_revcomp: Randstrobe::hash(strobe2.hash(), strobe1.hash(), parameters)
-                ^ ((canonical2 ^ 1) << parameters.partial_orientation_pos)
-                ^ ((canonical1 ^ 1) << STROBE2_OFFSET_BITS),
+                ^ ((is_forward2 ^ 1) << parameters.partial_orientation_pos)
+                ^ ((is_forward1 ^ 1) << STROBE2_OFFSET_BITS),
             strobe1_pos: strobe1.position,
             strobe2_pos: strobe2.position,
         }

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -81,8 +81,20 @@ impl Randstrobe {
         let is_forward1 = strobe1.is_forward() as u64;
         let is_forward2 = strobe2.is_forward() as u64;
         Randstrobe {
-            hash: Randstrobe::hash(strobe1.hash(), strobe2.hash(), is_forward1, is_forward2, parameters),
-            hash_revcomp: Randstrobe::hash(strobe2.hash(), strobe1.hash(), is_forward1 ^ 1, is_forward2  ^ 1, parameters),
+            hash: Randstrobe::hash(
+                strobe1.hash(),
+                strobe2.hash(),
+                is_forward1,
+                is_forward2,
+                parameters,
+            ),
+            hash_revcomp: Randstrobe::hash(
+                strobe2.hash(),
+                strobe1.hash(),
+                is_forward1 ^ 1,
+                is_forward2 ^ 1,
+                parameters,
+            ),
             strobe1_pos: strobe1.position,
             strobe2_pos: strobe2.position,
         }

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use super::{InvalidSeedingParameter, Syncmer};
-use crate::index::{REF_RANDSTROBE_HASH_MASK, STROBE2_OFFSET_BITS};
+use crate::index::{STROBE2_OFFSET_BITS, UNDIRECTED_HASH_MASK};
 
 pub const DEFAULT_AUX_LEN: u8 = 17;
 
@@ -88,7 +88,7 @@ impl Randstrobe {
     /// hash. Since entries in the index are sorted by randstrobe hash, this allows
     /// us to search for the main syncmer by masking out the lower bits.
     pub fn hash(hash1: u64, hash2: u64, main_hash_mask: u64) -> u64 {
-        ((hash1 & main_hash_mask) | (hash2 & !main_hash_mask)) & REF_RANDSTROBE_HASH_MASK
+        ((hash1 & main_hash_mask) | (hash2 & !main_hash_mask)) & UNDIRECTED_HASH_MASK
     }
 }
 

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use super::{InvalidSeedingParameter, Syncmer};
-use crate::index::REF_RANDSTROBE_HASH_MASK;
+use crate::index::{REF_RANDSTROBE_HASH_MASK, STROBE2_OFFSET_BITS};
 
 pub const DEFAULT_AUX_LEN: u8 = 17;
 
@@ -65,9 +65,15 @@ pub struct Randstrobe {
 
 impl Randstrobe {
     pub fn from_strobes(strobe1: Syncmer, strobe2: Syncmer, main_hash_mask: u64) -> Self {
+        let canonical1 = strobe1.is_canonical as u64;
+        let canonical2 = strobe2.is_canonical as u64;
         Randstrobe {
-            hash: Randstrobe::hash(strobe1.hash, strobe2.hash, main_hash_mask),
-            hash_revcomp: Randstrobe::hash(strobe2.hash, strobe1.hash, main_hash_mask),
+            hash: Randstrobe::hash(strobe1.hash, strobe2.hash, main_hash_mask)
+                | (canonical1 << (STROBE2_OFFSET_BITS + 1))
+                | (canonical2 << STROBE2_OFFSET_BITS),
+            hash_revcomp: Randstrobe::hash(strobe2.hash, strobe1.hash, main_hash_mask)
+                | ((1 - canonical2) << (STROBE2_OFFSET_BITS + 1))
+                | ((1 - canonical1) << STROBE2_OFFSET_BITS),
             strobe1_pos: strobe1.position,
             strobe2_pos: strobe2.position,
         }

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -137,7 +137,6 @@ impl<SI: Iterator<Item = Syncmer>> Iterator for RandstrobeIterator<SI> {
             return None;
         }
         let strobe1 = self.syncmers[0];
-        let strobe1_hash = strobe1.hash();
         let max_position = strobe1.position + self.parameters.max_dist as usize;
         let mut min_val = u64::MAX;
         let mut strobe2 = self.syncmers[0]; // Defaults if no nearby syncmer
@@ -147,7 +146,7 @@ impl<SI: Iterator<Item = Syncmer>> Iterator for RandstrobeIterator<SI> {
             if self.syncmers[i].position > max_position {
                 break;
             }
-            let b = (strobe1_hash ^ self.syncmers[i].hash()) & self.parameters.q;
+            let b = (strobe1.hash() ^ self.syncmers[i].hash()) & self.parameters.q;
             let ones = b.count_ones() as u64;
             if ones < min_val {
                 min_val = ones;

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -253,6 +253,7 @@ mod test {
             syncmers_reverse.reverse();
             for syncmer in &mut syncmers_reverse {
                 syncmer.position = s.len() - parameters.k - syncmer.position;
+                syncmer.toggle_canonical();
             }
 
             assert_eq!(syncmers_forward, syncmers_reverse);

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -8,6 +8,7 @@ use super::hash::xxh64;
 pub struct Syncmer {
     pub hash: u64,
     pub position: usize,
+    pub is_canonical: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -163,10 +164,12 @@ impl Iterator for SyncmerIterator<'_> {
                 }
                 if self.qs[self.t - 1] == self.qs_min_val {
                     // occurs at t:th position in k-mer
-                    let yk = min(self.xk[0], self.xk[1]);
+                    let is_canonical = self.xk[0] <= self.xk[1];
+                    let yk = if is_canonical { self.xk[0] } else { self.xk[1] };
                     let syncmer = Syncmer {
                         hash: syncmer_kmer_hash(yk),
                         position: i + 1 - self.k,
+                        is_canonical,
                     };
                     self.i = i + 1;
                     return Some(syncmer);

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -7,7 +7,7 @@ use super::hash::xxh64;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Syncmer {
     hash: u64,
-    canonical: bool,
+    forward: bool,
     pub position: usize,
 }
 
@@ -16,12 +16,12 @@ impl Syncmer {
         self.hash
     }
 
-    pub fn is_canonical(&self) -> bool {
-        self.canonical
+    pub fn is_forward(&self) -> bool {
+        self.forward
     }
 
-    pub fn toggle_canonical(&mut self) {
-        self.canonical = !self.canonical;
+    pub fn toggle_orientation(&mut self) {
+        self.forward = !self.forward;
     }
 }
 
@@ -181,7 +181,7 @@ impl Iterator for SyncmerIterator<'_> {
                     let yk = min(self.xk[0], self.xk[1]);
                     let syncmer = Syncmer {
                         hash: syncmer_kmer_hash(yk),
-                        canonical: self.xk[0] <= self.xk[1],
+                        forward: self.xk[0] <= self.xk[1],
                         position: i + 1 - self.k,
                     };
                     self.i = i + 1;
@@ -253,7 +253,7 @@ mod test {
             syncmers_reverse.reverse();
             for syncmer in &mut syncmers_reverse {
                 syncmer.position = s.len() - parameters.k - syncmer.position;
-                syncmer.toggle_canonical();
+                syncmer.toggle_orientation();
             }
 
             assert_eq!(syncmers_forward, syncmers_reverse);

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -180,7 +180,8 @@ impl Iterator for SyncmerIterator<'_> {
                     // occurs at t:th position in k-mer
                     let yk = min(self.xk[0], self.xk[1]);
                     let syncmer = Syncmer {
-                        hash_and_canonical: (syncmer_kmer_hash(yk) & !1) | ((self.xk[0] <= self.xk[1]) as u64),
+                        hash_and_canonical: (syncmer_kmer_hash(yk) & !1)
+                            | ((self.xk[0] <= self.xk[1]) as u64),
                         position: i + 1 - self.k,
                     };
                     self.i = i + 1;

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -7,21 +7,21 @@ use super::hash::xxh64;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Syncmer {
     /// Syncmer hash with canonicity stored in the least significant bit
-    hash_and_canonical: u64,
+    hash_canonical: u64,
     pub position: usize,
 }
 
 impl Syncmer {
     pub fn hash(&self) -> u64 {
-        self.hash_and_canonical & !1
+        self.hash_canonical & !1
     }
 
     pub fn is_canonical(&self) -> bool {
-        self.hash_and_canonical & 1 != 0
+        self.hash_canonical & 1 != 0
     }
 
     pub fn toggle_canonical(&mut self) {
-        self.hash_and_canonical ^= 1;
+        self.hash_canonical ^= 1;
     }
 }
 
@@ -180,7 +180,7 @@ impl Iterator for SyncmerIterator<'_> {
                     // occurs at t:th position in k-mer
                     let yk = min(self.xk[0], self.xk[1]);
                     let syncmer = Syncmer {
-                        hash_and_canonical: (syncmer_kmer_hash(yk) & !1)
+                        hash_canonical: (syncmer_kmer_hash(yk) & !1)
                             | ((self.xk[0] <= self.xk[1]) as u64),
                         position: i + 1 - self.k,
                     };

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -7,7 +7,7 @@ use super::hash::xxh64;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Syncmer {
     hash: u64,
-    forward: bool,
+    is_forward: bool,
     pub position: usize,
 }
 
@@ -17,11 +17,11 @@ impl Syncmer {
     }
 
     pub fn is_forward(&self) -> bool {
-        self.forward
+        self.is_forward
     }
 
     pub fn toggle_orientation(&mut self) {
-        self.forward = !self.forward;
+        self.is_forward = !self.is_forward;
     }
 }
 
@@ -181,7 +181,7 @@ impl Iterator for SyncmerIterator<'_> {
                     let yk = min(self.xk[0], self.xk[1]);
                     let syncmer = Syncmer {
                         hash: syncmer_kmer_hash(yk),
-                        forward: self.xk[0] <= self.xk[1],
+                        is_forward: self.xk[0] <= self.xk[1],
                         position: i + 1 - self.k,
                     };
                     self.i = i + 1;

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -6,22 +6,22 @@ use super::hash::xxh64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Syncmer {
-    /// Syncmer hash with canonicity stored in the least significant bit
-    hash_canonical: u64,
+    hash: u64,
+    canonical: bool,
     pub position: usize,
 }
 
 impl Syncmer {
     pub fn hash(&self) -> u64 {
-        self.hash_canonical & !1
+        self.hash
     }
 
     pub fn is_canonical(&self) -> bool {
-        self.hash_canonical & 1 != 0
+        self.canonical
     }
 
     pub fn toggle_canonical(&mut self) {
-        self.hash_canonical ^= 1;
+        self.canonical = !self.canonical;
     }
 }
 
@@ -180,8 +180,8 @@ impl Iterator for SyncmerIterator<'_> {
                     // occurs at t:th position in k-mer
                     let yk = min(self.xk[0], self.xk[1]);
                     let syncmer = Syncmer {
-                        hash_canonical: (syncmer_kmer_hash(yk) & !1)
-                            | ((self.xk[0] <= self.xk[1]) as u64),
+                        hash: syncmer_kmer_hash(yk),
+                        canonical: self.xk[0] <= self.xk[1],
                         position: i + 1 - self.k,
                     };
                     self.i = i + 1;

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -6,9 +6,23 @@ use super::hash::xxh64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Syncmer {
-    pub hash: u64,
+    /// Syncmer hash with canonicity stored in the least significant bit
+    hash_and_canonical: u64,
     pub position: usize,
-    pub is_canonical: bool,
+}
+
+impl Syncmer {
+    pub fn hash(&self) -> u64 {
+        self.hash_and_canonical & !1
+    }
+
+    pub fn is_canonical(&self) -> bool {
+        self.hash_and_canonical & 1 != 0
+    }
+
+    pub fn toggle_canonical(&mut self) {
+        self.hash_and_canonical ^= 1;
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,12 +178,10 @@ impl Iterator for SyncmerIterator<'_> {
                 }
                 if self.qs[self.t - 1] == self.qs_min_val {
                     // occurs at t:th position in k-mer
-                    let is_canonical = self.xk[0] <= self.xk[1];
-                    let yk = if is_canonical { self.xk[0] } else { self.xk[1] };
+                    let yk = min(self.xk[0], self.xk[1]);
                     let syncmer = Syncmer {
-                        hash: syncmer_kmer_hash(yk),
+                        hash_and_canonical: (syncmer_kmer_hash(yk) & !1) | ((self.xk[0] <= self.xk[1]) as u64),
                         position: i + 1 - self.k,
-                        is_canonical,
                     };
                     self.i = i + 1;
                     return Some(syncmer);


### PR DESCRIPTION
This stores a bool in `Syncmer` which is true iff the syncmer is canonical. These canonicity bits are then included in the randstrobe hash and used to filter out hits with a different orientation than the reference. The new randstrobe hash layout 

<strobe 1 hash><strobe 1 canonicity bit><strobe 2 hash><strobe 2 canonicity bit><offset>

Accuracy is the same as in main, the runtime is also mostly the same (slightly faster for sim6).

[ends.pdf](https://github.com/user-attachments/files/26169966/ends.pdf)

The main benefit is the removal of spurious anchors and the resulting small chains.

[chain-stats.pdf](https://github.com/user-attachments/files/26169997/chain-stats.pdf)



