### PR TITLE
Refactor: Move index creation to a new indexer module

### DIFF
--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -165,7 +165,7 @@ impl Chainer {
                 &query_randstrobes[is_revcomp],
                 index,
                 mcs_strategy,
-                index.filter_cutoff,
+                index.filter_cutoff(),
                 rescue_distance,
             );
         }

--- a/src/index.rs
+++ b/src/index.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 
 use thiserror::Error;
 
-use crate::io::fasta::RefSequence;
 use crate::partition::custom_partition_point;
 use crate::seeding::{
     InvalidSeedingParameter, RandstrobeParameters, SeedingParameters, SyncmerParameters,
@@ -350,14 +349,9 @@ impl StrobemerIndex {
 
 pub fn read_index<'a, P: AsRef<Path>>(
     path: P,
-    references: &'a [RefSequence],
     parameters: SeedingParameters,
-    bits: Option<u8>,
+    bits: u8,
 ) -> Result<StrobemerIndex, IndexReadingError> {
-    // TODO these two lines are duplicated in make_index
-    let total_reference_length = references.iter().map(|r| r.sequence.len()).sum();
-    let bits = bits.unwrap_or_else(|| parameters.syncmer.pick_bits(total_reference_length));
-
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
 
@@ -486,7 +480,7 @@ mod tests {
     use super::*;
 
     use crate::indexer::make_index;
-    use crate::io::fasta::read_ref;
+    use crate::io::fasta::{RefSequence, read_ref};
     use crate::revcomp::reverse_complement;
 
     #[test]
@@ -513,12 +507,12 @@ mod tests {
         let references = read_ref(fasta_path).unwrap();
 
         let parameters = SeedingParameters::new(300);
-        let index = make_index(&references, parameters, None, 0.0002, 1).0;
+        let bits = parameters.syncmer.pick_bits(&references);
+        let index = make_index(&references, parameters, bits, 0.0002, 1).0;
         let sti_path = dir.path().join("index.sti");
         index.write(&sti_path).unwrap();
 
-        let read_index_result =
-            read_index(&sti_path, &references, SeedingParameters::new(50), None);
+        let read_index_result = read_index(&sti_path, SeedingParameters::new(50), bits);
 
         match read_index_result {
             Err(IndexReadingError::ParameterMismatch) => {}
@@ -539,10 +533,11 @@ mod tests {
         }];
 
         let parameters = SeedingParameters::new(300);
+        let bits = parameters.syncmer.pick_bits(&references);
 
-        let (fwd_index, _stats) = make_index(&references, parameters.clone(), None, 0.0000001, 1);
+        let (fwd_index, _stats) = make_index(&references, parameters.clone(), bits, 0.0000001, 1);
 
-        let (rc_index, _stats) = make_index(&rc_references, parameters.clone(), None, 0.0000001, 1);
+        let (rc_index, _stats) = make_index(&rc_references, parameters.clone(), bits, 0.0000001, 1);
 
         assert_eq!(fwd_index.randstrobes.len(), rc_index.randstrobes.len());
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -476,10 +476,7 @@ mod tests {
     use super::*;
 
     use crate::indexer::make_index;
-    use crate::io::fasta::read_fasta;
-
-    use std::fs::File;
-    use std::io::BufReader;
+    use crate::io::fasta::read_ref;
 
     #[test]
     fn test_ref_randstrobe() {
@@ -502,8 +499,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let fasta_path = dir.path().join("phix.fasta");
         std::fs::copy("tests/phix.fasta", &fasta_path).unwrap();
-        let f = File::open(fasta_path).unwrap();
-        let references = read_fasta(&mut BufReader::new(f)).unwrap();
+        let references = read_ref(fasta_path).unwrap();
 
         let parameters = SeedingParameters::new(300);
         let index = make_index(&references, parameters, None, 0.0002, 1).0;

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,94 +1,17 @@
-use std::cmp::{Reverse, min};
-use std::fmt::{Display, Formatter};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Error, Read, Write};
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Instant;
 
-use log::{debug, trace};
-use rayon;
-use rayon::slice::ParallelSliceMut;
 use thiserror::Error;
 
 use crate::io::fasta::RefSequence;
 use crate::partition::custom_partition_point;
 use crate::seeding::{
-    InvalidSeedingParameter, RandstrobeIterator, RandstrobeParameters, SeedingParameters,
-    SyncmerIterator, SyncmerParameters,
+    InvalidSeedingParameter, RandstrobeParameters, SeedingParameters, SyncmerParameters,
 };
 
-impl SyncmerParameters {
-    /// Pick a suitable number of bits for indexing randstrobe start indices
-    fn pick_bits(&self, size: usize) -> u8 {
-        let estimated_number_of_randstrobes = size / (self.k - self.s + 1) + 1;
-        // Two randstrobes per bucket on average
-        // TOOD checked_ilog2 or ilog2
-        ((estimated_number_of_randstrobes as f64).log2() as u32).clamp(9, 32) as u8 - 1
-    }
-}
-
-type RandstrobeHash = u64;
-type BucketIndex = u64;
-
-#[derive(Default)]
-pub struct IndexCreationStatistics {
-    tot_strobemer_count: u64,
-    tot_occur_once: u64,
-    tot_high_ab: u64,
-    tot_mid_ab: u64,
-    index_cutoff: usize,
-    distinct_strobemers: u64,
-}
-
-impl Display for IndexCreationStatistics {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Index statistics")?;
-        writeln!(f, "  Total strobemers:    {:14}", self.tot_strobemer_count)?;
-        writeln!(
-            f,
-            "  Distinct strobemers: {:14} (100.00%)",
-            self.distinct_strobemers
-        )?;
-        writeln!(
-            f,
-            "    1 occurrence:      {:14} ({:6.2}%)",
-            self.tot_occur_once,
-            100.0 * self.tot_occur_once as f64 / self.distinct_strobemers as f64
-        )?;
-        writeln!(
-            f,
-            "    2..100 occurrences:{:14} ({:6.2}%)",
-            self.tot_mid_ab,
-            100.0 * self.tot_mid_ab as f64 / self.distinct_strobemers as f64
-        )?;
-        writeln!(
-            f,
-            "    >100 occurrences:  {:14} ({:6.2}%)",
-            self.tot_high_ab,
-            100.0 * self.tot_high_ab as f64 / self.distinct_strobemers as f64
-        )?;
-        if self.tot_high_ab >= 1 {
-            writeln!(
-                f,
-                "Ratio distinct to highly abundant: {}",
-                self.distinct_strobemers / self.tot_high_ab
-            )?;
-        }
-        if self.tot_mid_ab >= 1 {
-            writeln!(
-                f,
-                "Ratio distinct to non distinct: {}",
-                self.distinct_strobemers / (self.tot_high_ab + self.tot_mid_ab)
-            )?;
-        }
-        write!(f, "Filtered cutoff index: {}", self.index_cutoff)?;
-
-        Ok(())
-    }
-}
+pub type RandstrobeHash = u64;
+pub type BucketIndex = u64;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Default, Clone)]
 #[repr(C)]
@@ -116,7 +39,7 @@ pub const STROBE2_OFFSET_MASK: u64 = (1u64 << STROBE2_OFFSET_BITS) - 1;
 pub const REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES: usize = u32::MAX as usize;
 
 impl RefRandstrobe {
-    fn new(hash: RandstrobeHash, ref_index: u32, position: u32, offset: u8) -> Self {
+    pub fn new(hash: RandstrobeHash, ref_index: u32, position: u32, offset: u8) -> Self {
         let hash_offset = (hash & REF_RANDSTROBE_HASH_MASK) | (offset as u64);
         RefRandstrobe {
             hash_offset,
@@ -142,46 +65,8 @@ impl RefRandstrobe {
     }
 }
 
-/// Count randstrobes by counting syncmers
-fn count_randstrobes(seq: &[u8], parameters: &SeedingParameters) -> usize {
-    let syncmer_iterator = SyncmerIterator::new(
-        seq,
-        parameters.syncmer.k,
-        parameters.syncmer.s,
-        parameters.syncmer.t,
-    );
-
-    syncmer_iterator.count()
-}
-
-fn count_all_randstrobes(
-    references: &[RefSequence],
-    parameters: &SeedingParameters,
-    n_threads: usize,
-) -> Vec<usize> {
-    let counts = vec![0; references.len()];
-    let mutex = Mutex::new(counts);
-    let ref_index = AtomicUsize::new(0);
-    thread::scope(|s| {
-        for _ in 0..n_threads {
-            s.spawn(|| {
-                loop {
-                    let j = ref_index.fetch_add(1, Ordering::SeqCst);
-                    if j >= references.len() {
-                        break;
-                    }
-                    let count = count_randstrobes(&references[j].sequence, parameters);
-                    mutex.lock().unwrap()[j] = count;
-                }
-            });
-        }
-    });
-
-    mutex.into_inner().unwrap()
-}
-
 pub struct StrobemerIndex<'a> {
-    references: &'a [RefSequence],
+    pub references: &'a [RefSequence],
     pub parameters: SeedingParameters,
 
     /// no. of bits of the hash to use when indexing a randstrobe bucket
@@ -205,259 +90,10 @@ pub struct StrobemerIndex<'a> {
     /// randstrobe_start_indices has one extra guard entry at the end that
     /// is always randstrobes.len().
     pub randstrobes: Vec<RefRandstrobe>,
-    randstrobe_start_indices: Vec<BucketIndex>,
+    pub randstrobe_start_indices: Vec<BucketIndex>,
 }
 
 impl<'a> StrobemerIndex<'a> {
-    pub fn new(
-        references: &'a [RefSequence],
-        parameters: SeedingParameters,
-        bits: Option<u8>,
-    ) -> Self {
-        let total_reference_length = references.iter().map(|r| r.sequence.len()).sum();
-        let bits = bits.unwrap_or_else(|| parameters.syncmer.pick_bits(total_reference_length));
-        let randstrobes = vec![];
-        let randstrobe_start_indices = vec![];
-        let filter_cutoff = 0;
-        let rescue_cutoff = 0;
-        StrobemerIndex {
-            references,
-            parameters,
-            bits,
-            filter_cutoff,
-            partial_filter_cutoff: filter_cutoff,
-            rescue_cutoff,
-            randstrobes,
-            randstrobe_start_indices,
-        }
-    }
-
-    pub fn populate(&mut self, filter_fraction: f64, n_threads: usize) -> IndexCreationStatistics {
-        let timer = Instant::now();
-        let randstrobe_counts = count_all_randstrobes(self.references, &self.parameters, n_threads);
-        debug!("  Counting hashes: {:.2} s", timer.elapsed().as_secs_f64());
-        // stats.elapsed_counting_hashes = count_hash.duration();
-        let mut stats = IndexCreationStatistics::default();
-
-        let total_randstrobes: usize = randstrobe_counts.iter().sum();
-        stats.tot_strobemer_count = total_randstrobes as u64;
-
-        debug!("  Total number of randstrobes: {}", total_randstrobes);
-        let total_length: usize = self
-            .references
-            .iter()
-            .map(|refseq| refseq.sequence.len())
-            .sum();
-        let memory_bytes: usize = total_length
-            + size_of::<RefRandstrobe>() * total_randstrobes
-            + size_of::<BucketIndex>() * (1usize << self.bits);
-        debug!(
-            "  Estimated total memory usage: {:.1} GB",
-            memory_bytes as f64 / 1E9
-        );
-
-        if total_randstrobes > BucketIndex::MAX as usize {
-            panic!("Too many randstrobes");
-        }
-        let timer = Instant::now();
-        debug!("  Generating randstrobes ...");
-        self.randstrobes = self.make_randstrobes_parallel(&randstrobe_counts, n_threads);
-        debug!("  Generating seeds: {:.2} s", timer.elapsed().as_secs_f64());
-        // stats.elapsed_generating_seeds = randstrobes_timer.duration();
-
-        let timer = Instant::now();
-        debug!("  Sorting ...");
-        // TODO
-        // ensure comparison function is branchless
-        // Comment from C++ code:
-        // Compare both hash and position to ensure that the order of the
-        // RefRandstrobes in the index is reproducible no matter which sorting
-        // function is used. This branchless comparison is faster than the
-        // equivalent one using std::tie.
-        // __uint128_t lhs = (static_cast<__uint128_t>(m_hash_offset_flag) << 64) | ((static_cast<uint64_t>(m_position) << 32) | m_ref_index);
-        // __uint128_t rhs = (static_cast<__uint128_t>(other.m_hash_offset_flag) << 64) | ((static_cast<uint64_t>(other.m_position) << 32) | m_ref_index);
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(n_threads)
-            .build()
-            .unwrap();
-        pool.install(|| {
-            self.randstrobes
-                .par_sort_unstable_by_key(|r| (r.hash_offset, r.position, r.ref_index));
-        });
-
-        debug!("    Took {:.2} s", timer.elapsed().as_secs_f64());
-        // stats.elapsed_sorting_seeds = sorting_timer.duration();
-
-        let timer = Instant::now();
-        debug!("  Generating hash table index ...");
-
-        let mut tot_high_ab = 0;
-        let mut tot_mid_ab = 0;
-        let mut strobemer_counts = Vec::<usize>::new();
-
-        stats.tot_occur_once = 0;
-        self.randstrobe_start_indices
-            .reserve((1usize << self.bits) + 1);
-
-        let mut unique_mers = u64::from(!self.randstrobes.is_empty());
-
-        let mut prev_hash: RandstrobeHash = if self.randstrobes.is_empty() {
-            0
-        } else {
-            self.randstrobes[0].hash()
-        };
-        let mut count = 1;
-
-        if !self.randstrobes.is_empty() {
-            self.randstrobe_start_indices.push(0);
-        }
-        for position in 1..self.randstrobes.len() {
-            let cur_hash = self.randstrobes[position].hash();
-            if cur_hash == prev_hash {
-                count += 1;
-                continue;
-            }
-            unique_mers += 1;
-
-            if count == 1 {
-                stats.tot_occur_once += 1;
-            } else {
-                if count > 100 {
-                    tot_high_ab += 1;
-                } else {
-                    tot_mid_ab += 1;
-                }
-                strobemer_counts.push(count);
-            }
-            count = 1;
-            let cur_hash_n = cur_hash >> (64 - self.bits);
-            while self.randstrobe_start_indices.len() <= cur_hash_n as usize {
-                self.randstrobe_start_indices.push(position as BucketIndex);
-            }
-            prev_hash = cur_hash;
-        }
-        // wrap up last entry
-        if count == 1 {
-            stats.tot_occur_once += 1;
-        } else {
-            if count > 100 {
-                tot_high_ab += 1;
-            } else {
-                tot_mid_ab += 1;
-            }
-            strobemer_counts.push(count);
-        }
-        while self.randstrobe_start_indices.len() < ((1usize << self.bits) + 1) {
-            self.randstrobe_start_indices
-                .push(self.randstrobes.len() as BucketIndex);
-        }
-        stats.tot_high_ab = tot_high_ab;
-        stats.tot_mid_ab = tot_mid_ab;
-
-        strobemer_counts.sort_unstable_by_key(|k| Reverse(*k));
-
-        let index_cutoff = (unique_mers as f64 * filter_fraction) as usize;
-        stats.index_cutoff = index_cutoff;
-        let filter_cutoff = if index_cutoff < strobemer_counts.len() {
-            strobemer_counts[index_cutoff]
-        } else {
-            *strobemer_counts.last().unwrap_or(&30)
-        };
-        trace!(
-            "Filter cutoff before clamping to [30, 100]: {}",
-            filter_cutoff
-        );
-        self.filter_cutoff = usize::clamp(
-            filter_cutoff,
-            30, // cutoff is around 30-50 on hg38. No reason to have a lower cutoff than this if aligning to a smaller genome or contigs.
-            100, // limit upper cutoff for normal NAM finding - use rescue mode instead
-        );
-        self.rescue_cutoff = min(self.filter_cutoff * 2, 1000);
-        //stats.elapsed_hash_index = hash_index_timer.duration();
-        debug!("    Took {:.2} s", timer.elapsed().as_secs_f64());
-        stats.distinct_strobemers = unique_mers;
-
-        stats
-    }
-
-    /*
-        fn make_randstrobes(&self, randstrobe_counts: &[usize]) -> Vec<RefRandstrobe> {
-            let mut randstrobes = vec![RefRandstrobe::default(); randstrobe_counts.iter().sum()];
-
-            // Fill randstrobes vector
-            let mut offset = 0;
-            for ref_index in 0..self.references.len() {
-                self.assign_randstrobes(ref_index, &mut randstrobes[offset..offset+randstrobe_counts[ref_index]]);
-                offset += randstrobe_counts[ref_index];
-            }
-            randstrobes
-        }
-    */
-
-    fn make_randstrobes_parallel(
-        &mut self,
-        randstrobe_counts: &[usize],
-        n_threads: usize,
-    ) -> Vec<RefRandstrobe> {
-        let mut randstrobes = vec![RefRandstrobe::default(); randstrobe_counts.iter().sum()];
-        let mut slices = vec![];
-        {
-            let mut slice = &mut randstrobes[..];
-            for &mid in randstrobe_counts.iter().take(self.references.len() - 1) {
-                let (left, right) = slice.split_at_mut(mid);
-                slices.push(Arc::new(Mutex::new(left)));
-                slice = right;
-            }
-            slices.push(Arc::new(Mutex::new(slice)));
-        }
-        let ref_index = AtomicUsize::new(0);
-        thread::scope(|s| {
-            for _ in 0..n_threads {
-                s.spawn(|| {
-                    loop {
-                        let j = ref_index.fetch_add(1, Ordering::SeqCst);
-                        if j >= self.references.len() {
-                            break;
-                        }
-                        self.assign_randstrobes(j, *slices[j].lock().unwrap());
-                    }
-                });
-            }
-        });
-
-        randstrobes
-    }
-
-    /// Compute randstrobes of one reference contig and assign them to the provided slice
-    fn assign_randstrobes(&self, ref_index: usize, randstrobes: &mut [RefRandstrobe]) {
-        let seq = &self.references[ref_index].sequence;
-        if seq.len() < self.parameters.randstrobe.w_max {
-            return;
-        }
-        let syncmer_iter = SyncmerIterator::new(
-            seq,
-            self.parameters.syncmer.k,
-            self.parameters.syncmer.s,
-            self.parameters.syncmer.t,
-        );
-
-        let randstrobe_iter =
-            RandstrobeIterator::new(syncmer_iter, self.parameters.randstrobe.clone());
-
-        let mut n = 0;
-        for (i, randstrobe) in randstrobe_iter.enumerate() {
-            n += 1;
-            let offset = randstrobe.strobe2_pos - randstrobe.strobe1_pos;
-            randstrobes[i] = RefRandstrobe::new(
-                randstrobe.hash,
-                ref_index as u32,
-                randstrobe.strobe1_pos as u32,
-                offset as u8,
-            );
-        }
-        debug_assert_eq!(n, randstrobes.len());
-    }
-
     // Find the first entry that matches the forwald full hash (including orientation bits)
     pub fn get_full_forward(&self, hash: RandstrobeHash) -> Option<usize> {
         self.get_masked(hash, REF_RANDSTROBE_HASH_MASK)
@@ -696,80 +332,100 @@ impl<'a> StrobemerIndex<'a> {
 
         Ok(())
     }
+}
 
-    #[must_use]
-    pub fn read<P: AsRef<Path>>(&mut self, path: P) -> Result<(), IndexReadingError> {
-        let file = File::open(path)?;
-        let mut reader = BufReader::new(file);
+pub fn read_index<'a, P: AsRef<Path>>(
+    path: P,
+    references: &'a [RefSequence],
+    parameters: SeedingParameters,
+    bits: Option<u8>,
+) -> Result<StrobemerIndex<'a>, IndexReadingError> {
+    // TODO these two lines are duplicated in make_index
+    let total_reference_length = references.iter().map(|r| r.sequence.len()).sum();
+    let bits = bits.unwrap_or_else(|| parameters.syncmer.pick_bits(total_reference_length));
 
-        let mut magic = [0; 4];
-        reader.read_exact(&mut magic)?;
-        if &magic != b"STI\x01" {
-            // Magic number
-            return Err(IndexReadingError::WrongMagic);
-        }
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
 
-        let file_format_version = read_u32(&mut reader)?;
-        if file_format_version != STI_FILE_FORMAT_VERSION {
-            return Err(IndexReadingError::WrongFileFormatVersion(
-                file_format_version,
-            ));
-        }
-
-        // Skip over variable-length chunk reserved for future use
-        let mut buf = [0; 8];
-        reader.read_exact(&mut buf)?;
-        let reserved_chunk_size = u64::from_ne_bytes(buf);
-        let mut buf = vec![0; reserved_chunk_size as usize];
-        reader.read_exact(&mut buf)?;
-
-        self.filter_cutoff = read_u32(&mut reader)? as usize;
-        self.rescue_cutoff = self.filter_cutoff;
-        let bits = read_u32(&mut reader)?;
-
-        let profile = read_u32(&mut reader)?
-            .try_into()
-            .map_err(|_| IndexReadingError::WrongProfile)?;
-
-        let k = read_u32(&mut reader)? as usize;
-        let s = read_u32(&mut reader)? as usize;
-
-        let w_min = read_u32(&mut reader)? as usize;
-        let w_max = read_u32(&mut reader)? as usize;
-        let q = read_u32(&mut reader)? as u64;
-        let max_dist = read_u32(&mut reader)? as u8;
-        let main_hash_mask = read_u64(&mut reader)?;
-
-        let syncmer_parameters = SyncmerParameters::try_new(k, s)?;
-        let partial_orientation_pos = main_hash_mask.trailing_zeros() - 1;
-        let randstrobe_parameters = RandstrobeParameters {
-            w_min,
-            w_max,
-            q,
-            max_dist,
-            main_hash_mask,
-            forward_main_hash_mask: main_hash_mask | (1u64 << partial_orientation_pos),
-            partial_orientation_pos,
-        };
-        let sti_parameters = SeedingParameters {
-            profile,
-            syncmer: syncmer_parameters,
-            randstrobe: randstrobe_parameters,
-        };
-
-        if self.parameters != sti_parameters {
-            return Err(IndexReadingError::ParameterMismatch);
-        }
-
-        self.randstrobes = read_vec(&mut reader)?;
-        self.randstrobe_start_indices = read_vec(&mut reader)?;
-
-        if self.randstrobe_start_indices.len() != (1 << bits) + 1 {
-            return Err(IndexReadingError::RandstrobeStartIndicesWrongSize);
-        }
-
-        Ok(())
+    let mut magic = [0; 4];
+    reader.read_exact(&mut magic)?;
+    if &magic != b"STI\x01" {
+        // Magic number
+        return Err(IndexReadingError::WrongMagic);
     }
+
+    let file_format_version = read_u32(&mut reader)?;
+    if file_format_version != STI_FILE_FORMAT_VERSION {
+        return Err(IndexReadingError::WrongFileFormatVersion(
+            file_format_version,
+        ));
+    }
+
+    // Skip over variable-length chunk reserved for future use
+    let mut buf = [0; 8];
+    reader.read_exact(&mut buf)?;
+    let reserved_chunk_size = u64::from_ne_bytes(buf);
+    let mut buf = vec![0; reserved_chunk_size as usize];
+    reader.read_exact(&mut buf)?;
+
+    let filter_cutoff = read_u32(&mut reader)? as usize;
+    let rescue_cutoff = filter_cutoff;
+    let sti_bits = read_u32(&mut reader)? as u8;
+    if sti_bits != bits {
+        return Err(IndexReadingError::ParameterMismatch);
+    }
+
+    let profile = read_u32(&mut reader)?
+        .try_into()
+        .map_err(|_| IndexReadingError::WrongProfile)?;
+
+    let k = read_u32(&mut reader)? as usize;
+    let s = read_u32(&mut reader)? as usize;
+
+    let w_min = read_u32(&mut reader)? as usize;
+    let w_max = read_u32(&mut reader)? as usize;
+    let q = read_u32(&mut reader)? as u64;
+    let max_dist = read_u32(&mut reader)? as u8;
+    let main_hash_mask = read_u64(&mut reader)?;
+
+    let syncmer_parameters = SyncmerParameters::try_new(k, s)?;
+    let partial_orientation_pos = main_hash_mask.trailing_zeros() - 1;
+    let randstrobe_parameters = RandstrobeParameters {
+        w_min,
+        w_max,
+        q,
+        max_dist,
+        main_hash_mask,
+        forward_main_hash_mask: main_hash_mask | (1u64 << partial_orientation_pos),
+        partial_orientation_pos,
+    };
+    let sti_parameters = SeedingParameters {
+        profile,
+        syncmer: syncmer_parameters,
+        randstrobe: randstrobe_parameters,
+    };
+
+    if parameters != sti_parameters {
+        return Err(IndexReadingError::ParameterMismatch);
+    }
+
+    let randstrobes = read_vec(&mut reader)?;
+    let randstrobe_start_indices = read_vec(&mut reader)?;
+
+    if randstrobe_start_indices.len() != (1 << bits) + 1 {
+        return Err(IndexReadingError::RandstrobeStartIndicesWrongSize);
+    }
+
+    Ok(StrobemerIndex {
+        references,
+        parameters,
+        bits,
+        filter_cutoff,
+        partial_filter_cutoff: filter_cutoff,
+        rescue_cutoff,
+        randstrobes,
+        randstrobe_start_indices,
+    })
 }
 
 fn read_u32<T: BufRead>(file: &mut T) -> Result<u32, Error> {
@@ -819,13 +475,11 @@ fn write_vec<T>(file: &mut File, data: &[T]) -> Result<(), Error> {
 mod tests {
     use super::*;
 
+    use crate::indexer::make_index;
     use crate::io::fasta::read_fasta;
-    use crate::revcomp::reverse_complement;
-    use crate::seeding::Syncmer;
 
     use std::fs::File;
     use std::io::BufReader;
-    use std::path::Path;
 
     #[test]
     fn test_ref_randstrobe() {
@@ -841,71 +495,6 @@ mod tests {
         assert_eq!(rr.strobe2_offset(), offset as usize);
     }
 
-    fn syncmers_of(seq: &[u8], parameters: &SyncmerParameters) -> Vec<Syncmer> {
-        SyncmerIterator::new(seq, parameters.k, parameters.s, parameters.t).collect()
-    }
-
-    #[test]
-    fn test_canonical_syncmers() {
-        let parameters = SyncmerParameters::try_new(20, 16).unwrap();
-        let f = File::open("tests/phix.fasta").unwrap();
-        let mut reader = BufReader::new(f);
-        let records = read_fasta(&mut reader).unwrap();
-        let seqs = vec![
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".as_bytes(),
-            &records[0].sequence,
-        ];
-        for seq in seqs {
-            let seq_revcomp = reverse_complement(seq);
-            let syncmers_forward = syncmers_of(seq, &parameters);
-            let mut syncmers_reverse = syncmers_of(&seq_revcomp, &parameters);
-            syncmers_reverse.reverse();
-            for syncmer_rev in &mut syncmers_reverse {
-                syncmer_rev.position = seq.len() - parameters.k - syncmer_rev.position;
-            }
-            assert_eq!(syncmers_forward.len(), syncmers_reverse.len());
-            for (sf, sr) in syncmers_forward.iter().zip(syncmers_reverse.iter()) {
-                assert_eq!(sf.hash(), sr.hash());
-                assert_eq!(sf.position, sr.position);
-                assert_ne!(sf.is_forward(), sr.is_forward());
-            }
-        }
-    }
-
-    #[test]
-    fn test_pick_bits() {
-        let parameters = SyncmerParameters::try_new(20, 16).unwrap();
-        assert_eq!(parameters.pick_bits(0), 8);
-    }
-
-    pub fn read_ref<P: AsRef<Path>>(path: P) -> Vec<RefSequence> {
-        let f = File::open(path).unwrap();
-        let mut reader = BufReader::new(f);
-
-        read_fasta(&mut reader).unwrap()
-    }
-
-    #[test]
-    fn test_index_phix() {
-        let references = read_ref("tests/phix.fasta");
-        let parameters = SeedingParameters::new(150);
-        let mut index = StrobemerIndex::new(&references, parameters, None);
-        let stats = index.populate(0.1, 1);
-        assert!(stats.distinct_strobemers > 0);
-    }
-
-    #[test]
-    fn test_index_empty_reference() {
-        let references = vec![RefSequence {
-            name: "name".to_string(),
-            sequence: vec![],
-        }];
-        let parameters = SeedingParameters::new(150);
-        let mut index = StrobemerIndex::new(&references, parameters, None);
-        let stats = index.populate(0.1, 1);
-        assert_eq!(stats.distinct_strobemers, 0);
-    }
-
     #[test]
     fn test_sti_parameters_mismatch() {
         use temp_dir::TempDir;
@@ -917,53 +506,18 @@ mod tests {
         let references = read_fasta(&mut BufReader::new(f)).unwrap();
 
         let parameters = SeedingParameters::new(300);
-        let mut index = StrobemerIndex::new(&references, parameters, None);
-        index.populate(0.0002, 1);
+        let index = make_index(&references, parameters, None, 0.0002, 1).0;
         let sti_path = dir.path().join("index.sti");
         index.write(&sti_path).unwrap();
 
-        let mut other_index = StrobemerIndex::new(&references, SeedingParameters::new(50), None);
+        let read_index_result =
+            read_index(&sti_path, &references, SeedingParameters::new(50), None);
 
-        match other_index.read(&sti_path) {
+        match read_index_result {
             Err(IndexReadingError::ParameterMismatch) => {}
             _ => {
                 panic!("Parameters are expected not to match");
             }
-        }
-    }
-
-    #[test]
-    fn test_partial_orientation() {
-        let references = read_ref("tests/phix.fasta");
-        let seq = &references[0].sequence;
-        let rc_seq = reverse_complement(seq);
-        let rc_references = vec![RefSequence {
-            name: "phix_rc".to_string(),
-            sequence: rc_seq,
-        }];
-
-        let parameters = SeedingParameters::new(300);
-
-        let mut fwd_index = StrobemerIndex::new(&references, parameters.clone(), None);
-        fwd_index.populate(0.0000001, 1);
-
-        let mut rc_index = StrobemerIndex::new(&rc_references, parameters.clone(), None);
-        rc_index.populate(0.0000001, 1);
-
-        assert_eq!(fwd_index.randstrobes.len(), rc_index.randstrobes.len());
-
-        // Iterate over fwd index entries and look up each hash in the rc index
-        for i in 0..fwd_index.randstrobes.len() {
-            let fwd_hash = fwd_index.randstrobes[i].hash();
-
-            let rev_pos_result = rc_index.get_partial(fwd_hash);
-            assert!(rev_pos_result.is_some());
-            let rev_pos = rev_pos_result.unwrap();
-
-            let rc_partial_query = fwd_index.randstrobes[i].hash()
-                ^ ((1 as u64) << rc_index.parameters.randstrobe.partial_orientation_pos);
-            let rev_pos_forward = rc_index.get_partial_forward_from(rc_partial_query, rev_pos);
-            assert!(rev_pos_forward.is_some());
         }
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -79,8 +79,6 @@ pub struct StrobemerIndex<'a> {
     /// Filter partial seeds that occur more often than this
     partial_filter_cutoff: usize,
 
-    rescue_cutoff: usize,
-
     /// The randstrobes vector contains all randstrobes sorted by hash.
     /// The randstrobe_start_indices vector points to entries in the
     /// randstrobes vector. `randstrobe_start_indices[x]` is the index of the
@@ -100,7 +98,6 @@ impl<'a> StrobemerIndex<'a> {
         bits: u8,
         filter_cutoff: usize,
         partial_filter_cutoff: usize,
-        rescue_cutoff: usize,
         randstrobes: Vec<RefRandstrobe>,
         randstrobe_start_indices: Vec<BucketIndex>,
     ) -> Self {
@@ -110,7 +107,6 @@ impl<'a> StrobemerIndex<'a> {
             bits,
             filter_cutoff,
             partial_filter_cutoff,
-            rescue_cutoff,
             randstrobes,
             randstrobe_start_indices,
         }
@@ -118,10 +114,6 @@ impl<'a> StrobemerIndex<'a> {
 
     pub fn filter_cutoff(&self) -> usize {
         self.filter_cutoff
-    }
-
-    pub fn rescue_cutoff(&self) -> usize {
-        self.rescue_cutoff
     }
 
     // Find the first entry that matches the forwald full hash (including orientation bits)
@@ -399,7 +391,6 @@ pub fn read_index<'a, P: AsRef<Path>>(
     reader.read_exact(&mut buf)?;
 
     let filter_cutoff = read_u32(&mut reader)? as usize;
-    let rescue_cutoff = filter_cutoff;
     let sti_bits = read_u32(&mut reader)? as u8;
     if sti_bits != bits {
         return Err(IndexReadingError::ParameterMismatch);
@@ -452,7 +443,6 @@ pub fn read_index<'a, P: AsRef<Path>>(
         bits,
         filter_cutoff,
         partial_filter_cutoff: filter_cutoff,
-        rescue_cutoff,
         randstrobes,
         randstrobe_start_indices,
     })

--- a/src/index.rs
+++ b/src/index.rs
@@ -75,9 +75,6 @@ pub struct StrobemerIndex {
     /// this (see StrobemerIndex::is_too_frequent())
     filter_cutoff: usize,
 
-    /// Filter partial seeds that occur more often than this
-    partial_filter_cutoff: usize,
-
     /// The randstrobes vector contains all randstrobes sorted by hash.
     /// The randstrobe_start_indices vector points to entries in the
     /// randstrobes vector. `randstrobe_start_indices[x]` is the index of the
@@ -95,7 +92,6 @@ impl StrobemerIndex {
         parameters: SeedingParameters,
         bits: u8,
         filter_cutoff: usize,
-        partial_filter_cutoff: usize,
         randstrobes: Vec<RefRandstrobe>,
         randstrobe_start_indices: Vec<BucketIndex>,
     ) -> Self {
@@ -103,7 +99,6 @@ impl StrobemerIndex {
             parameters,
             bits,
             filter_cutoff,
-            partial_filter_cutoff,
             randstrobes,
             randstrobe_start_indices,
         }
@@ -438,7 +433,6 @@ pub fn read_index<'a, P: AsRef<Path>>(
         parameters,
         bits,
         filter_cutoff,
-        partial_filter_cutoff: filter_cutoff,
         randstrobes,
         randstrobe_start_indices,
     })

--- a/src/index.rs
+++ b/src/index.rs
@@ -65,8 +65,7 @@ impl RefRandstrobe {
     }
 }
 
-pub struct StrobemerIndex<'a> {
-    references: &'a [RefSequence],
+pub struct StrobemerIndex {
     pub parameters: SeedingParameters,
 
     /// no. of bits of the hash to use when indexing a randstrobe bucket
@@ -91,9 +90,8 @@ pub struct StrobemerIndex<'a> {
     randstrobe_start_indices: Vec<BucketIndex>,
 }
 
-impl<'a> StrobemerIndex<'a> {
+impl StrobemerIndex {
     pub fn new(
-        references: &'a [RefSequence],
         parameters: SeedingParameters,
         bits: u8,
         filter_cutoff: usize,
@@ -102,7 +100,6 @@ impl<'a> StrobemerIndex<'a> {
         randstrobe_start_indices: Vec<BucketIndex>,
     ) -> Self {
         StrobemerIndex {
-            references,
             parameters,
             bits,
             filter_cutoff,
@@ -317,7 +314,7 @@ pub enum IndexReadingError {
     InvalidIndexParameter(#[from] InvalidSeedingParameter),
 }
 
-impl<'a> StrobemerIndex<'a> {
+impl StrobemerIndex {
     pub fn write<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
         let mut file = File::create(path)?;
 
@@ -361,7 +358,7 @@ pub fn read_index<'a, P: AsRef<Path>>(
     references: &'a [RefSequence],
     parameters: SeedingParameters,
     bits: Option<u8>,
-) -> Result<StrobemerIndex<'a>, IndexReadingError> {
+) -> Result<StrobemerIndex, IndexReadingError> {
     // TODO these two lines are duplicated in make_index
     let total_reference_length = references.iter().map(|r| r.sequence.len()).sum();
     let bits = bits.unwrap_or_else(|| parameters.syncmer.pick_bits(total_reference_length));
@@ -438,7 +435,6 @@ pub fn read_index<'a, P: AsRef<Path>>(
     }
 
     Ok(StrobemerIndex {
-        references,
         parameters,
         bits,
         filter_cutoff,

--- a/src/index.rs
+++ b/src/index.rs
@@ -180,11 +180,9 @@ fn count_all_randstrobes(
     mutex.into_inner().unwrap()
 }
 
-// TODO UnpopulatedStrobemerIndex
 pub struct StrobemerIndex<'a> {
     references: &'a [RefSequence],
     pub parameters: SeedingParameters,
-    pub stats: IndexCreationStatistics,
 
     /// no. of bits of the hash to use when indexing a randstrobe bucket
     pub bits: u8,
@@ -220,13 +218,11 @@ impl<'a> StrobemerIndex<'a> {
         let bits = bits.unwrap_or_else(|| parameters.syncmer.pick_bits(total_reference_length));
         let randstrobes = vec![];
         let randstrobe_start_indices = vec![];
-        let stats = IndexCreationStatistics::default();
         let filter_cutoff = 0;
         let rescue_cutoff = 0;
         StrobemerIndex {
             references,
             parameters,
-            stats,
             bits,
             filter_cutoff,
             partial_filter_cutoff: filter_cutoff,
@@ -236,14 +232,15 @@ impl<'a> StrobemerIndex<'a> {
         }
     }
 
-    pub fn populate(&mut self, filter_fraction: f64, n_threads: usize) {
+    pub fn populate(&mut self, filter_fraction: f64, n_threads: usize) -> IndexCreationStatistics {
         let timer = Instant::now();
         let randstrobe_counts = count_all_randstrobes(self.references, &self.parameters, n_threads);
         debug!("  Counting hashes: {:.2} s", timer.elapsed().as_secs_f64());
         // stats.elapsed_counting_hashes = count_hash.duration();
+        let mut stats = IndexCreationStatistics::default();
 
         let total_randstrobes: usize = randstrobe_counts.iter().sum();
-        self.stats.tot_strobemer_count = total_randstrobes as u64;
+        stats.tot_strobemer_count = total_randstrobes as u64;
 
         debug!("  Total number of randstrobes: {}", total_randstrobes);
         let total_length: usize = self
@@ -298,7 +295,7 @@ impl<'a> StrobemerIndex<'a> {
         let mut tot_mid_ab = 0;
         let mut strobemer_counts = Vec::<usize>::new();
 
-        self.stats.tot_occur_once = 0;
+        stats.tot_occur_once = 0;
         self.randstrobe_start_indices
             .reserve((1usize << self.bits) + 1);
 
@@ -323,7 +320,7 @@ impl<'a> StrobemerIndex<'a> {
             unique_mers += 1;
 
             if count == 1 {
-                self.stats.tot_occur_once += 1;
+                stats.tot_occur_once += 1;
             } else {
                 if count > 100 {
                     tot_high_ab += 1;
@@ -341,7 +338,7 @@ impl<'a> StrobemerIndex<'a> {
         }
         // wrap up last entry
         if count == 1 {
-            self.stats.tot_occur_once += 1;
+            stats.tot_occur_once += 1;
         } else {
             if count > 100 {
                 tot_high_ab += 1;
@@ -354,13 +351,13 @@ impl<'a> StrobemerIndex<'a> {
             self.randstrobe_start_indices
                 .push(self.randstrobes.len() as BucketIndex);
         }
-        self.stats.tot_high_ab = tot_high_ab;
-        self.stats.tot_mid_ab = tot_mid_ab;
+        stats.tot_high_ab = tot_high_ab;
+        stats.tot_mid_ab = tot_mid_ab;
 
         strobemer_counts.sort_unstable_by_key(|k| Reverse(*k));
 
         let index_cutoff = (unique_mers as f64 * filter_fraction) as usize;
-        self.stats.index_cutoff = index_cutoff;
+        stats.index_cutoff = index_cutoff;
         let filter_cutoff = if index_cutoff < strobemer_counts.len() {
             strobemer_counts[index_cutoff]
         } else {
@@ -378,7 +375,9 @@ impl<'a> StrobemerIndex<'a> {
         self.rescue_cutoff = min(self.filter_cutoff * 2, 1000);
         //stats.elapsed_hash_index = hash_index_timer.duration();
         debug!("    Took {:.2} s", timer.elapsed().as_secs_f64());
-        self.stats.distinct_strobemers = unique_mers;
+        stats.distinct_strobemers = unique_mers;
+
+        stats
     }
 
     /*
@@ -891,8 +890,8 @@ mod tests {
         let references = read_ref("tests/phix.fasta");
         let parameters = SeedingParameters::new(150);
         let mut index = StrobemerIndex::new(&references, parameters, None);
-        index.populate(0.1, 1);
-        assert!(index.stats.distinct_strobemers > 0);
+        let stats = index.populate(0.1, 1);
+        assert!(stats.distinct_strobemers > 0);
     }
 
     #[test]
@@ -903,8 +902,8 @@ mod tests {
         }];
         let parameters = SeedingParameters::new(150);
         let mut index = StrobemerIndex::new(&references, parameters, None);
-        index.populate(0.1, 1);
-        assert_eq!(index.stats.distinct_strobemers, 0);
+        let stats = index.populate(0.1, 1);
+        assert_eq!(stats.distinct_strobemers, 0);
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -66,20 +66,20 @@ impl RefRandstrobe {
 }
 
 pub struct StrobemerIndex<'a> {
-    pub references: &'a [RefSequence],
+    references: &'a [RefSequence],
     pub parameters: SeedingParameters,
 
     /// no. of bits of the hash to use when indexing a randstrobe bucket
-    pub bits: u8,
+    bits: u8,
 
     /// Regular (non-rescue) NAM finding ignores randstrobes that occur more often than
     /// this (see StrobemerIndex::is_too_frequent())
-    pub filter_cutoff: usize,
+    filter_cutoff: usize,
 
     /// Filter partial seeds that occur more often than this
-    pub partial_filter_cutoff: usize,
+    partial_filter_cutoff: usize,
 
-    pub rescue_cutoff: usize,
+    rescue_cutoff: usize,
 
     /// The randstrobes vector contains all randstrobes sorted by hash.
     /// The randstrobe_start_indices vector points to entries in the
@@ -90,10 +90,40 @@ pub struct StrobemerIndex<'a> {
     /// randstrobe_start_indices has one extra guard entry at the end that
     /// is always randstrobes.len().
     pub randstrobes: Vec<RefRandstrobe>,
-    pub randstrobe_start_indices: Vec<BucketIndex>,
+    randstrobe_start_indices: Vec<BucketIndex>,
 }
 
 impl<'a> StrobemerIndex<'a> {
+    pub fn new(
+        references: &'a [RefSequence],
+        parameters: SeedingParameters,
+        bits: u8,
+        filter_cutoff: usize,
+        partial_filter_cutoff: usize,
+        rescue_cutoff: usize,
+        randstrobes: Vec<RefRandstrobe>,
+        randstrobe_start_indices: Vec<BucketIndex>,
+    ) -> Self {
+        StrobemerIndex {
+            references,
+            parameters,
+            bits,
+            filter_cutoff,
+            partial_filter_cutoff,
+            rescue_cutoff,
+            randstrobes,
+            randstrobe_start_indices,
+        }
+    }
+
+    pub fn filter_cutoff(&self) -> usize {
+        self.filter_cutoff
+    }
+
+    pub fn rescue_cutoff(&self) -> usize {
+        self.rescue_cutoff
+    }
+
     // Find the first entry that matches the forwald full hash (including orientation bits)
     pub fn get_full_forward(&self, hash: RandstrobeHash) -> Option<usize> {
         self.get_masked(hash, REF_RANDSTROBE_HASH_MASK)
@@ -477,6 +507,7 @@ mod tests {
 
     use crate::indexer::make_index;
     use crate::io::fasta::read_ref;
+    use crate::revcomp::reverse_complement;
 
     #[test]
     fn test_ref_randstrobe() {
@@ -514,6 +545,39 @@ mod tests {
             _ => {
                 panic!("Parameters are expected not to match");
             }
+        }
+    }
+
+    #[test]
+    fn test_partial_orientation() {
+        let references = read_ref("tests/phix.fasta").unwrap();
+        let seq = &references[0].sequence;
+        let rc_seq = reverse_complement(seq);
+        let rc_references = vec![RefSequence {
+            name: "phix_rc".to_string(),
+            sequence: rc_seq,
+        }];
+
+        let parameters = SeedingParameters::new(300);
+
+        let (fwd_index, _stats) = make_index(&references, parameters.clone(), None, 0.0000001, 1);
+
+        let (rc_index, _stats) = make_index(&rc_references, parameters.clone(), None, 0.0000001, 1);
+
+        assert_eq!(fwd_index.randstrobes.len(), rc_index.randstrobes.len());
+
+        // Iterate over fwd index entries and look up each hash in the rc index
+        for i in 0..fwd_index.randstrobes.len() {
+            let fwd_hash = fwd_index.randstrobes[i].hash();
+
+            let rev_pos_result = rc_index.get_partial(fwd_hash);
+            assert!(rev_pos_result.is_some());
+            let rev_pos = rev_pos_result.unwrap();
+
+            let rc_partial_query = fwd_index.randstrobes[i].hash()
+                ^ ((1 as u64) << rc_index.parameters.randstrobe.partial_orientation_pos);
+            let rev_pos_forward = rc_index.get_partial_forward_from(rc_partial_query, rev_pos);
+            assert!(rev_pos_forward.is_some());
         }
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -2,7 +2,7 @@ use crate::index::{BucketIndex, RandstrobeHash, RefRandstrobe, StrobemerIndex};
 use crate::io::fasta::RefSequence;
 use crate::seeding::{RandstrobeIterator, SeedingParameters, SyncmerIterator, SyncmerParameters};
 
-use std::cmp::{Reverse, min};
+use std::cmp::Reverse;
 use std::fmt::{Display, Formatter};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -154,7 +154,6 @@ pub fn make_index<'a>(
         30, // cutoff is around 30-50 on hg38. No reason to have a lower cutoff than this if aligning to a smaller genome or contigs.
         100, // limit upper cutoff for normal NAM finding - use rescue mode instead
     );
-    let rescue_cutoff = min(filter_cutoff * 2, 1000);
     //stats.elapsed_hash_index = hash_index_timer.duration();
     debug!("    Took {:.2} s", timer.elapsed().as_secs_f64());
     stats.distinct_strobemers = unique_mers;
@@ -166,7 +165,6 @@ pub fn make_index<'a>(
             bits,
             filter_cutoff,
             filter_cutoff,
-            rescue_cutoff,
             randstrobes,
             randstrobe_start_indices,
         ),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -20,7 +20,7 @@ pub fn make_index<'a>(
     bits: Option<u8>,
     filter_fraction: f64,
     n_threads: usize,
-) -> (StrobemerIndex<'a>, IndexCreationStatistics) {
+) -> (StrobemerIndex, IndexCreationStatistics) {
     let total_reference_length = references.iter().map(|r| r.sequence.len()).sum();
     let bits = bits.unwrap_or_else(|| parameters.syncmer.pick_bits(total_reference_length));
 
@@ -160,7 +160,6 @@ pub fn make_index<'a>(
 
     (
         StrobemerIndex::new(
-            references,
             parameters,
             bits,
             filter_cutoff,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -364,11 +364,9 @@ impl Display for IndexCreationStatistics {
 
 #[cfg(test)]
 mod test {
-    use std::{fs::File, io::BufReader, path::Path};
-
     use crate::{
         indexer::make_index,
-        io::fasta::{RefSequence, read_fasta},
+        io::fasta::{RefSequence, read_ref},
         revcomp::reverse_complement,
         seeding::{SeedingParameters, SyncmerParameters},
     };
@@ -378,16 +376,10 @@ mod test {
         let parameters = SyncmerParameters::try_new(20, 16).unwrap();
         assert_eq!(parameters.pick_bits(0), 8);
     }
-    pub fn read_ref<P: AsRef<Path>>(path: P) -> Vec<RefSequence> {
-        let f = File::open(path).unwrap();
-        let mut reader = BufReader::new(f);
-
-        read_fasta(&mut reader).unwrap()
-    }
 
     #[test]
     fn test_index_phix() {
-        let references = read_ref("tests/phix.fasta");
+        let references = read_ref("tests/phix.fasta").unwrap();
         let parameters = SeedingParameters::new(150);
         let (_index, stats) = make_index(&references, parameters, None, 0.1, 1);
         assert!(stats.distinct_strobemers > 0);
@@ -406,7 +398,7 @@ mod test {
 
     #[test]
     fn test_partial_orientation() {
-        let references = read_ref("tests/phix.fasta");
+        let references = read_ref("tests/phix.fasta").unwrap();
         let seq = &references[0].sequence;
         let rc_seq = reverse_complement(seq);
         let rc_references = vec![RefSequence {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -163,7 +163,6 @@ pub fn make_index<'a>(
             parameters,
             bits,
             filter_cutoff,
-            filter_cutoff,
             randstrobes,
             randstrobe_start_indices,
         ),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,0 +1,439 @@
+use crate::index::{BucketIndex, RandstrobeHash, RefRandstrobe, StrobemerIndex};
+use crate::io::fasta::RefSequence;
+use crate::seeding::{RandstrobeIterator, SeedingParameters, SyncmerIterator, SyncmerParameters};
+
+use std::cmp::{Reverse, min};
+use std::fmt::{Display, Formatter};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Instant;
+
+use log::{debug, trace};
+use rayon;
+use rayon::slice::ParallelSliceMut;
+
+/// Create a StrobemerIndex
+pub fn make_index<'a>(
+    references: &'a [RefSequence],
+    parameters: SeedingParameters,
+    bits: Option<u8>,
+    filter_fraction: f64,
+    n_threads: usize,
+) -> (StrobemerIndex<'a>, IndexCreationStatistics) {
+    let total_reference_length = references.iter().map(|r| r.sequence.len()).sum();
+    let bits = bits.unwrap_or_else(|| parameters.syncmer.pick_bits(total_reference_length));
+
+    let timer = Instant::now();
+    let randstrobe_counts = count_all_randstrobes(references, &parameters, n_threads);
+    debug!("  Counting hashes: {:.2} s", timer.elapsed().as_secs_f64());
+    // stats.elapsed_counting_hashes = count_hash.duration();
+    let mut stats = IndexCreationStatistics::default();
+
+    let total_randstrobes: usize = randstrobe_counts.iter().sum();
+    stats.tot_strobemer_count = total_randstrobes as u64;
+
+    debug!("  Total number of randstrobes: {}", total_randstrobes);
+    let total_length: usize = references.iter().map(|refseq| refseq.sequence.len()).sum();
+    let memory_bytes: usize = total_length
+        + size_of::<RefRandstrobe>() * total_randstrobes
+        + size_of::<BucketIndex>() * (1usize << bits);
+    debug!(
+        "  Estimated total memory usage: {:.1} GB",
+        memory_bytes as f64 / 1E9
+    );
+
+    if total_randstrobes > BucketIndex::MAX as usize {
+        panic!("Too many randstrobes");
+    }
+    let timer = Instant::now();
+    debug!("  Generating randstrobes ...");
+    let mut randstrobes =
+        make_randstrobes_parallel(references, &parameters, &randstrobe_counts, n_threads);
+    debug!("  Generating seeds: {:.2} s", timer.elapsed().as_secs_f64());
+    // stats.elapsed_generating_seeds = randstrobes_timer.duration();
+
+    let timer = Instant::now();
+    debug!("  Sorting ...");
+    // TODO
+    // ensure comparison function is branchless
+    // Comment from C++ code:
+    // Compare both hash and position to ensure that the order of the
+    // RefRandstrobes in the index is reproducible no matter which sorting
+    // function is used. This branchless comparison is faster than the
+    // equivalent one using std::tie.
+    // __uint128_t lhs = (static_cast<__uint128_t>(m_hash_offset_flag) << 64) | ((static_cast<uint64_t>(m_position) << 32) | m_ref_index);
+    // __uint128_t rhs = (static_cast<__uint128_t>(other.m_hash_offset_flag) << 64) | ((static_cast<uint64_t>(other.m_position) << 32) | m_ref_index);
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(n_threads)
+        .build()
+        .unwrap();
+    pool.install(|| randstrobes.par_sort_unstable());
+
+    debug!("    Took {:.2} s", timer.elapsed().as_secs_f64());
+    // stats.elapsed_sorting_seeds = sorting_timer.duration();
+
+    let timer = Instant::now();
+    debug!("  Generating hash table index ...");
+
+    let mut tot_high_ab = 0;
+    let mut tot_mid_ab = 0;
+    let mut strobemer_counts = Vec::<usize>::new();
+
+    stats.tot_occur_once = 0;
+    let mut randstrobe_start_indices = Vec::with_capacity((1usize << bits) + 1);
+    let mut unique_mers = u64::from(!randstrobes.is_empty());
+
+    let mut prev_hash: RandstrobeHash = if randstrobes.is_empty() {
+        0
+    } else {
+        randstrobes[0].hash()
+    };
+    let mut count = 1;
+
+    if !randstrobes.is_empty() {
+        randstrobe_start_indices.push(0);
+    }
+    for position in 1..randstrobes.len() {
+        let cur_hash = randstrobes[position].hash();
+        if cur_hash == prev_hash {
+            count += 1;
+            continue;
+        }
+        unique_mers += 1;
+
+        if count == 1 {
+            stats.tot_occur_once += 1;
+        } else {
+            if count > 100 {
+                tot_high_ab += 1;
+            } else {
+                tot_mid_ab += 1;
+            }
+            strobemer_counts.push(count);
+        }
+        count = 1;
+        let cur_hash_n = cur_hash >> (64 - bits);
+        while randstrobe_start_indices.len() <= cur_hash_n as usize {
+            randstrobe_start_indices.push(position as BucketIndex);
+        }
+        prev_hash = cur_hash;
+    }
+    // wrap up last entry
+    if count == 1 {
+        stats.tot_occur_once += 1;
+    } else {
+        if count > 100 {
+            tot_high_ab += 1;
+        } else {
+            tot_mid_ab += 1;
+        }
+        strobemer_counts.push(count);
+    }
+    while randstrobe_start_indices.len() < ((1usize << bits) + 1) {
+        randstrobe_start_indices.push(randstrobes.len() as BucketIndex);
+    }
+    stats.tot_high_ab = tot_high_ab;
+    stats.tot_mid_ab = tot_mid_ab;
+
+    strobemer_counts.sort_unstable_by_key(|k| Reverse(*k));
+
+    let index_cutoff = (unique_mers as f64 * filter_fraction) as usize;
+    stats.index_cutoff = index_cutoff;
+    let filter_cutoff = if index_cutoff < strobemer_counts.len() {
+        strobemer_counts[index_cutoff]
+    } else {
+        *strobemer_counts.last().unwrap_or(&30)
+    };
+    trace!(
+        "Filter cutoff before clamping to [30, 100]: {}",
+        filter_cutoff
+    );
+    let filter_cutoff = usize::clamp(
+        filter_cutoff,
+        30, // cutoff is around 30-50 on hg38. No reason to have a lower cutoff than this if aligning to a smaller genome or contigs.
+        100, // limit upper cutoff for normal NAM finding - use rescue mode instead
+    );
+    let rescue_cutoff = min(filter_cutoff * 2, 1000);
+    //stats.elapsed_hash_index = hash_index_timer.duration();
+    debug!("    Took {:.2} s", timer.elapsed().as_secs_f64());
+    stats.distinct_strobemers = unique_mers;
+
+    (
+        StrobemerIndex {
+            references,
+            parameters,
+            bits,
+            filter_cutoff,
+            partial_filter_cutoff: filter_cutoff,
+            rescue_cutoff,
+            randstrobes,
+            randstrobe_start_indices,
+        },
+        stats,
+    )
+}
+
+/*
+    fn make_randstrobes(&self, randstrobe_counts: &[usize]) -> Vec<RefRandstrobe> {
+        let mut randstrobes = vec![RefRandstrobe::default(); randstrobe_counts.iter().sum()];
+
+        // Fill randstrobes vector
+        let mut offset = 0;
+        for ref_index in 0..self.references.len() {
+            self.assign_randstrobes(ref_index, &mut randstrobes[offset..offset+randstrobe_counts[ref_index]]);
+            offset += randstrobe_counts[ref_index];
+        }
+        randstrobes
+    }
+*/
+
+fn make_randstrobes_parallel(
+    references: &[RefSequence],
+    parameters: &SeedingParameters,
+    randstrobe_counts: &[usize],
+    n_threads: usize,
+) -> Vec<RefRandstrobe> {
+    let mut randstrobes = vec![RefRandstrobe::default(); randstrobe_counts.iter().sum()];
+    let mut slices = vec![];
+    {
+        let mut slice = &mut randstrobes[..];
+        for &mid in randstrobe_counts.iter().take(references.len() - 1) {
+            let (left, right) = slice.split_at_mut(mid);
+            slices.push(Arc::new(Mutex::new(left)));
+            slice = right;
+        }
+        slices.push(Arc::new(Mutex::new(slice)));
+    }
+    let ref_index = AtomicUsize::new(0);
+    thread::scope(|s| {
+        for _ in 0..n_threads {
+            s.spawn(|| {
+                loop {
+                    let j = ref_index.fetch_add(1, Ordering::SeqCst);
+                    if j >= references.len() {
+                        break;
+                    }
+                    assign_randstrobes(references, parameters, j, *slices[j].lock().unwrap());
+                }
+            });
+        }
+    });
+
+    randstrobes
+}
+
+/// Compute randstrobes of one reference contig and assign them to the provided slice
+fn assign_randstrobes(
+    references: &[RefSequence],
+    parameters: &SeedingParameters,
+    ref_index: usize,
+    randstrobes: &mut [RefRandstrobe],
+) {
+    let seq = &references[ref_index].sequence;
+    if seq.len() < parameters.randstrobe.w_max {
+        return;
+    }
+    let syncmer_iter = SyncmerIterator::new(
+        seq,
+        parameters.syncmer.k,
+        parameters.syncmer.s,
+        parameters.syncmer.t,
+    );
+
+    let randstrobe_iter = RandstrobeIterator::new(syncmer_iter, parameters.randstrobe.clone());
+
+    let mut n = 0;
+    for (i, randstrobe) in randstrobe_iter.enumerate() {
+        n += 1;
+        let offset = randstrobe.strobe2_pos - randstrobe.strobe1_pos;
+        randstrobes[i] = RefRandstrobe::new(
+            randstrobe.hash,
+            ref_index as u32,
+            randstrobe.strobe1_pos as u32,
+            offset as u8,
+        );
+    }
+    debug_assert_eq!(n, randstrobes.len());
+}
+
+fn count_all_randstrobes(
+    references: &[RefSequence],
+    parameters: &SeedingParameters,
+    n_threads: usize,
+) -> Vec<usize> {
+    let counts = vec![0; references.len()];
+    let mutex = Mutex::new(counts);
+    let ref_index = AtomicUsize::new(0);
+    thread::scope(|s| {
+        for _ in 0..n_threads {
+            s.spawn(|| {
+                loop {
+                    let j = ref_index.fetch_add(1, Ordering::SeqCst);
+                    if j >= references.len() {
+                        break;
+                    }
+                    let count = count_randstrobes(&references[j].sequence, parameters);
+                    mutex.lock().unwrap()[j] = count;
+                }
+            });
+        }
+    });
+
+    mutex.into_inner().unwrap()
+}
+
+/// Count randstrobes by counting syncmers
+fn count_randstrobes(seq: &[u8], parameters: &SeedingParameters) -> usize {
+    let syncmer_iterator = SyncmerIterator::new(
+        seq,
+        parameters.syncmer.k,
+        parameters.syncmer.s,
+        parameters.syncmer.t,
+    );
+
+    syncmer_iterator.count()
+}
+
+impl SyncmerParameters {
+    /// Pick a suitable number of bits for indexing randstrobe start indices
+    pub fn pick_bits(&self, size: usize) -> u8 {
+        let estimated_number_of_randstrobes = size / (self.k - self.s + 1) + 1;
+        // Two randstrobes per bucket on average
+        // TOOD checked_ilog2 or ilog2
+        ((estimated_number_of_randstrobes as f64).log2() as u32).clamp(9, 32) as u8 - 1
+    }
+}
+
+#[derive(Default)]
+pub struct IndexCreationStatistics {
+    tot_strobemer_count: u64,
+    tot_occur_once: u64,
+    tot_high_ab: u64,
+    tot_mid_ab: u64,
+    index_cutoff: usize,
+    distinct_strobemers: u64,
+}
+
+impl Display for IndexCreationStatistics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Index statistics")?;
+        writeln!(f, "  Total strobemers:    {:14}", self.tot_strobemer_count)?;
+        writeln!(
+            f,
+            "  Distinct strobemers: {:14} (100.00%)",
+            self.distinct_strobemers
+        )?;
+        writeln!(
+            f,
+            "    1 occurrence:      {:14} ({:6.2}%)",
+            self.tot_occur_once,
+            100.0 * self.tot_occur_once as f64 / self.distinct_strobemers as f64
+        )?;
+        writeln!(
+            f,
+            "    2..100 occurrences:{:14} ({:6.2}%)",
+            self.tot_mid_ab,
+            100.0 * self.tot_mid_ab as f64 / self.distinct_strobemers as f64
+        )?;
+        writeln!(
+            f,
+            "    >100 occurrences:  {:14} ({:6.2}%)",
+            self.tot_high_ab,
+            100.0 * self.tot_high_ab as f64 / self.distinct_strobemers as f64
+        )?;
+        if self.tot_high_ab >= 1 {
+            writeln!(
+                f,
+                "Ratio distinct to highly abundant: {}",
+                self.distinct_strobemers / self.tot_high_ab
+            )?;
+        }
+        if self.tot_mid_ab >= 1 {
+            writeln!(
+                f,
+                "Ratio distinct to non distinct: {}",
+                self.distinct_strobemers / (self.tot_high_ab + self.tot_mid_ab)
+            )?;
+        }
+        write!(f, "Filtered cutoff index: {}", self.index_cutoff)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{fs::File, io::BufReader, path::Path};
+
+    use crate::{
+        indexer::make_index,
+        io::fasta::{RefSequence, read_fasta},
+        revcomp::reverse_complement,
+        seeding::{SeedingParameters, SyncmerParameters},
+    };
+
+    #[test]
+    fn test_pick_bits() {
+        let parameters = SyncmerParameters::try_new(20, 16).unwrap();
+        assert_eq!(parameters.pick_bits(0), 8);
+    }
+    pub fn read_ref<P: AsRef<Path>>(path: P) -> Vec<RefSequence> {
+        let f = File::open(path).unwrap();
+        let mut reader = BufReader::new(f);
+
+        read_fasta(&mut reader).unwrap()
+    }
+
+    #[test]
+    fn test_index_phix() {
+        let references = read_ref("tests/phix.fasta");
+        let parameters = SeedingParameters::new(150);
+        let (_index, stats) = make_index(&references, parameters, None, 0.1, 1);
+        assert!(stats.distinct_strobemers > 0);
+    }
+
+    #[test]
+    fn test_index_empty_reference() {
+        let references = vec![RefSequence {
+            name: "name".to_string(),
+            sequence: vec![],
+        }];
+        let parameters = SeedingParameters::new(150);
+        let (_index2, stats) = make_index(&references, parameters, None, 0.1, 1);
+        assert_eq!(stats.distinct_strobemers, 0);
+    }
+
+    #[test]
+    fn test_partial_orientation() {
+        let references = read_ref("tests/phix.fasta");
+        let seq = &references[0].sequence;
+        let rc_seq = reverse_complement(seq);
+        let rc_references = vec![RefSequence {
+            name: "phix_rc".to_string(),
+            sequence: rc_seq,
+        }];
+
+        let parameters = SeedingParameters::new(300);
+
+        let (fwd_index, _stats) = make_index(&references, parameters.clone(), None, 0.0000001, 1);
+
+        let (rc_index, _stats) = make_index(&rc_references, parameters.clone(), None, 0.0000001, 1);
+
+        assert_eq!(fwd_index.randstrobes.len(), rc_index.randstrobes.len());
+
+        // Iterate over fwd index entries and look up each hash in the rc index
+        for i in 0..fwd_index.randstrobes.len() {
+            let fwd_hash = fwd_index.randstrobes[i].hash();
+
+            let rev_pos_result = rc_index.get_partial(fwd_hash);
+            assert!(rev_pos_result.is_some());
+            let rev_pos = rev_pos_result.unwrap();
+
+            let rc_partial_query = fwd_index.randstrobes[i].hash()
+                ^ ((1 as u64) << rc_index.parameters.randstrobe.partial_orientation_pos);
+            let rev_pos_forward = rc_index.get_partial_forward_from(rc_partial_query, rev_pos);
+            assert!(rev_pos_forward.is_some());
+        }
+    }
+}

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -160,16 +160,16 @@ pub fn make_index<'a>(
     stats.distinct_strobemers = unique_mers;
 
     (
-        StrobemerIndex {
+        StrobemerIndex::new(
             references,
             parameters,
             bits,
             filter_cutoff,
-            partial_filter_cutoff: filter_cutoff,
+            filter_cutoff,
             rescue_cutoff,
             randstrobes,
             randstrobe_start_indices,
-        },
+        ),
         stats,
     )
 }
@@ -364,12 +364,9 @@ impl Display for IndexCreationStatistics {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        indexer::make_index,
-        io::fasta::{RefSequence, read_ref},
-        revcomp::reverse_complement,
-        seeding::{SeedingParameters, SyncmerParameters},
-    };
+    use crate::io::fasta::read_ref;
+
+    use super::*;
 
     #[test]
     fn test_pick_bits() {
@@ -394,38 +391,5 @@ mod test {
         let parameters = SeedingParameters::new(150);
         let (_index2, stats) = make_index(&references, parameters, None, 0.1, 1);
         assert_eq!(stats.distinct_strobemers, 0);
-    }
-
-    #[test]
-    fn test_partial_orientation() {
-        let references = read_ref("tests/phix.fasta").unwrap();
-        let seq = &references[0].sequence;
-        let rc_seq = reverse_complement(seq);
-        let rc_references = vec![RefSequence {
-            name: "phix_rc".to_string(),
-            sequence: rc_seq,
-        }];
-
-        let parameters = SeedingParameters::new(300);
-
-        let (fwd_index, _stats) = make_index(&references, parameters.clone(), None, 0.0000001, 1);
-
-        let (rc_index, _stats) = make_index(&rc_references, parameters.clone(), None, 0.0000001, 1);
-
-        assert_eq!(fwd_index.randstrobes.len(), rc_index.randstrobes.len());
-
-        // Iterate over fwd index entries and look up each hash in the rc index
-        for i in 0..fwd_index.randstrobes.len() {
-            let fwd_hash = fwd_index.randstrobes[i].hash();
-
-            let rev_pos_result = rc_index.get_partial(fwd_hash);
-            assert!(rev_pos_result.is_some());
-            let rev_pos = rev_pos_result.unwrap();
-
-            let rc_partial_query = fwd_index.randstrobes[i].hash()
-                ^ ((1 as u64) << rc_index.parameters.randstrobe.partial_orientation_pos);
-            let rev_pos_forward = rc_index.get_partial_forward_from(rc_partial_query, rev_pos);
-            assert!(rev_pos_forward.is_some());
-        }
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -17,13 +17,10 @@ use rayon::slice::ParallelSliceMut;
 pub fn make_index<'a>(
     references: &'a [RefSequence],
     parameters: SeedingParameters,
-    bits: Option<u8>,
+    bits: u8,
     filter_fraction: f64,
     n_threads: usize,
 ) -> (StrobemerIndex, IndexCreationStatistics) {
-    let total_reference_length = references.iter().map(|r| r.sequence.len()).sum();
-    let bits = bits.unwrap_or_else(|| parameters.syncmer.pick_bits(total_reference_length));
-
     let timer = Instant::now();
     let randstrobe_counts = count_all_randstrobes(references, &parameters, n_threads);
     debug!("  Counting hashes: {:.2} s", timer.elapsed().as_secs_f64());
@@ -293,8 +290,9 @@ fn count_randstrobes(seq: &[u8], parameters: &SeedingParameters) -> usize {
 
 impl SyncmerParameters {
     /// Pick a suitable number of bits for indexing randstrobe start indices
-    pub fn pick_bits(&self, size: usize) -> u8 {
-        let estimated_number_of_randstrobes = size / (self.k - self.s + 1) + 1;
+    pub fn pick_bits(&self, references: &[RefSequence]) -> u8 {
+        let total_length: usize = references.iter().map(|r| r.sequence.len()).sum();
+        let estimated_number_of_randstrobes = total_length / (self.k - self.s + 1) + 1;
         // Two randstrobes per bucket on average
         // TOOD checked_ilog2 or ilog2
         ((estimated_number_of_randstrobes as f64).log2() as u32).clamp(9, 32) as u8 - 1
@@ -367,14 +365,16 @@ mod test {
     #[test]
     fn test_pick_bits() {
         let parameters = SyncmerParameters::try_new(20, 16).unwrap();
-        assert_eq!(parameters.pick_bits(0), 8);
+        let references = read_ref("tests/phix.fasta").unwrap();
+        assert_eq!(parameters.pick_bits(&references), 9);
     }
 
     #[test]
     fn test_index_phix() {
         let references = read_ref("tests/phix.fasta").unwrap();
         let parameters = SeedingParameters::new(150);
-        let (_index, stats) = make_index(&references, parameters, None, 0.1, 1);
+        let bits = parameters.syncmer.pick_bits(&references);
+        let (_index, stats) = make_index(&references, parameters, bits, 0.1, 1);
         assert!(stats.distinct_strobemers > 0);
     }
 
@@ -385,7 +385,8 @@ mod test {
             sequence: vec![],
         }];
         let parameters = SeedingParameters::new(150);
-        let (_index2, stats) = make_index(&references, parameters, None, 0.1, 1);
+        let bits = parameters.syncmer.pick_bits(&references);
+        let (_index2, stats) = make_index(&references, parameters, bits, 0.1, 1);
         assert_eq!(stats.distinct_strobemers, 0);
     }
 }

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -1,4 +1,6 @@
-use std::io::BufRead;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
 
 use crate::io::record::{End, SequenceRecord};
 use crate::io::{SequenceIOError, split_header};
@@ -131,6 +133,13 @@ pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<Vec<RefSequence>, Sequen
     Ok(records)
 }
 
+pub fn read_ref<P: AsRef<Path>>(path: P) -> Result<Vec<RefSequence>, SequenceIOError> {
+    let f = File::open(path).unwrap();
+    let mut reader = BufReader::new(f);
+
+    read_fasta(&mut reader)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,9 +148,7 @@ mod tests {
 
     #[test]
     fn test_read_fasta() {
-        let f = File::open("tests/phix.fasta").unwrap();
-        let mut reader = BufReader::new(f);
-        let records = read_fasta(&mut reader).unwrap();
+        let records = read_ref("tests/phix.fasta").unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].name, "NC_001422.1");
         assert_eq!(records[0].sequence.len(), 5386);
@@ -210,8 +217,7 @@ mod tests {
         let tmp = temp_file::with_contents(
             b">ref1 a comment\nacgt\n\n>ref2\naacc\ngg\n\ntt\n>empty\n>empty_at_end_of_file",
         );
-        let mut reader = BufReader::new(File::open(tmp.path()).unwrap());
-        let records = read_fasta(&mut reader).unwrap();
+        let records = read_ref(tmp.path()).unwrap();
         assert_eq!(records.len(), 4);
         assert_eq!(records[0].name, "ref1");
         assert_eq!(records[0].sequence, b"ACGT");
@@ -243,10 +249,7 @@ mod tests {
 
     #[test]
     fn test_fasta_error_on_fastq() {
-        let f = File::open("tests/phix.1.fastq").unwrap();
-        let mut reader = BufReader::new(f);
-        let result = read_fasta(&mut reader);
-        assert!(result.is_err());
+        assert!(read_ref("tests/phix.1.fastq").is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cigar;
 pub mod details;
 pub mod hit;
 pub mod index;
+pub mod indexer;
 pub mod insertsize;
 pub mod io;
 pub mod maponly;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,14 @@ use clap::builder::styling::AnsiColor;
 use fastrand::Rng;
 use log::{debug, error, info, trace, warn};
 use mimalloc::MiMalloc;
+use strobealign::indexer::make_index;
 use thiserror::Error;
 
 use strobealign::aligner::{Aligner, Scores};
 use strobealign::chainer::{Chainer, ChainingParameters};
 use strobealign::details::Details;
 use strobealign::index::{
-    IndexReadingError, REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES, StrobemerIndex,
+    IndexReadingError, REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES, StrobemerIndex, read_index,
 };
 use strobealign::insertsize::InsertSizeDistribution;
 use strobealign::io::SequenceIOError;
@@ -445,23 +446,24 @@ fn run() -> Result<(), CliError> {
     }
 
     // Create the index
-    let mut index = StrobemerIndex::new(&references, parameters.clone(), args.bits);
     debug!("Auxiliary hash length: {}", args.aux_len);
     info!("Multi-context seed strategy: {}", args.mcs_strategy);
-    info!("Bits used to index buckets: {}", index.bits);
+    //info!("Bits used to index buckets: {}", index.bits);
 
-    if args.use_index {
+    let index = if args.use_index {
         // Read the index from a file
         assert!(!args.create_index);
         let read_index_timer = Instant::now();
         let mut sti_path = args.ref_path.clone();
         sti_path.push_str(&parameters.filename_extension());
         info!("Reading index from {}", sti_path);
-        index.read(&sti_path)?;
+        let index = read_index(&sti_path, &references, parameters.clone(), args.bits)?;
         info!(
             "Total time reading index: {:.2} s",
             read_index_timer.elapsed().as_secs_f64()
         );
+
+        index
     } else {
         let timer = Instant::now();
         let indexing_threads = args.indexing_threads.unwrap_or(args.threads);
@@ -470,14 +472,21 @@ fn run() -> Result<(), CliError> {
             indexing_threads,
             if indexing_threads == 1 { "" } else { "s" }
         );
-        let index_stats = index.populate(args.filter_fraction, indexing_threads);
+        let (index, index_stats) = make_index(
+            &references,
+            parameters.clone(),
+            args.bits,
+            args.filter_fraction,
+            indexing_threads,
+        );
         info!(
             "Total time indexing: {:.2} s",
             timer.elapsed().as_secs_f64()
         );
         debug!("{}", &index_stats);
-    }
-    let index = index;
+
+        index
+    };
     debug!("Filtered cutoff count: {}", index.filter_cutoff);
     debug!("Using rescue cutoff: {}", index.rescue_cutoff);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -848,7 +848,7 @@ enum Mode {
 
 #[derive(Clone)]
 struct Mapper<'a> {
-    index: &'a StrobemerIndex<'a>,
+    index: &'a StrobemerIndex,
     references: &'a [RefSequence],
     mapping_parameters: &'a MappingParameters,
     seeding_parameters: &'a SeedingParameters,

--- a/src/main.rs
+++ b/src/main.rs
@@ -488,7 +488,6 @@ fn run() -> Result<(), CliError> {
         index
     };
     debug!("Filtered cutoff count: {}", index.filter_cutoff());
-    debug!("Using rescue cutoff: {}", index.rescue_cutoff());
 
     if args.create_index {
         let timer = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -487,8 +487,8 @@ fn run() -> Result<(), CliError> {
 
         index
     };
-    debug!("Filtered cutoff count: {}", index.filter_cutoff);
-    debug!("Using rescue cutoff: {}", index.rescue_cutoff);
+    debug!("Filtered cutoff count: {}", index.filter_cutoff());
+    debug!("Using rescue cutoff: {}", index.rescue_cutoff());
 
     if args.create_index {
         let timer = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -470,14 +470,14 @@ fn run() -> Result<(), CliError> {
             indexing_threads,
             if indexing_threads == 1 { "" } else { "s" }
         );
-        index.populate(args.filter_fraction, indexing_threads);
+        let index_stats = index.populate(args.filter_fraction, indexing_threads);
         info!(
             "Total time indexing: {:.2} s",
             timer.elapsed().as_secs_f64()
         );
+        debug!("{}", &index_stats);
     }
     let index = index;
-    debug!("{}", &index.stats);
     debug!("Filtered cutoff count: {}", index.filter_cutoff);
     debug!("Using rescue cutoff: {}", index.rescue_cutoff);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -448,7 +448,10 @@ fn run() -> Result<(), CliError> {
     // Create the index
     debug!("Auxiliary hash length: {}", args.aux_len);
     info!("Multi-context seed strategy: {}", args.mcs_strategy);
-    //info!("Bits used to index buckets: {}", index.bits);
+    let bits = args
+        .bits
+        .unwrap_or_else(|| parameters.syncmer.pick_bits(&references));
+    info!("Bits used to index buckets: {}", bits);
 
     let index = if args.use_index {
         // Read the index from a file
@@ -457,7 +460,7 @@ fn run() -> Result<(), CliError> {
         let mut sti_path = args.ref_path.clone();
         sti_path.push_str(&parameters.filename_extension());
         info!("Reading index from {}", sti_path);
-        let index = read_index(&sti_path, &references, parameters.clone(), args.bits)?;
+        let index = read_index(&sti_path, parameters.clone(), bits)?;
         info!(
             "Total time reading index: {:.2} s",
             read_index_timer.elapsed().as_secs_f64()
@@ -475,7 +478,7 @@ fn run() -> Result<(), CliError> {
         let (index, index_stats) = make_index(
             &references,
             parameters.clone(),
-            args.bits,
+            bits,
             args.filter_fraction,
             indexing_threads,
         );

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -357,7 +357,7 @@ pub fn align_single_end_read(
     let mut alignments_with_best_score = 0;
     let mut best_alignment = None;
 
-    let k = index.parameters.syncmer.k;
+    let k = index.k();
     let read = Read::new(&record.sequence);
     for (tries, nam) in nams
         .iter_mut()

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -179,17 +179,16 @@ impl<SI: Iterator<Item = Syncmer>> Iterator for RandstrobeIterator<SI> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::io::fasta::{RefSequence, read_fasta};
+    use crate::io::fasta::{RefSequence, read_ref};
     use crate::seeding::SeedingParameters;
     use crate::seeding::SyncmerIterator;
-    use std::fs::File;
-    use std::io::BufReader;
 
     fn read_phix() -> RefSequence {
-        let f = File::open("tests/phix.fasta").unwrap();
-        let mut reader = BufReader::new(f);
-
-        read_fasta(&mut reader).unwrap().first().unwrap().clone()
+        read_ref("tests/phix.fasta")
+            .unwrap()
+            .first()
+            .unwrap()
+            .clone()
     }
 
     #[test]

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -235,28 +235,30 @@ mod test {
         assert_eq!(syncmer.position, 0);
     }
 
+    fn syncmers_of(seq: &[u8], parameters: &SyncmerParameters) -> Vec<Syncmer> {
+        SyncmerIterator::new(seq, parameters.k, parameters.s, parameters.t).collect()
+    }
+
     #[test]
     fn test_canonical_syncmers() {
+        let parameters = SyncmerParameters::try_new(20, 16).unwrap();
         let mut f = BufReader::new(File::open("tests/phix.fasta").unwrap());
         let seq = read_fasta(&mut f).unwrap().pop().unwrap().sequence;
         let sequences = ["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into(), seq];
-        let parameters = SyncmerParameters::try_new(20, 16).unwrap();
         for s in sequences {
-            let revcomped = reverse_complement(&s);
-
-            let syncmers_forward: Vec<_> =
-                SyncmerIterator::new(&s, parameters.k, parameters.s, parameters.t).collect();
-
-            let mut syncmers_reverse: Vec<_> =
-                SyncmerIterator::new(&revcomped, parameters.k, parameters.s, parameters.t)
-                    .collect();
+            let seq_revcomp = reverse_complement(&s);
+            let syncmers_forward = syncmers_of(&s, &parameters);
+            let mut syncmers_reverse = syncmers_of(&seq_revcomp, &parameters);
             syncmers_reverse.reverse();
-            for syncmer in &mut syncmers_reverse {
-                syncmer.position = s.len() - parameters.k - syncmer.position;
-                syncmer.toggle_orientation();
+            for syncmer_rev in &mut syncmers_reverse {
+                syncmer_rev.position = s.len() - parameters.k - syncmer_rev.position;
             }
-
-            assert_eq!(syncmers_forward, syncmers_reverse);
+            assert_eq!(syncmers_forward.len(), syncmers_reverse.len());
+            for (sf, sr) in syncmers_forward.iter().zip(syncmers_reverse.iter()) {
+                assert_eq!(sf.hash(), sr.hash());
+                assert_eq!(sf.position, sr.position);
+                assert_ne!(sf.is_forward(), sr.is_forward());
+            }
         }
     }
 }

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -204,9 +204,7 @@ impl Iterator for SyncmerIterator<'_> {
 
 #[cfg(test)]
 mod test {
-    use std::{fs::File, io::BufReader};
-
-    use crate::{io::fasta::read_fasta, revcomp::reverse_complement};
+    use crate::{io::fasta::read_ref, revcomp::reverse_complement};
 
     use super::*;
 
@@ -242,8 +240,11 @@ mod test {
     #[test]
     fn test_canonical_syncmers() {
         let parameters = SyncmerParameters::try_new(20, 16).unwrap();
-        let mut f = BufReader::new(File::open("tests/phix.fasta").unwrap());
-        let seq = read_fasta(&mut f).unwrap().pop().unwrap().sequence;
+        let seq = read_ref("tests/phix.fasta")
+            .unwrap()
+            .pop()
+            .unwrap()
+            .sequence;
         let sequences = ["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into(), seq];
         for s in sequences {
             let seq_revcomp = reverse_complement(&s);


### PR DESCRIPTION
The index.rs file was a bit large, so this splits up index creation and index querying.

Also, it was a bit sketchy that to create an empty StrobemerIndex, one had to do `index = StrobemerIndex::new()` followed by `index.populate()`, so in between those steps, you had a half-initialized index. Now, there is only a `make_index()` function that returns a fully populated index.