### PR TITLE
Add a "noisy" profile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@
   If you need one of the above features, use version 0.17.0.
 * #550: Introduce piecewise extension for single-end reads. The previous 
   SSW extension can be enabled with `--ssw`.
+* #539: Add a "noisy" read profile. Use `-P noisy` on the command line to
+  select it. This is equivalent to `-k 16 -s 12 -l 2 -u 2 -m 100`.
+  We found these settings to increase accuracy on error-prone reads at the cost
+  of runtime.
 
 ## v0.17.0 (2025-12-18)
 

--- a/README.md
+++ b/README.md
@@ -171,15 +171,14 @@ options. Some important ones are:
   to disk next to the input reference FASTA. Do not map reads. If read files are
   provided, they are used to estimate read length. See [index files](#index-files).
 
-## Index files
+## Read profiles and canonical read lengths
 
-### Background
+Strobealign needs to build an index of the reference before it can map reads to it.
 
-Strobealign needs to build an index (strobemer index) of the reference before
-it can map reads to it.
-The optimal indexing parameters depend on the length of the input reads.
-There are pre-defined sets of parameters that are optimized for different read
-lengths. These *canonical read lengths* are
+The optimal indexing parameters depend on the type of reads that are to be mapped.
+
+Strobealign by default uses pre-defined sets of parameters that are optimized
+for different read lengths. These *canonical read lengths* are
 50, 75, 100, 125, 150, 250 and 400. When deciding which of the pre-defined
 indexing parameter sets to use, strobealign chooses one whose canonical
 read length is close to the average read length of the input.
@@ -187,31 +186,46 @@ read length is close to the average read length of the input.
 The average read length of the input is normally estimated from the first
 500 reads, but can also be explicitly set with `-r`.
 
+In addition, it is possible to choose a profile optimized for “noisy”, that is,
+error-prone reads. Use `-P noisy` on the command line to select it.
+This is equivalent to `-k 16 -s 12 -l 2 -u 2 -m 100`.
+We found these settings to increase accuracy on error-prone reads,
+but note this comes at the cost of runtime.
+
+## Index files
+
 ### Pre-computing an index (`.sti`)
 
 By default, strobealign creates a new index every time the program is run.
-Depending on CPU, indexing a human-sized genome takes
-1 to 2 minutes, which is not long compared to mapping many millions of reads.
-However, for repeatedly mapping small libraries, it is faster to pre-generate
+On current CPUs (and using multiple cores), indexing a human-sized genome takes
+less than 1 minute, which is not long compared to mapping many millions of reads.
+However, for repeatedly mapping small libraries, it may be faster to pre-generate
 an index on disk and use that.
 
 To create an index, use the `--create-index` option.
-Since strobealign needs to know the read length, either provide it with
-read file(s) as if you wanted to map them:
+Since strobealign needs to know the read profile, either provide some reads on
+the command line as if you wanted to map them:
 
     strobealign --create-index -t 8 ref.fa reads.1.fastq.gz reads.2.fastq.gz
 
-Or set the read length explicitly with `-r`:
+This will use a read-length based profile based on the estimated read length.
+You can also set the read length explicitly with `-r`:
 
-    strobealign --create-index -t 8 ref.fa -r 150
+    strobealign --create-index -t 8  -r 150 ref.fa
 
-This creates a file named `ref.fa.rX.sti` containing the strobemer index,
-where `X` is the canonical read length that the index is optimized for (see
-above).
+Or use the “noisy” profile with `-P noisy`:
+
+    strobealign --create-index -t 8 -P noisy ref.fa
+
+This creates a file named `ref.fa.X.sti` containing the strobemer index,
+where `X` is an identifier for the read profile (such as `r50`, `r100`, `noisy`).
 To use the index when mapping, provide option `--use-index` when doing the
 actual mapping:
 
     strobealign --use-index -t 8 ref.fa reads.1.fastq.gz reads.2.fastq.gz | samtools ...
+
+If you want to use the “noisy” profile, you also need to specify `-P noisy`
+during mapping.
 
 - Note that the `.sti` files are usually tied to a specific strobealign version.
   That is, when upgrading strobealign, the `.sti` files need to be regenerated.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,5 +1,5 @@
-use ::strobealign::fasta;
-use ::strobealign::fasta::RefSequence;
+use ::strobealign::io::fasta;
+use ::strobealign::io::fasta::RefSequence;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 use std::fs::File;

--- a/src/index.rs
+++ b/src/index.rs
@@ -832,7 +832,7 @@ mod tests {
     #[test]
     fn test_index_phix() {
         let references = read_ref("tests/phix.fasta");
-        let parameters = SeedingParameters::default_from_read_length(150);
+        let parameters = SeedingParameters::new(150);
         let mut index = StrobemerIndex::new(&references, parameters, None);
         index.populate(0.1, 1);
         assert!(index.stats.distinct_strobemers > 0);
@@ -844,7 +844,7 @@ mod tests {
             name: "name".to_string(),
             sequence: vec![],
         }];
-        let parameters = SeedingParameters::default_from_read_length(150);
+        let parameters = SeedingParameters::new(150);
         let mut index = StrobemerIndex::new(&references, parameters, None);
         index.populate(0.1, 1);
         assert_eq!(index.stats.distinct_strobemers, 0);
@@ -860,17 +860,13 @@ mod tests {
         let f = File::open(fasta_path).unwrap();
         let references = read_fasta(&mut BufReader::new(f)).unwrap();
 
-        let parameters = SeedingParameters::default_from_read_length(300);
+        let parameters = SeedingParameters::new(300);
         let mut index = StrobemerIndex::new(&references, parameters, None);
         index.populate(0.0002, 1);
         let sti_path = dir.path().join("index.sti");
         index.write(&sti_path).unwrap();
 
-        let mut other_index = StrobemerIndex::new(
-            &references,
-            SeedingParameters::default_from_read_length(50),
-            None,
-        );
+        let mut other_index = StrobemerIndex::new(&references, SeedingParameters::new(50), None);
 
         match other_index.read(&sti_path) {
             Err(IndexReadingError::ParameterMismatch) => {}

--- a/src/index.rs
+++ b/src/index.rs
@@ -604,6 +604,9 @@ pub enum IndexReadingError {
     )]
     RandstrobeStartIndicesWrongSize,
 
+    #[error("The .sti (index) file uses an unknown profile")]
+    WrongProfile,
+
     #[error("The .sti (index) file uses an invalid indexing parameter: {0}")]
     InvalidIndexParameter(#[from] InvalidSeedingParameter),
 }
@@ -622,7 +625,7 @@ impl<'a> StrobemerIndex<'a> {
         file.write_all(&(self.filter_cutoff as u32).to_ne_bytes())?;
         file.write_all(&(self.bits as u32).to_ne_bytes())?;
 
-        file.write_all(&(self.parameters.canonical_read_length as u32).to_ne_bytes())?;
+        file.write_all(&(self.parameters.profile.clone() as u32).to_ne_bytes())?;
         let sp = &self.parameters.syncmer;
         for val in [sp.k, sp.s].iter() {
             file.write_all(&(*val as u32).to_ne_bytes())?
@@ -676,7 +679,10 @@ impl<'a> StrobemerIndex<'a> {
         self.rescue_cutoff = self.filter_cutoff;
         let bits = read_u32(&mut reader)?;
 
-        let canonical_read_length = read_u32(&mut reader)? as usize;
+        let profile = read_u32(&mut reader)?
+            .try_into()
+            .map_err(|_| IndexReadingError::WrongProfile)?;
+
         let k = read_u32(&mut reader)? as usize;
         let s = read_u32(&mut reader)? as usize;
 
@@ -695,7 +701,7 @@ impl<'a> StrobemerIndex<'a> {
             main_hash_mask,
         };
         let sti_parameters = SeedingParameters {
-            canonical_read_length,
+            profile,
             syncmer: syncmer_parameters,
             randstrobe: randstrobe_parameters,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,8 +146,12 @@ struct Args {
     // Seeding arguments
 
     /// Mean read length. Default: estimated from the first 500 records in the input file
-    #[arg(short, help_heading = "Seeding")]
+    #[arg(short, conflicts_with = "profile", help_heading = "Seeding")]
     read_length: Option<usize>,
+
+    /// Read profile (cannot be used together with -r). 'noisy' improves accuracy on error-prone reads but is slower.
+    #[arg(short = 'P', value_enum, help_heading = "Seeding")]
+    profile: Option<CmdlineProfile>,
 
     /// Maximum seed length.
     /// For reasonable values on -l and -u, the seed length distribution is
@@ -273,6 +277,11 @@ struct Args {
     reads_path2: Option<String>,
 }
 
+#[derive(Debug, Clone, clap::ValueEnum)]
+enum CmdlineProfile {
+    Noisy,
+}
+
 #[derive(Debug, Error)]
 enum CliError {
     #[error("{0}")]
@@ -353,21 +362,38 @@ fn run() -> Result<(), CliError> {
         reads_reader1 = None;
     }
 
-    let parameters = SeedingParameters::from_read_length(
-        read_length,
-        args.k,
-        args.s,
-        args.l,
-        args.u,
-        args.c,
-        args.max_seed_length,
-        args.aux_len,
-    )?;
-
+    let parameters = if args.profile.is_some() {
+        SeedingParameters::noisy(
+            args.k,
+            args.s,
+            args.l,
+            args.u,
+            args.c,
+            args.max_seed_length,
+            args.aux_len,
+        )
+    } else {
+        SeedingParameters::from_read_length(
+            read_length,
+            args.k,
+            args.s,
+            args.l,
+            args.u,
+            args.c,
+            args.max_seed_length,
+            args.aux_len,
+        )
+    }?;
     info!(
-        "Canonical read length: {} bp",
-        parameters.canonical_read_length
+        "Read profile: {} {}",
+        parameters.profile,
+        if parameters.is_custom() {
+            " (modified from default)"
+        } else {
+            ""
+        }
     );
+
     debug!("  {:?}", parameters.syncmer);
     debug!("  {:?}", parameters.randstrobe);
     debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -363,15 +363,7 @@ fn run() -> Result<(), CliError> {
     }
 
     let parameters = if args.profile.is_some() {
-        SeedingParameters::noisy(
-            args.k,
-            args.s,
-            args.l,
-            args.u,
-            args.c,
-            args.max_seed_length,
-            args.aux_len,
-        )
+        SeedingParameters::noisy(args.k, args.s, args.l, args.u, args.c, args.max_seed_length)
     } else {
         SeedingParameters::from_read_length(
             read_length,
@@ -381,9 +373,9 @@ fn run() -> Result<(), CliError> {
             args.u,
             args.c,
             args.max_seed_length,
-            args.aux_len,
         )
-    }?;
+    }?
+    .with_aux_len(args.aux_len)?;
     info!(
         "Read profile: {} {}",
         parameters.profile,

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,20 +362,20 @@ fn run() -> Result<(), CliError> {
         reads_reader1 = None;
     }
 
-    let parameters = if args.profile.is_some() {
-        SeedingParameters::noisy(args.k, args.s, args.l, args.u, args.c, args.max_seed_length)
+    let mut parameters = if args.profile.is_some() {
+        SeedingParameters::noisy()
     } else {
-        SeedingParameters::from_read_length(
-            read_length,
-            args.k,
-            args.s,
-            args.l,
-            args.u,
-            args.c,
-            args.max_seed_length,
-        )
-    }?
+        SeedingParameters::new(read_length)
+    }
+    .with_k_s(args.k, args.s)?
+    .with_window(args.l, args.u)?
     .with_aux_len(args.aux_len)?;
+    if let Some(length) = args.max_seed_length {
+        parameters = parameters.with_max_seed_length(length)?;
+    }
+    if let Some(bitcount) = args.c {
+        parameters = parameters.with_bitcount(bitcount)?;
+    }
     info!(
         "Read profile: {} {}",
         parameters.profile,

--- a/src/seeding/mod.rs
+++ b/src/seeding/mod.rs
@@ -3,7 +3,7 @@ pub mod parameters;
 pub mod strobes;
 pub mod syncmers;
 
-pub use parameters::{InvalidSeedingParameter, SeedingParameters};
+pub use parameters::{InvalidSeedingParameter, Profile, SeedingParameters};
 pub use strobes::{DEFAULT_AUX_LEN, RandstrobeIterator, RandstrobeParameters};
 pub use syncmers::{Syncmer, SyncmerIterator, SyncmerParameters};
 

--- a/src/seeding/parameters.rs
+++ b/src/seeding/parameters.rs
@@ -5,23 +5,24 @@ use thiserror::Error;
 use super::strobes::{DEFAULT_AUX_LEN, RandstrobeParameters};
 use super::syncmers::SyncmerParameters;
 
-// A preset for seeding parameters (k, s, l, u, etc.)
+/// A preset for seeding parameters
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Profile {
     Noisy,
-    Canonical50,
-    Canonical75,
-    Canonical100,
-    Canonical125,
-    Canonical150,
-    Canonical250,
-    Canonical400,
+    ReadLength50,
+    ReadLength75,
+    ReadLength100,
+    ReadLength125,
+    ReadLength150,
+    ReadLength250,
+    ReadLength400,
 }
 
-impl From<usize> for Profile {
+/*impl From<usize> for Profile {
     /// Given a read length, returns the corresponding closest canonical `Profile`
     ///
-    /// This never returns the `Noisy` variant (construct that explicitly).
+    /// This never returns the `Noisy` variant (to get it, construct it explicitly
+    /// instead).
     fn from(read_length: usize) -> Self {
         // unwrap is fine because the last r_threshold is usize::MAX
         READ_LENGTH_SETTINGS
@@ -31,39 +32,49 @@ impl From<usize> for Profile {
             .profile
             .clone()
     }
-}
+}*/
 
 impl Profile {
+    /// If this is a read-length based profile, returns the canonical length.
+    /// Otherwise, returns None.
+    fn length(&self) -> Option<usize> {
+        match *self {
+            Profile::Noisy => None,
+            Profile::ReadLength50 => Some(50),
+            Profile::ReadLength75 => Some(75),
+            Profile::ReadLength100 => Some(100),
+            Profile::ReadLength125 => Some(125),
+            Profile::ReadLength150 => Some(150),
+            Profile::ReadLength250 => Some(250),
+            Profile::ReadLength400 => Some(400),
+        }
+    }
+
     /// Returns the identifier for the profile (used in the index file name).
     fn identifier(&self) -> String {
-        match self {
-            Profile::Noisy => "noisy",
-            Profile::Canonical50 => "r50",
-            Profile::Canonical75 => "r75",
-            Profile::Canonical100 => "r100",
-            Profile::Canonical125 => "r125",
-            Profile::Canonical150 => "r150",
-            Profile::Canonical250 => "r250",
-            Profile::Canonical400 => "r400",
+        if let Some(length) = self.length() {
+            format!("r{}", length)
+        } else {
+            "noisy".to_string()
         }
-        .to_string()
     }
 }
 
-/// A u32 value is stored in `.sti` files to encode the profile.
+/// A u32 value is stored in `.sti` files to encode the profile. This trait
+/// implementation is used to convert it back to a `Profile`.
 impl TryFrom<u32> for Profile {
     type Error = ();
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value as u32 {
             x if x == Profile::Noisy as u32 => Ok(Profile::Noisy),
-            x if x == Profile::Canonical50 as u32 => Ok(Profile::Canonical50),
-            x if x == Profile::Canonical75 as u32 => Ok(Profile::Canonical75),
-            x if x == Profile::Canonical100 as u32 => Ok(Profile::Canonical100),
-            x if x == Profile::Canonical125 as u32 => Ok(Profile::Canonical125),
-            x if x == Profile::Canonical150 as u32 => Ok(Profile::Canonical150),
-            x if x == Profile::Canonical250 as u32 => Ok(Profile::Canonical250),
-            x if x == Profile::Canonical400 as u32 => Ok(Profile::Canonical400),
+            x if x == Profile::ReadLength50 as u32 => Ok(Profile::ReadLength50),
+            x if x == Profile::ReadLength75 as u32 => Ok(Profile::ReadLength75),
+            x if x == Profile::ReadLength100 as u32 => Ok(Profile::ReadLength100),
+            x if x == Profile::ReadLength125 as u32 => Ok(Profile::ReadLength125),
+            x if x == Profile::ReadLength150 as u32 => Ok(Profile::ReadLength150),
+            x if x == Profile::ReadLength250 as u32 => Ok(Profile::ReadLength250),
+            x if x == Profile::ReadLength400 as u32 => Ok(Profile::ReadLength400),
             _ => Err(()),
         }
     }
@@ -71,15 +82,10 @@ impl TryFrom<u32> for Profile {
 
 impl Display for Profile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Profile::Noisy => write!(f, "noisy"),
-            Profile::Canonical50 => write!(f, "canonical 50 nt"),
-            Profile::Canonical75 => write!(f, "canonical 75 nt"),
-            Profile::Canonical100 => write!(f, "canonical 100 nt"),
-            Profile::Canonical125 => write!(f, "canonical 125 nt"),
-            Profile::Canonical150 => write!(f, "canonical 150 nt"),
-            Profile::Canonical250 => write!(f, "canonical 250 nt"),
-            Profile::Canonical400 => write!(f, "canonical 400 nt"),
+        if let Some(length) = self.length() {
+            write!(f, "canonical {} nt", length)
+        } else {
+            write!(f, "noisy")
         }
     }
 }
@@ -97,7 +103,7 @@ struct ReadLengthSettings {
 
 static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
     ReadLengthSettings {
-        profile: Profile::Canonical50,
+        profile: Profile::ReadLength50,
         canonical_read_length: 50,
         r_threshold: 70,
         k: 18,
@@ -106,7 +112,7 @@ static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
         w_max: 4,
     },
     ReadLengthSettings {
-        profile: Profile::Canonical75,
+        profile: Profile::ReadLength75,
         canonical_read_length: 75,
         r_threshold: 90,
         k: 20,
@@ -115,7 +121,7 @@ static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
         w_max: 6,
     },
     ReadLengthSettings {
-        profile: Profile::Canonical100,
+        profile: Profile::ReadLength100,
         canonical_read_length: 100,
         r_threshold: 110,
         k: 20,
@@ -124,7 +130,7 @@ static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
         w_max: 6,
     },
     ReadLengthSettings {
-        profile: Profile::Canonical125,
+        profile: Profile::ReadLength125,
         canonical_read_length: 125,
         r_threshold: 135,
         k: 20,
@@ -133,7 +139,7 @@ static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
         w_max: 8,
     },
     ReadLengthSettings {
-        profile: Profile::Canonical150,
+        profile: Profile::ReadLength150,
         canonical_read_length: 150,
         r_threshold: 175,
         k: 20,
@@ -142,7 +148,7 @@ static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
         w_max: 11,
     },
     ReadLengthSettings {
-        profile: Profile::Canonical250,
+        profile: Profile::ReadLength250,
         canonical_read_length: 250,
         r_threshold: 375,
         k: 22,
@@ -151,7 +157,7 @@ static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
         w_max: 16,
     },
     ReadLengthSettings {
-        profile: Profile::Canonical400,
+        profile: Profile::ReadLength400,
         canonical_read_length: 400,
         r_threshold: usize::MAX,
         k: 23,
@@ -169,38 +175,6 @@ pub struct SeedingParameters {
     pub randstrobe: RandstrobeParameters,
 }
 
-impl From<&Profile> for SeedingParameters {
-    fn from(profile: &Profile) -> Self {
-        let rp = READ_LENGTH_SETTINGS
-            .iter()
-            .find(|&rlp| rlp.profile == *profile)
-            .expect("missing profile");
-
-        // TODO duplicated code
-        let q = 2u64.pow(8) - 1;
-
-        // TODO duplicated code
-        let main_hash_mask = !0u64 << (9 + DEFAULT_AUX_LEN);
-
-        // TODO duplicated code
-        let max_dist = usize::clamp(rp.canonical_read_length.saturating_sub(70), rp.k, 255) as u8;
-
-        SeedingParameters {
-            profile: profile.clone(),
-            syncmer: SyncmerParameters::try_new(rp.k, (rp.k as isize + rp.s_offset) as usize)
-                .unwrap(),
-            randstrobe: RandstrobeParameters::try_new(
-                rp.w_min,
-                rp.w_max,
-                q,
-                max_dist,
-                main_hash_mask,
-            )
-            .unwrap(),
-        }
-    }
-}
-
 #[derive(Error, Debug)]
 pub enum InvalidSeedingParameter {
     #[error("Invalid seeding parameter: {0}")]
@@ -208,6 +182,55 @@ pub enum InvalidSeedingParameter {
 }
 
 impl SeedingParameters {
+    pub fn new(profile: &Profile) -> Self {
+        let c = 8;
+        let q = 2u64.pow(c) - 1;
+        let main_hash_mask = !0u64 << (9 + DEFAULT_AUX_LEN);
+
+        match profile {
+            Profile::Noisy => SeedingParameters {
+                profile: profile.clone(),
+                syncmer: SyncmerParameters::try_new(16, 12).unwrap(),
+                randstrobe: RandstrobeParameters::try_new(2, 2, q, 84, main_hash_mask).unwrap(),
+            },
+            profile => {
+                let read_length = profile.length().unwrap();
+                let read_length_profile = READ_LENGTH_SETTINGS
+                    .iter()
+                    .find(|&rp| read_length <= rp.r_threshold)
+                    .expect("missing profile");
+
+                let s = (read_length_profile.k as isize + read_length_profile.s_offset) as usize;
+                let max_dist =
+                    usize::clamp(read_length.saturating_sub(70), read_length_profile.k, 255) as u8;
+
+                SeedingParameters {
+                    profile: profile.clone(),
+                    syncmer: SyncmerParameters::try_new(read_length_profile.k, s).unwrap(),
+                    randstrobe: RandstrobeParameters::try_new(
+                        read_length_profile.w_min,
+                        read_length_profile.w_max,
+                        q,
+                        max_dist,
+                        main_hash_mask,
+                    )
+                    .unwrap(),
+                }
+            }
+        }
+    }
+
+    pub fn with_aux_len(mut self, aux_len: u8) -> Result<Self, InvalidSeedingParameter> {
+        if aux_len > 63 {
+            return Err(InvalidSeedingParameter::InvalidParameter(
+                "aux length must be less than 64",
+            ));
+        }
+        self.randstrobe.main_hash_mask = !0u64 << (9 + aux_len);
+
+        Ok(self)
+    }
+
     pub fn try_new(
         profile: Profile,
         k: usize,
@@ -216,15 +239,8 @@ impl SeedingParameters {
         w_max: usize,
         q: u64,
         max_dist: u8,
-        aux_len: u8,
     ) -> Result<Self, InvalidSeedingParameter> {
-        if aux_len > 63 {
-            return Err(InvalidSeedingParameter::InvalidParameter(
-                "aux length must be less than 64",
-            ));
-        }
-
-        let main_hash_mask = !0u64 << (9 + aux_len);
+        let main_hash_mask = Self::new(&profile).randstrobe.main_hash_mask;
         Ok(SeedingParameters {
             profile,
             syncmer: SyncmerParameters::try_new(k, s)?,
@@ -241,7 +257,6 @@ impl SeedingParameters {
         w_max: Option<usize>,
         c: Option<u32>,
         max_seed_len: Option<usize>,
-        aux_len: u8,
     ) -> Result<Self, InvalidSeedingParameter> {
         struct P {
             k: usize,
@@ -277,7 +292,7 @@ impl SeedingParameters {
             None => p.max_dist,
         };
 
-        SeedingParameters::try_new(Profile::Noisy, k, s, w_min, w_max, q, max_dist, aux_len)
+        SeedingParameters::try_new(Profile::Noisy, k, s, w_min, w_max, q, max_dist)
     }
 
     /// Create an IndexParameters instance based on a given read length.
@@ -290,7 +305,6 @@ impl SeedingParameters {
         w_max: Option<usize>,
         c: Option<u32>,
         max_seed_len: Option<usize>,
-        aux_len: u8,
     ) -> Result<Self, InvalidSeedingParameter> {
         let read_length_profile = READ_LENGTH_SETTINGS
             .iter()
@@ -327,39 +341,22 @@ impl SeedingParameters {
             w_max,
             q,
             max_dist,
-            aux_len,
         )
     }
 
     pub fn default_from_read_length(read_length: usize) -> SeedingParameters {
-        Self::from_read_length(
-            read_length,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            DEFAULT_AUX_LEN,
-        )
-        .unwrap()
+        Self::from_read_length(read_length, None, None, None, None, None, None).unwrap()
     }
 
     pub fn default_from_profile(profile: &Profile) -> SeedingParameters {
-        match profile {
-            Profile::Noisy => {
-                Self::noisy(None, None, None, None, None, None, DEFAULT_AUX_LEN).unwrap()
-            }
-            Profile::Canonical50 => Self::default_from_read_length(50),
-            Profile::Canonical75 => Self::default_from_read_length(75),
-            Profile::Canonical100 => Self::default_from_read_length(100),
-            Profile::Canonical125 => Self::default_from_read_length(125),
-            Profile::Canonical150 => Self::default_from_read_length(150),
-            Profile::Canonical250 => Self::default_from_read_length(250),
-            Profile::Canonical400 => Self::default_from_read_length(400),
+        if let Some(length) = profile.length() {
+            Self::default_from_read_length(length)
+        } else {
+            Self::noisy(None, None, None, None, None, None).unwrap()
         }
     }
 
+    /// Returns whether the settings differ from the profile they are based on.
     pub fn is_custom(&self) -> bool {
         Self::default_from_profile(&self.profile) != *self
     }
@@ -369,7 +366,7 @@ impl SeedingParameters {
     ///
     /// If the profile was modified from the default, returns just ".sti".
     pub fn filename_extension(&self) -> String {
-        if *self != SeedingParameters::from(&self.profile) {
+        if self.is_custom() {
             ".sti".to_string()
         } else {
             format!(".{}.sti", self.profile.identifier())
@@ -400,23 +397,17 @@ mod test {
             max_dist,
             main_hash_mask,
         };
-        let seeding_parameters = SeedingParameters::try_new(
-            Profile::Canonical250,
-            k,
-            s,
-            w_min,
-            w_max,
-            q,
-            max_dist,
-            aux_len,
-        )
-        .unwrap();
-        assert_eq!(seeding_parameters.profile, Profile::Canonical250);
+        let seeding_parameters =
+            SeedingParameters::try_new(Profile::ReadLength250, k, s, w_min, w_max, q, max_dist)
+                .unwrap()
+                .with_aux_len(aux_len)
+                .unwrap();
+        assert_eq!(seeding_parameters.profile, Profile::ReadLength250);
         assert_eq!(seeding_parameters.randstrobe, rp);
         assert_eq!(seeding_parameters.syncmer, sp);
 
         let ip = SeedingParameters::default_from_read_length(canonical_read_length + 1);
-        assert_eq!(ip.profile, Profile::Canonical250);
+        assert_eq!(ip.profile, Profile::ReadLength250);
         assert_eq!(ip.randstrobe, rp);
         assert_eq!(ip.syncmer, sp);
     }

--- a/src/seeding/parameters.rs
+++ b/src/seeding/parameters.rs
@@ -6,7 +6,7 @@ use super::strobes::{DEFAULT_AUX_LEN, RandstrobeParameters};
 use super::syncmers::SyncmerParameters;
 
 /// A preset for seeding parameters
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Profile {
     Noisy,
     ReadLength50,
@@ -18,7 +18,7 @@ pub enum Profile {
     ReadLength400,
 }
 
-/*impl From<usize> for Profile {
+impl From<usize> for Profile {
     /// Given a read length, returns the corresponding closest canonical `Profile`
     ///
     /// This never returns the `Noisy` variant (to get it, construct it explicitly
@@ -32,7 +32,7 @@ pub enum Profile {
             .profile
             .clone()
     }
-}*/
+}
 
 impl Profile {
     /// If this is a read-length based profile, returns the canonical length.
@@ -90,13 +90,12 @@ impl Display for Profile {
     }
 }
 
-/// Preset seeding parameters based on read length (the "canonical read length").
+/// Seeding parameters for a read-length-based profile
 struct ReadLengthSettings {
     profile: Profile,
-    canonical_read_length: usize,
     r_threshold: usize,
     k: usize,
-    s_offset: isize,
+    s: usize,
     w_min: usize,
     w_max: usize,
 }
@@ -104,64 +103,57 @@ struct ReadLengthSettings {
 static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
     ReadLengthSettings {
         profile: Profile::ReadLength50,
-        canonical_read_length: 50,
         r_threshold: 70,
         k: 18,
-        s_offset: -4,
+        s: 14,
         w_min: 1,
         w_max: 4,
     },
     ReadLengthSettings {
         profile: Profile::ReadLength75,
-        canonical_read_length: 75,
         r_threshold: 90,
         k: 20,
-        s_offset: -4,
+        s: 16,
         w_min: 1,
         w_max: 6,
     },
     ReadLengthSettings {
         profile: Profile::ReadLength100,
-        canonical_read_length: 100,
         r_threshold: 110,
         k: 20,
-        s_offset: -4,
+        s: 16,
         w_min: 2,
         w_max: 6,
     },
     ReadLengthSettings {
         profile: Profile::ReadLength125,
-        canonical_read_length: 125,
         r_threshold: 135,
         k: 20,
-        s_offset: -4,
+        s: 16,
         w_min: 3,
         w_max: 8,
     },
     ReadLengthSettings {
         profile: Profile::ReadLength150,
-        canonical_read_length: 150,
         r_threshold: 175,
         k: 20,
-        s_offset: -4,
+        s: 16,
         w_min: 5,
         w_max: 11,
     },
     ReadLengthSettings {
         profile: Profile::ReadLength250,
-        canonical_read_length: 250,
         r_threshold: 375,
         k: 22,
-        s_offset: -4,
+        s: 18,
         w_min: 6,
         w_max: 16,
     },
     ReadLengthSettings {
         profile: Profile::ReadLength400,
-        canonical_read_length: 400,
         r_threshold: usize::MAX,
         k: 23,
-        s_offset: -6,
+        s: 17,
         w_min: 5,
         w_max: 15,
     },
@@ -170,6 +162,8 @@ static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
 /// Settings that influence seed creation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SeedingParameters {
+    /// The base profile provided at construction time from which the settings are derived.
+    /// If parameters were changed after construction, `is_custom()` returns false.
     pub profile: Profile,
     pub syncmer: SyncmerParameters,
     pub randstrobe: RandstrobeParameters,
@@ -182,9 +176,13 @@ pub enum InvalidSeedingParameter {
 }
 
 impl SeedingParameters {
-    pub fn new(profile: &Profile) -> Self {
-        let c = 8;
-        let q = 2u64.pow(c) - 1;
+    /// Constructs a new SeedingParameters object with default parameters
+    /// specific to the given profile. If a `usize` is provided, it is treated
+    /// as a read length and the appropriate `Profile::ReadLength...` value is used.
+    pub fn new<T: Into<Profile>>(t: T) -> Self {
+        let profile = t.into();
+        let bitcount = 8;
+        let q = 2u64.pow(bitcount) - 1;
         let main_hash_mask = !0u64 << (9 + DEFAULT_AUX_LEN);
 
         match profile {
@@ -197,16 +195,19 @@ impl SeedingParameters {
                 let read_length = profile.length().unwrap();
                 let read_length_profile = READ_LENGTH_SETTINGS
                     .iter()
-                    .find(|&rp| read_length <= rp.r_threshold)
-                    .expect("missing profile");
+                    .find(|&rlp| read_length <= rlp.r_threshold)
+                    .expect("missing profile"); // should not happen because the last r_threshold is usize::MAX
 
-                let s = (read_length_profile.k as isize + read_length_profile.s_offset) as usize;
                 let max_dist =
                     usize::clamp(read_length.saturating_sub(70), read_length_profile.k, 255) as u8;
 
                 SeedingParameters {
                     profile: profile.clone(),
-                    syncmer: SyncmerParameters::try_new(read_length_profile.k, s).unwrap(),
+                    syncmer: SyncmerParameters::try_new(
+                        read_length_profile.k,
+                        read_length_profile.s,
+                    )
+                    .unwrap(),
                     randstrobe: RandstrobeParameters::try_new(
                         read_length_profile.w_min,
                         read_length_profile.w_max,
@@ -220,6 +221,70 @@ impl SeedingParameters {
         }
     }
 
+    /// A shortcut for `SeedingParameters::new(Profile::Noisy)`
+    pub fn noisy() -> Self {
+        Self::new(Profile::Noisy)
+    }
+
+    /// Returns parameters with updated k, s and also max_dist. The latter is
+    /// updated because it depends on k.
+    pub fn with_k_s(
+        mut self,
+        k: Option<usize>,
+        s: Option<usize>,
+    ) -> Result<Self, InvalidSeedingParameter> {
+        let new_k = k.unwrap_or(self.syncmer.k);
+        let new_s = if let Some(s) = s {
+            s
+        } else {
+            // When only k, but no s is not given, adjust s such that k - s stays the same.
+            let diff = self.syncmer.k - self.syncmer.s;
+            assert!(new_k >= diff);
+
+            new_k - diff
+        };
+        self.syncmer = SyncmerParameters::try_new(new_k, new_s)?;
+
+        self.randstrobe.max_dist = if let Some(length) = self.profile.length() {
+            usize::clamp(length.saturating_sub(70), new_k, 255) as u8
+        } else {
+            // noisy
+            100 - new_k as u8
+        };
+
+        Ok(self)
+    }
+
+    /// Returns parameters with updated w_min and w_max.
+    pub fn with_window(
+        mut self,
+        w_min: Option<usize>,
+        w_max: Option<usize>,
+    ) -> Result<Self, InvalidSeedingParameter> {
+        self.randstrobe = self.randstrobe.with_window(w_min, w_max)?;
+
+        Ok(self)
+    }
+
+    /// Returns parameters with updated max_dist.
+    ///
+    /// Change k before this as k is used to compute max_dist from max_seed_length.
+    pub fn with_max_seed_length(
+        mut self,
+        max_seed_length: usize,
+    ) -> Result<Self, InvalidSeedingParameter> {
+        if max_seed_length < self.syncmer.k || max_seed_length - self.syncmer.k > 255 {
+            return Err(InvalidSeedingParameter::InvalidParameter(
+                "max seed length must be between k and k + 255",
+            ));
+        }
+
+        self.randstrobe.max_dist = (max_seed_length - self.syncmer.k) as u8;
+
+        Ok(self)
+    }
+
+    /// Returns parameters with updated main_hash_mask, computed from aux_len.
     pub fn with_aux_len(mut self, aux_len: u8) -> Result<Self, InvalidSeedingParameter> {
         if aux_len > 63 {
             return Err(InvalidSeedingParameter::InvalidParameter(
@@ -231,137 +296,26 @@ impl SeedingParameters {
         Ok(self)
     }
 
-    pub fn try_new(
-        profile: Profile,
-        k: usize,
-        s: usize,
-        w_min: usize,
-        w_max: usize,
-        q: u64,
-        max_dist: u8,
-    ) -> Result<Self, InvalidSeedingParameter> {
-        let main_hash_mask = Self::new(&profile).randstrobe.main_hash_mask;
-        Ok(SeedingParameters {
-            profile,
-            syncmer: SyncmerParameters::try_new(k, s)?,
-            randstrobe: RandstrobeParameters::try_new(w_min, w_max, q, max_dist, main_hash_mask)?,
-        })
-    }
-
-    /// Create an IndexParameters instance based on a given read length.
-    /// k, s, l, u, c and max_seed_len can be used to override determined parameters
-    pub fn noisy(
-        k: Option<usize>,
-        s: Option<usize>,
-        w_min: Option<usize>,
-        w_max: Option<usize>,
-        c: Option<u32>,
-        max_seed_len: Option<usize>,
-    ) -> Result<Self, InvalidSeedingParameter> {
-        struct P {
-            k: usize,
-            s_offset: isize,
-            w_min: usize,
-            w_max: usize,
-            max_dist: u8,
+    /// Returns parameters with updated q mask, computed from bitcount.
+    pub fn with_bitcount(mut self, bitcount: u32) -> Result<Self, InvalidSeedingParameter> {
+        if bitcount < 2 || bitcount > 63 {
+            return Err(InvalidSeedingParameter::InvalidParameter(
+                "bitcount must be between 2 and 63",
+            ));
         }
 
-        let p = P {
-            k: 16,
-            s_offset: -4,
-            w_min: 2,
-            w_max: 2,
-            max_dist: 84,
-        };
+        self.randstrobe.q = 2u64.pow(bitcount) - 1;
 
-        // TODO this is duplicated in from_read_length
-        let k = k.unwrap_or(p.k);
-        let s = s.unwrap_or((k as isize + p.s_offset) as usize);
-        let w_min = w_min.unwrap_or(p.w_min);
-        let w_max = w_max.unwrap_or(p.w_max);
-        let q = 2u64.pow(c.unwrap_or(8)) - 1;
-        let max_dist = match max_seed_len {
-            Some(max_seed_len) => {
-                if max_seed_len < k || max_seed_len - k > 255 {
-                    return Err(InvalidSeedingParameter::InvalidParameter(
-                        "max seed length must be between k and k + 255",
-                    ));
-                }
-                (max_seed_len - k) as u8
-            }
-            None => p.max_dist,
-        };
-
-        SeedingParameters::try_new(Profile::Noisy, k, s, w_min, w_max, q, max_dist)
+        Ok(self)
     }
 
-    /// Create an IndexParameters instance based on a given read length.
-    /// k, s, l, u, c and max_seed_len can be used to override determined parameters
-    pub fn from_read_length(
-        read_length: usize,
-        k: Option<usize>,
-        s: Option<usize>,
-        w_min: Option<usize>,
-        w_max: Option<usize>,
-        c: Option<u32>,
-        max_seed_len: Option<usize>,
-    ) -> Result<Self, InvalidSeedingParameter> {
-        let read_length_profile = READ_LENGTH_SETTINGS
-            .iter()
-            .find(|&rp| read_length <= rp.r_threshold)
-            .expect("missing profile");
-
-        let k = k.unwrap_or(read_length_profile.k);
-        let s = s.unwrap_or((k as isize + read_length_profile.s_offset) as usize);
-        let w_min = w_min.unwrap_or(read_length_profile.w_min);
-        let w_max = w_max.unwrap_or(read_length_profile.w_max);
-        let q = 2u64.pow(c.unwrap_or(8)) - 1;
-        let max_dist = match max_seed_len {
-            Some(max_seed_len) => {
-                if max_seed_len < k || max_seed_len - k > 255 {
-                    dbg!(max_seed_len);
-                    return Err(InvalidSeedingParameter::InvalidParameter(
-                        "max seed length must be between k and k + 255",
-                    ));
-                }
-                (max_seed_len - k) as u8
-            }
-            None => usize::clamp(
-                read_length_profile.canonical_read_length.saturating_sub(70),
-                k,
-                255,
-            ) as u8,
-        };
-
-        SeedingParameters::try_new(
-            read_length_profile.profile.clone(),
-            k,
-            s,
-            w_min,
-            w_max,
-            q,
-            max_dist,
-        )
-    }
-
-    pub fn default_from_read_length(read_length: usize) -> SeedingParameters {
-        Self::from_read_length(read_length, None, None, None, None, None, None).unwrap()
-    }
-
-    pub fn default_from_profile(profile: &Profile) -> SeedingParameters {
-        if let Some(length) = profile.length() {
-            Self::default_from_read_length(length)
-        } else {
-            Self::noisy(None, None, None, None, None, None).unwrap()
-        }
-    }
-
-    /// Returns whether the settings differ from the profile they are based on.
+    /// Returns whether the settings differ from the base profile (that was given at
+    /// construction time).
     pub fn is_custom(&self) -> bool {
-        Self::default_from_profile(&self.profile) != *self
+        Self::new(self.profile) != *self
     }
 
-    /// Returns a filename extension such as ".r100.sti",
+    /// Returns an index filename extension such as ".r100.sti",
     /// where `r100` is the profile name.
     ///
     /// If the profile was modified from the default, returns just ".sti".
@@ -397,36 +351,70 @@ mod test {
             max_dist,
             main_hash_mask,
         };
-        let seeding_parameters =
-            SeedingParameters::try_new(Profile::ReadLength250, k, s, w_min, w_max, q, max_dist)
-                .unwrap()
-                .with_aux_len(aux_len)
-                .unwrap();
+        let seeding_parameters = SeedingParameters::new(250)
+            .with_k_s(Some(k), Some(s))
+            .unwrap()
+            .with_window(Some(w_min), Some(w_max))
+            .unwrap()
+            .with_max_seed_length(max_dist as usize + k)
+            .unwrap()
+            .with_aux_len(aux_len)
+            .unwrap()
+            .with_bitcount(8)
+            .unwrap();
         assert_eq!(seeding_parameters.profile, Profile::ReadLength250);
         assert_eq!(seeding_parameters.randstrobe, rp);
         assert_eq!(seeding_parameters.syncmer, sp);
 
-        let ip = SeedingParameters::default_from_read_length(canonical_read_length + 1);
+        let ip = SeedingParameters::new(canonical_read_length + 1);
         assert_eq!(ip.profile, Profile::ReadLength250);
         assert_eq!(ip.randstrobe, rp);
         assert_eq!(ip.syncmer, sp);
     }
 
     #[test]
-    fn test_seeding_parameters_same_read_length() {
-        let sp150a = SeedingParameters::default_from_read_length(150);
-        let sp150b = SeedingParameters::default_from_read_length(150);
-
-        assert_eq!(sp150a, sp150b);
-    }
-
-    #[test]
     fn test_seeding_parameters_similar_read_length() {
-        let sp150 = SeedingParameters::default_from_read_length(150);
-        let sp149 = SeedingParameters::default_from_read_length(149);
-        let sp151 = SeedingParameters::default_from_read_length(151);
+        let sp150 = SeedingParameters::new(150);
+        let sp149 = SeedingParameters::new(149);
+        let sp151 = SeedingParameters::new(151);
 
         assert_eq!(sp150, sp149);
         assert_eq!(sp150, sp151);
+    }
+
+    #[test]
+    fn test_seeding_parameters_is_custom() {
+        assert!(!SeedingParameters::new(100).is_custom());
+        assert!(
+            !SeedingParameters::new(100)
+                .with_window(None, None)
+                .unwrap()
+                .is_custom()
+        );
+
+        assert!(
+            SeedingParameters::new(100)
+                .with_k_s(Some(17), None)
+                .unwrap()
+                .is_custom()
+        );
+        assert!(
+            SeedingParameters::new(100)
+                .with_k_s(None, Some(8))
+                .unwrap()
+                .is_custom()
+        );
+        assert!(
+            SeedingParameters::new(100)
+                .with_window(Some(3), Some(19))
+                .unwrap()
+                .is_custom()
+        );
+        assert!(
+            SeedingParameters::new(100)
+                .with_max_seed_length(123)
+                .unwrap()
+                .is_custom()
+        );
     }
 }

--- a/src/seeding/parameters.rs
+++ b/src/seeding/parameters.rs
@@ -1,11 +1,92 @@
+use std::fmt::Display;
+
 use thiserror::Error;
 
 use super::strobes::{DEFAULT_AUX_LEN, RandstrobeParameters};
 use super::syncmers::SyncmerParameters;
 
-/// Pre-defined seeding parameters that work well for a certain
-/// "canonical" read length (and similar read lengths)
-struct Profile {
+// A preset for seeding parameters (k, s, l, u, etc.)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Profile {
+    Noisy,
+    Canonical50,
+    Canonical75,
+    Canonical100,
+    Canonical125,
+    Canonical150,
+    Canonical250,
+    Canonical400,
+}
+
+impl From<usize> for Profile {
+    /// Given a read length, returns the corresponding closest canonical `Profile`
+    ///
+    /// This never returns the `Noisy` variant (construct that explicitly).
+    fn from(read_length: usize) -> Self {
+        // unwrap is fine because the last r_threshold is usize::MAX
+        READ_LENGTH_SETTINGS
+            .iter()
+            .find(|&profile| read_length <= profile.r_threshold)
+            .unwrap()
+            .profile
+            .clone()
+    }
+}
+
+impl Profile {
+    /// Returns the identifier for the profile (used in the index file name).
+    fn identifier(&self) -> String {
+        match self {
+            Profile::Noisy => "noisy",
+            Profile::Canonical50 => "r50",
+            Profile::Canonical75 => "r75",
+            Profile::Canonical100 => "r100",
+            Profile::Canonical125 => "r125",
+            Profile::Canonical150 => "r150",
+            Profile::Canonical250 => "r250",
+            Profile::Canonical400 => "r400",
+        }
+        .to_string()
+    }
+}
+
+/// A u32 value is stored in `.sti` files to encode the profile.
+impl TryFrom<u32> for Profile {
+    type Error = ();
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value as u32 {
+            x if x == Profile::Noisy as u32 => Ok(Profile::Noisy),
+            x if x == Profile::Canonical50 as u32 => Ok(Profile::Canonical50),
+            x if x == Profile::Canonical75 as u32 => Ok(Profile::Canonical75),
+            x if x == Profile::Canonical100 as u32 => Ok(Profile::Canonical100),
+            x if x == Profile::Canonical125 as u32 => Ok(Profile::Canonical125),
+            x if x == Profile::Canonical150 as u32 => Ok(Profile::Canonical150),
+            x if x == Profile::Canonical250 as u32 => Ok(Profile::Canonical250),
+            x if x == Profile::Canonical400 as u32 => Ok(Profile::Canonical400),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Display for Profile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Profile::Noisy => write!(f, "noisy"),
+            Profile::Canonical50 => write!(f, "canonical 50 nt"),
+            Profile::Canonical75 => write!(f, "canonical 75 nt"),
+            Profile::Canonical100 => write!(f, "canonical 100 nt"),
+            Profile::Canonical125 => write!(f, "canonical 125 nt"),
+            Profile::Canonical150 => write!(f, "canonical 150 nt"),
+            Profile::Canonical250 => write!(f, "canonical 250 nt"),
+            Profile::Canonical400 => write!(f, "canonical 400 nt"),
+        }
+    }
+}
+
+/// Preset seeding parameters based on read length (the "canonical read length").
+struct ReadLengthSettings {
+    profile: Profile,
     canonical_read_length: usize,
     r_threshold: usize,
     k: usize,
@@ -14,8 +95,9 @@ struct Profile {
     w_max: usize,
 }
 
-static PROFILES: [Profile; 7] = [
-    Profile {
+static READ_LENGTH_SETTINGS: [ReadLengthSettings; 7] = [
+    ReadLengthSettings {
+        profile: Profile::Canonical50,
         canonical_read_length: 50,
         r_threshold: 70,
         k: 18,
@@ -23,7 +105,8 @@ static PROFILES: [Profile; 7] = [
         w_min: 1,
         w_max: 4,
     },
-    Profile {
+    ReadLengthSettings {
+        profile: Profile::Canonical75,
         canonical_read_length: 75,
         r_threshold: 90,
         k: 20,
@@ -31,7 +114,8 @@ static PROFILES: [Profile; 7] = [
         w_min: 1,
         w_max: 6,
     },
-    Profile {
+    ReadLengthSettings {
+        profile: Profile::Canonical100,
         canonical_read_length: 100,
         r_threshold: 110,
         k: 20,
@@ -39,7 +123,8 @@ static PROFILES: [Profile; 7] = [
         w_min: 2,
         w_max: 6,
     },
-    Profile {
+    ReadLengthSettings {
+        profile: Profile::Canonical125,
         canonical_read_length: 125,
         r_threshold: 135,
         k: 20,
@@ -47,7 +132,8 @@ static PROFILES: [Profile; 7] = [
         w_min: 3,
         w_max: 8,
     },
-    Profile {
+    ReadLengthSettings {
+        profile: Profile::Canonical150,
         canonical_read_length: 150,
         r_threshold: 175,
         k: 20,
@@ -55,7 +141,8 @@ static PROFILES: [Profile; 7] = [
         w_min: 5,
         w_max: 11,
     },
-    Profile {
+    ReadLengthSettings {
+        profile: Profile::Canonical250,
         canonical_read_length: 250,
         r_threshold: 375,
         k: 22,
@@ -63,7 +150,8 @@ static PROFILES: [Profile; 7] = [
         w_min: 6,
         w_max: 16,
     },
-    Profile {
+    ReadLengthSettings {
+        profile: Profile::Canonical400,
         canonical_read_length: 400,
         r_threshold: usize::MAX,
         k: 23,
@@ -73,24 +161,42 @@ static PROFILES: [Profile; 7] = [
     },
 ];
 
-/* Settings that influence seeding (creation */
+/// Settings that influence seed creation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SeedingParameters {
-    pub canonical_read_length: usize,
+    pub profile: Profile,
     pub syncmer: SyncmerParameters,
     pub randstrobe: RandstrobeParameters,
 }
 
-impl SeedingParameters {
-    /// Return a parameter-specific filename extension such as ".r100.sti"
-    ///
-    /// If any of the parameters deviate from the defaults for the current
-    /// canonical read length, the returned extension is just ".sti".
-    pub fn filename_extension(&self) -> String {
-        if *self != SeedingParameters::default_from_read_length(self.canonical_read_length) {
-            ".sti".to_string()
-        } else {
-            format!(".r{}.sti", self.canonical_read_length)
+impl From<&Profile> for SeedingParameters {
+    fn from(profile: &Profile) -> Self {
+        let rp = READ_LENGTH_SETTINGS
+            .iter()
+            .find(|&rlp| rlp.profile == *profile)
+            .expect("missing profile");
+
+        // TODO duplicated code
+        let q = 2u64.pow(8) - 1;
+
+        // TODO duplicated code
+        let main_hash_mask = !0u64 << (9 + DEFAULT_AUX_LEN);
+
+        // TODO duplicated code
+        let max_dist = usize::clamp(rp.canonical_read_length.saturating_sub(70), rp.k, 255) as u8;
+
+        SeedingParameters {
+            profile: profile.clone(),
+            syncmer: SyncmerParameters::try_new(rp.k, (rp.k as isize + rp.s_offset) as usize)
+                .unwrap(),
+            randstrobe: RandstrobeParameters::try_new(
+                rp.w_min,
+                rp.w_max,
+                q,
+                max_dist,
+                main_hash_mask,
+            )
+            .unwrap(),
         }
     }
 }
@@ -103,7 +209,7 @@ pub enum InvalidSeedingParameter {
 
 impl SeedingParameters {
     pub fn try_new(
-        canonical_read_length: usize,
+        profile: Profile,
         k: usize,
         s: usize,
         w_min: usize,
@@ -120,7 +226,7 @@ impl SeedingParameters {
 
         let main_hash_mask = !0u64 << (9 + aux_len);
         Ok(SeedingParameters {
-            canonical_read_length,
+            profile,
             syncmer: SyncmerParameters::try_new(k, s)?,
             randstrobe: RandstrobeParameters::try_new(w_min, w_max, q, max_dist, main_hash_mask)?,
         })
@@ -128,42 +234,74 @@ impl SeedingParameters {
 
     /// Create an IndexParameters instance based on a given read length.
     /// k, s, l, u, c and max_seed_len can be used to override determined parameters
-    pub fn from_read_length(
-        read_length: usize,
-        mut k: Option<usize>,
-        mut s: Option<usize>,
-        mut w_min: Option<usize>,
-        mut w_max: Option<usize>,
+    pub fn noisy(
+        k: Option<usize>,
+        s: Option<usize>,
+        w_min: Option<usize>,
+        w_max: Option<usize>,
         c: Option<u32>,
         max_seed_len: Option<usize>,
         aux_len: u8,
-    ) -> Result<SeedingParameters, InvalidSeedingParameter> {
-        let default_c = 8;
-        let mut canonical_read_length = 50;
-        for profile in &PROFILES {
-            if read_length <= profile.r_threshold {
-                if k.is_none() {
-                    k = Some(profile.k);
-                }
-                if s.is_none() {
-                    s = Some((k.unwrap() as isize + profile.s_offset) as usize);
-                }
-                if w_min.is_none() {
-                    w_min = Some(profile.w_min);
-                }
-                if w_max.is_none() {
-                    w_max = Some(profile.w_max);
-                }
-                canonical_read_length = profile.canonical_read_length;
-                break;
-            }
+    ) -> Result<Self, InvalidSeedingParameter> {
+        struct P {
+            k: usize,
+            s_offset: isize,
+            w_min: usize,
+            w_max: usize,
+            max_dist: u8,
         }
 
-        let k = k.unwrap();
-        let s = s.unwrap();
-        let w_min = w_min.unwrap();
-        let w_max = w_max.unwrap();
+        let p = P {
+            k: 16,
+            s_offset: -4,
+            w_min: 2,
+            w_max: 2,
+            max_dist: 84,
+        };
 
+        // TODO this is duplicated in from_read_length
+        let k = k.unwrap_or(p.k);
+        let s = s.unwrap_or((k as isize + p.s_offset) as usize);
+        let w_min = w_min.unwrap_or(p.w_min);
+        let w_max = w_max.unwrap_or(p.w_max);
+        let q = 2u64.pow(c.unwrap_or(8)) - 1;
+        let max_dist = match max_seed_len {
+            Some(max_seed_len) => {
+                if max_seed_len < k || max_seed_len - k > 255 {
+                    return Err(InvalidSeedingParameter::InvalidParameter(
+                        "max seed length must be between k and k + 255",
+                    ));
+                }
+                (max_seed_len - k) as u8
+            }
+            None => p.max_dist,
+        };
+
+        SeedingParameters::try_new(Profile::Noisy, k, s, w_min, w_max, q, max_dist, aux_len)
+    }
+
+    /// Create an IndexParameters instance based on a given read length.
+    /// k, s, l, u, c and max_seed_len can be used to override determined parameters
+    pub fn from_read_length(
+        read_length: usize,
+        k: Option<usize>,
+        s: Option<usize>,
+        w_min: Option<usize>,
+        w_max: Option<usize>,
+        c: Option<u32>,
+        max_seed_len: Option<usize>,
+        aux_len: u8,
+    ) -> Result<Self, InvalidSeedingParameter> {
+        let read_length_profile = READ_LENGTH_SETTINGS
+            .iter()
+            .find(|&rp| read_length <= rp.r_threshold)
+            .expect("missing profile");
+
+        let k = k.unwrap_or(read_length_profile.k);
+        let s = s.unwrap_or((k as isize + read_length_profile.s_offset) as usize);
+        let w_min = w_min.unwrap_or(read_length_profile.w_min);
+        let w_max = w_max.unwrap_or(read_length_profile.w_max);
+        let q = 2u64.pow(c.unwrap_or(8)) - 1;
         let max_dist = match max_seed_len {
             Some(max_seed_len) => {
                 if max_seed_len < k || max_seed_len - k > 255 {
@@ -174,12 +312,15 @@ impl SeedingParameters {
                 }
                 (max_seed_len - k) as u8
             }
-            None => usize::clamp(canonical_read_length.saturating_sub(70), k, 255) as u8,
+            None => usize::clamp(
+                read_length_profile.canonical_read_length.saturating_sub(70),
+                k,
+                255,
+            ) as u8,
         };
-        let q = 2u64.pow(c.unwrap_or(default_c)) - 1;
 
         SeedingParameters::try_new(
-            canonical_read_length,
+            read_length_profile.profile.clone(),
             k,
             s,
             w_min,
@@ -202,6 +343,37 @@ impl SeedingParameters {
             DEFAULT_AUX_LEN,
         )
         .unwrap()
+    }
+
+    pub fn default_from_profile(profile: &Profile) -> SeedingParameters {
+        match profile {
+            Profile::Noisy => {
+                Self::noisy(None, None, None, None, None, None, DEFAULT_AUX_LEN).unwrap()
+            }
+            Profile::Canonical50 => Self::default_from_read_length(50),
+            Profile::Canonical75 => Self::default_from_read_length(75),
+            Profile::Canonical100 => Self::default_from_read_length(100),
+            Profile::Canonical125 => Self::default_from_read_length(125),
+            Profile::Canonical150 => Self::default_from_read_length(150),
+            Profile::Canonical250 => Self::default_from_read_length(250),
+            Profile::Canonical400 => Self::default_from_read_length(400),
+        }
+    }
+
+    pub fn is_custom(&self) -> bool {
+        Self::default_from_profile(&self.profile) != *self
+    }
+
+    /// Returns a filename extension such as ".r100.sti",
+    /// where `r100` is the profile name.
+    ///
+    /// If the profile was modified from the default, returns just ".sti".
+    pub fn filename_extension(&self) -> String {
+        if *self != SeedingParameters::from(&self.profile) {
+            ".sti".to_string()
+        } else {
+            format!(".{}.sti", self.profile.identifier())
+        }
     }
 }
 
@@ -229,7 +401,7 @@ mod test {
             main_hash_mask,
         };
         let seeding_parameters = SeedingParameters::try_new(
-            canonical_read_length,
+            Profile::Canonical250,
             k,
             s,
             w_min,
@@ -239,15 +411,12 @@ mod test {
             aux_len,
         )
         .unwrap();
-        assert_eq!(
-            seeding_parameters.canonical_read_length,
-            canonical_read_length
-        );
+        assert_eq!(seeding_parameters.profile, Profile::Canonical250);
         assert_eq!(seeding_parameters.randstrobe, rp);
         assert_eq!(seeding_parameters.syncmer, sp);
 
         let ip = SeedingParameters::default_from_read_length(canonical_read_length + 1);
-        assert_eq!(ip.canonical_read_length, canonical_read_length);
+        assert_eq!(ip.profile, Profile::Canonical250);
         assert_eq!(ip.randstrobe, rp);
         assert_eq!(ip.syncmer, sp);
     }

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -24,18 +24,34 @@ impl RandstrobeParameters {
         max_dist: u8,
         main_hash_mask: u64,
     ) -> Result<Self, InvalidSeedingParameter> {
-        if w_min > w_max {
-            return Err(InvalidSeedingParameter::InvalidParameter(
-                "w_min is greater than w_max (choose different -l/-u parameters)",
-            ));
-        }
-        Ok(RandstrobeParameters {
+        RandstrobeParameters {
             w_min,
             w_max,
             q,
             max_dist,
             main_hash_mask,
-        })
+        }
+        .with_window(Some(w_min), Some(w_max))
+    }
+
+    pub fn with_window(
+        mut self,
+        w_min: Option<usize>,
+        w_max: Option<usize>,
+    ) -> Result<Self, InvalidSeedingParameter> {
+        let new_w_min = w_min.unwrap_or(self.w_min);
+        let new_w_max = w_max.unwrap_or(self.w_max);
+
+        if w_min > w_max {
+            return Err(InvalidSeedingParameter::InvalidParameter(
+                "w_min is greater than w_max (choose different -l/-u parameters)",
+            ));
+        }
+
+        self.w_min = new_w_min;
+        self.w_max = new_w_max;
+
+        Ok(self)
     }
 }
 
@@ -145,7 +161,7 @@ mod test {
     #[test]
     fn test_randstrobe_iterator() {
         let refseq = read_phix().sequence;
-        let parameters = SeedingParameters::default_from_read_length(300);
+        let parameters = SeedingParameters::new(300);
         let syncmer_iter = SyncmerIterator::new(
             &refseq,
             parameters.syncmer.k,
@@ -167,7 +183,7 @@ mod test {
     #[test]
     fn test_syncmer_and_randstrobe_iterator_same_count() {
         let refseq = read_phix().sequence;
-        let parameters = SeedingParameters::default_from_read_length(100);
+        let parameters = SeedingParameters::new(100);
         let syncmer_iter = SyncmerIterator::new(
             &refseq,
             parameters.syncmer.k,


### PR DESCRIPTION
This adds a `-P` command-line option that allows to specify a read profile, currently the only supported one is `noisy`. Options `-P` and `-r` cannot be used at the same time.

This PR contains quite a few changes in `parameters.rs` because the existing read profiles are based on canonical read lengths, and generalizing this such that a profile can be either a read length or "noisy" (which is independent of read length) wasn’t so straightforward.

What helped me clean up the code after I got it working initially was this article:
https://matklad.github.io/2022/05/29/builder-lite.html
That’s where the `with_k_s`, `with_window`, `with_max_seed_length` etc. method names come from.

Closes #539
