### PR TITLE
Add a test that runs 'cargo fmt --check'

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -26,7 +26,6 @@ function diff() {
 trap 'echo -e "\e[1;31mFailure\e[0m"' ERR
 
 cargo build
-cargo fmt --check
 
 # Unit tests
 cargo test

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,6 +13,19 @@ fn cmd() -> Command {
 }
 
 #[test]
+fn cargo_fmt_check() {
+    assert!(
+        Command::new("cargo")
+            .arg("fmt")
+            .arg("--check")
+            .assert()
+            .try_success()
+            .is_ok(),
+        "'cargo fmt --check' failed, please run 'cargo fmt'"
+    );
+}
+
+#[test]
 fn fail_without_arguments() {
     let mut cmd = cmd();
     cmd.assert().failure();


### PR DESCRIPTION
Currently, to run all tests, it is necessary to run `tests/run.sh` because some tests are implemented as a shell script. However, it would be much nicer if all tests were available via `cargo test` as would be the expectation for a Rust project.

This moves one of the tests (running `cargo fmt --check` to ensure the code is formatted) into native Rust.