### PR TITLE
Introduce IndexEntry for accessing entries in the StrobemerIndex

### DIFF
--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -4,7 +4,7 @@ use log::trace;
 
 use crate::details::NamDetails;
 use crate::hit::{Hit, HitsDetails, find_hits};
-use crate::index::StrobemerIndex;
+use crate::index::{IndexEntry, StrobemerIndex};
 use crate::mcsstrategy::McsStrategy;
 use crate::nam::Nam;
 use crate::seeding::QueryRandstrobe;
@@ -290,11 +290,13 @@ fn add_to_anchors_full(
     query_start: usize,
     query_end: usize,
     index: &StrobemerIndex,
-    position: usize,
+    entry: IndexEntry,
 ) {
     let mut min_length_diff = usize::MAX;
-    let forward_hash = index.randstrobes[position].hash();
-    for randstrobe in &index.randstrobes[position..] {
+    let forward_hash = entry.randstrobe().hash();
+    for i in entry.position..index.len() {
+        let entry = index.entry(i);
+        let randstrobe = entry.randstrobe();
         if randstrobe.hash() != forward_hash {
             break;
         }
@@ -322,17 +324,18 @@ fn add_to_anchors_partial(
     anchors: &mut Vec<Anchor>,
     query_start: usize,
     index: &StrobemerIndex,
-    position: usize,
+    entry: IndexEntry,
 ) {
-    let forward_hash = index.get_hash_partial_forward(position);
-    for pos in position..index.randstrobes.len() {
+    let forward_hash = entry.get_hash_partial_forward();
+    for i in entry.position..index.len() {
+        let entry = index.entry(i);
+        let randstrobe = entry.randstrobe();
         // Filter out partial lookups with different orientation
-        if index.get_hash_partial_forward(pos) != forward_hash {
+        if entry.get_hash_partial_forward() != forward_hash {
             break;
         }
-        let randstrobe = &index.randstrobes[pos];
         let ref_id = randstrobe.reference_index();
-        let ref_start = index.strobe_extent_partial(pos).0;
+        let ref_start = entry.strobe_extent_partial().0;
 
         anchors.push(Anchor {
             ref_id,
@@ -349,8 +352,8 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
             continue;
         }
         if hit.is_partial {
-            if let Some(forward_position) = index.get_partial_forward_from(hit.hash, hit.position) {
-                add_to_anchors_partial(&mut anchors, hit.query_start, index, forward_position);
+            if let Some(forward_entry) = index.get_partial_forward_from(hit.hash, hit.position) {
+                add_to_anchors_partial(&mut anchors, hit.query_start, index, forward_entry);
             }
         } else {
             add_to_anchors_full(
@@ -358,7 +361,7 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_start,
                 hit.query_end,
                 index,
-                hit.position,
+                index.entry(hit.position),
             );
         }
     }

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -94,10 +94,11 @@ fn rescue_least_frequent(
     // Index and hit count
     let mut hit_counts = vec![];
     for i in start..end {
+        let entry = index.entry(hits[i].position);
         let cnt = if hits[i].is_partial {
-            index.get_count_partial(hits[i].position)
+            entry.get_count_partial()
         } else {
-            index.get_count_full(hits[i].position, hits[i].hash_revcomp)
+            entry.get_count_full(hits[i].hash_revcomp)
         };
         if rescue_threshold.is_none() || cnt <= rescue_threshold.unwrap() {
             hit_counts.push((i, cnt));
@@ -129,16 +130,15 @@ fn find_all_hits(
 
     if mcs_strategy != McsStrategy::FirstStrobe {
         for randstrobe in query_randstrobes {
-            if let Some(position) = index.get_full_forward(randstrobe.hash) {
-                let is_filtered =
-                    index.is_too_frequent(position, filter_cutoff, randstrobe.hash_revcomp);
+            if let Some(entry) = index.get_full_forward(randstrobe.hash) {
+                let is_filtered = entry.is_too_frequent(filter_cutoff, randstrobe.hash_revcomp);
                 if is_filtered {
                     hits_details.full_filtered += 1;
                 } else {
                     hits_details.full_found += 1;
                 }
                 let hit = Hit {
-                    position,
+                    position: entry.position,
                     query_start: randstrobe.start,
                     query_end: randstrobe.end,
                     is_partial: false,
@@ -151,16 +151,15 @@ fn find_all_hits(
                 hits_details.full_not_found += 1;
                 if mcs_strategy == McsStrategy::Always {
                     // Perform partial lookup in both directions for later use in rescue
-                    if let Some(undirected_pos) = index.get_partial(randstrobe.hash) {
-                        let is_filtered =
-                            index.is_too_frequent_partial(undirected_pos, filter_cutoff);
+                    if let Some(undirected_entry) = index.get_partial(randstrobe.hash) {
+                        let is_filtered = undirected_entry.is_too_frequent_partial(filter_cutoff);
                         if is_filtered {
                             hits_details.partial_filtered += 1;
                         } else {
                             hits_details.partial_found += 1;
                         }
                         let hit = Hit {
-                            position: undirected_pos,
+                            position: undirected_entry.position,
                             query_start: randstrobe.start,
                             query_end: randstrobe.start + index.k(),
                             is_partial: true,
@@ -192,15 +191,15 @@ fn find_all_hits(
     {
         for randstrobe in query_randstrobes {
             // Perform partial lookup in both directions for later use in rescue
-            if let Some(undirected_pos) = index.get_partial(randstrobe.hash) {
-                let is_filtered = index.is_too_frequent_partial(undirected_pos, filter_cutoff);
+            if let Some(undirected_entry) = index.get_partial(randstrobe.hash) {
+                let is_filtered = undirected_entry.is_too_frequent_partial(filter_cutoff);
                 if is_filtered {
                     hits_details.partial_filtered += 1;
                 } else {
                     hits_details.partial_found += 1;
                 }
                 let hit = Hit {
-                    position: undirected_pos,
+                    position: undirected_entry.position,
                     query_start: randstrobe.start,
                     query_end: randstrobe.start + index.k(),
                     is_partial: true,
@@ -299,10 +298,11 @@ pub fn find_hits(
         );
         trace!("querypos count (p=partial, F=filtered)");
         for hit in &hits {
+            let entry = index.entry(hit.position);
             let cnt = if hit.is_partial {
-                index.get_count_partial(hit.position)
+                entry.get_count_partial()
             } else {
-                index.get_count_full(hit.position, hit.hash_revcomp)
+                entry.get_count_full(hit.hash_revcomp)
             };
             trace!(
                 "{:6} {}{:6} {}",

--- a/src/index.rs
+++ b/src/index.rs
@@ -82,8 +82,13 @@ pub struct StrobemerIndex {
     ///
     /// randstrobe_start_indices has one extra guard entry at the end that
     /// is always randstrobes.len().
-    pub randstrobes: Vec<RefRandstrobe>,
+    randstrobes: Vec<RefRandstrobe>,
     randstrobe_start_indices: Vec<BucketIndex>,
+}
+
+pub struct IndexEntry<'a> {
+    strobemer_index: &'a StrobemerIndex,
+    pub position: usize,
 }
 
 impl StrobemerIndex {
@@ -103,32 +108,42 @@ impl StrobemerIndex {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.randstrobes.len()
+    }
     pub fn filter_cutoff(&self) -> usize {
         self.filter_cutoff
     }
 
+    pub fn entry(&'_ self, position: usize) -> IndexEntry<'_> {
+        IndexEntry {
+            strobemer_index: self,
+            position,
+        }
+    }
+
     // Find the first entry that matches the forwald full hash (including orientation bits)
-    pub fn get_full_forward(&self, hash: RandstrobeHash) -> Option<usize> {
+    pub fn get_full_forward(&'_ self, hash: RandstrobeHash) -> Option<IndexEntry<'_>> {
         self.get_masked(hash, REF_RANDSTROBE_HASH_MASK)
     }
 
     /// Find the first entry that matches the undirected main hash (without orientation bit)
-    pub fn get_partial(&self, hash: RandstrobeHash) -> Option<usize> {
+    pub fn get_partial(&'_ self, hash: RandstrobeHash) -> Option<IndexEntry<'_>> {
         self.get_masked(hash, self.parameters.randstrobe.main_hash_mask)
     }
 
     /// Find the first entry matching the forward main hash
-    pub fn get_partial_forward(&self, hash: RandstrobeHash) -> Option<usize> {
+    pub fn get_partial_forward(&'_ self, hash: RandstrobeHash) -> Option<IndexEntry<'_>> {
         self.get_masked(hash, self.parameters.randstrobe.forward_main_hash_mask)
     }
 
     /// Find the first entry matching the forward main hash, starting from
     /// the undirected main position
     pub fn get_partial_forward_from(
-        &self,
+        &'_ self,
         hash: RandstrobeHash,
         undirected_position: usize,
-    ) -> Option<usize> {
+    ) -> Option<IndexEntry<'_>> {
         self.get_masked_from(
             hash,
             self.parameters.randstrobe.forward_main_hash_mask,
@@ -141,11 +156,11 @@ impl StrobemerIndex {
     /// If `start_position` is provided, search starts from there instead of
     /// the bucket start.
     pub fn get_masked_from(
-        &self,
+        &'_ self,
         hash: RandstrobeHash,
         hash_mask: RandstrobeHash,
         start_position: Option<usize>,
-    ) -> Option<usize> {
+    ) -> Option<IndexEntry<'_>> {
         let masked_hash = hash & hash_mask;
         const MAX_LINEAR_SEARCH: usize = 4;
         let top_n = (hash >> (64 - self.bits)) as usize;
@@ -158,7 +173,10 @@ impl StrobemerIndex {
         } else if bucket.len() < MAX_LINEAR_SEARCH {
             for (pos, randstrobe) in bucket.iter().enumerate() {
                 if randstrobe.hash() & hash_mask == masked_hash {
-                    return Some(position_start as usize + pos);
+                    return Some(IndexEntry {
+                        strobemer_index: self,
+                        position: position_start as usize + pos,
+                    });
                 }
                 if randstrobe.hash() & hash_mask > masked_hash {
                     return None;
@@ -169,64 +187,85 @@ impl StrobemerIndex {
 
         let pos = custom_partition_point(bucket, |h| h.hash() & hash_mask < masked_hash);
         if pos < bucket.len() && bucket[pos].hash() & hash_mask == masked_hash {
-            Some(position_start as usize + pos)
+            Some(IndexEntry {
+                strobemer_index: self,
+                position: position_start as usize + pos,
+            })
         } else {
             None
         }
     }
 
-    pub fn get_masked(&self, hash: RandstrobeHash, hash_mask: RandstrobeHash) -> Option<usize> {
+    pub fn get_masked(
+        &'_ self,
+        hash: RandstrobeHash,
+        hash_mask: RandstrobeHash,
+    ) -> Option<IndexEntry<'_>> {
         self.get_masked_from(hash, hash_mask, None)
     }
 
     pub fn k(&self) -> usize {
         self.parameters.syncmer.k
     }
+}
 
-    pub fn get_hash_partial(&self, position: usize) -> RandstrobeHash {
-        self.randstrobes[position].hash() & self.parameters.randstrobe.main_hash_mask
+impl<'a> IndexEntry<'a> {
+    pub fn randstrobe(&self) -> &RefRandstrobe {
+        &self.strobemer_index.randstrobes[self.position]
     }
 
-    pub fn get_hash_partial_forward(&self, position: usize) -> RandstrobeHash {
-        self.randstrobes[position].hash_offset & self.parameters.randstrobe.forward_main_hash_mask
+    pub fn get_hash_partial(&self) -> RandstrobeHash {
+        self.strobemer_index.randstrobes[self.position].hash()
+            & self.strobemer_index.parameters.randstrobe.main_hash_mask
     }
 
-    pub fn strobe_extent_partial(&self, position: usize) -> (usize, usize) {
-        let p = self.randstrobes[position].position;
+    pub fn get_hash_partial_forward(&self) -> RandstrobeHash {
+        self.strobemer_index.randstrobes[self.position].hash_offset
+            & self
+                .strobemer_index
+                .parameters
+                .randstrobe
+                .forward_main_hash_mask
+    }
+
+    pub fn strobe_extent_partial(&self) -> (usize, usize) {
+        let p = self.strobemer_index.randstrobes[self.position].position;
 
         (p as usize, p as usize + self.k())
     }
 
     /// Count number of hits for the randstrobe *and* its "reverse complement"
-    pub fn get_count_full(&self, position: usize, hash_revcomp: u64) -> usize {
+    pub fn get_count_full(&self, hash_revcomp: u64) -> usize {
         let reverse_count;
-        if let Some(position_revcomp) = self.get_full_forward(hash_revcomp) {
-            reverse_count = self.get_count_full_forward(position_revcomp);
+        if let Some(entry_revcomp) = self.strobemer_index.get_full_forward(hash_revcomp) {
+            reverse_count = entry_revcomp.get_count_full_forward();
         } else {
             reverse_count = 0;
         }
-        reverse_count + self.get_count_full_forward(position)
+        reverse_count + self.get_count_full_forward()
     }
 
-    pub fn get_count_full_forward(&self, position: usize) -> usize {
-        self.get_count(position, REF_RANDSTROBE_HASH_MASK)
+    pub fn get_count_full_forward(&self) -> usize {
+        self.get_count(REF_RANDSTROBE_HASH_MASK)
     }
 
-    pub fn get_count_partial(&self, position: usize) -> usize {
-        self.get_count(position, self.parameters.randstrobe.main_hash_mask)
+    pub fn get_count_partial(&self) -> usize {
+        self.get_count(self.strobemer_index.parameters.randstrobe.main_hash_mask)
     }
 
-    pub fn get_count(&self, position: usize, hash_mask: u64) -> usize {
+    pub fn get_count(&self, hash_mask: u64) -> usize {
+        let position = self.position;
         const MAX_LINEAR_SEARCH: usize = 8;
-        let key = self.randstrobes[position].hash();
+        let key = self.strobemer_index.randstrobes[position].hash();
         let masked_key = key & hash_mask;
-        let top_n = (key >> (64 - self.bits)) as usize;
-        let position_end = self.randstrobe_start_indices[top_n + 1] as usize;
+        let top_n = (key >> (64 - self.strobemer_index.bits)) as usize;
+        let position_end = self.strobemer_index.randstrobe_start_indices[top_n + 1] as usize;
 
         if position_end - position < MAX_LINEAR_SEARCH {
             let mut count = 1;
             for position_start in position + 1..position_end {
-                if self.randstrobes[position_start].hash() & hash_mask == masked_key {
+                if self.strobemer_index.randstrobes[position_start].hash() & hash_mask == masked_key
+                {
                     count += 1;
                 } else {
                     break;
@@ -234,30 +273,32 @@ impl StrobemerIndex {
             }
             count
         } else {
-            let bucket = &self.randstrobes[position..position_end];
+            let bucket = &self.strobemer_index.randstrobes[position..position_end];
             custom_partition_point(bucket, |h| h.hash() & hash_mask <= masked_key)
         }
     }
 
     /// Return whether the randstrobe at the given position occurs more often than cutoff
-    pub fn is_too_frequent_forward(&self, position: usize, cutoff: usize) -> bool {
-        if position + self.filter_cutoff < self.randstrobes.len() {
-            self.randstrobes[position].hash() == self.randstrobes[position + cutoff].hash()
+    pub fn is_too_frequent_forward(&self, cutoff: usize) -> bool {
+        if self.position + self.strobemer_index.filter_cutoff
+            < self.strobemer_index.randstrobes.len()
+        {
+            self.strobemer_index.randstrobes[self.position].hash()
+                == self.strobemer_index.randstrobes[self.position + cutoff].hash()
         } else {
             false
         }
     }
 
-    pub fn is_too_frequent(&self, position: usize, cutoff: usize, hash_revcomp: u64) -> bool {
-        if self.is_too_frequent_forward(position, cutoff) {
+    pub fn is_too_frequent(&self, cutoff: usize, hash_revcomp: u64) -> bool {
+        if self.is_too_frequent_forward(cutoff) {
             return true;
         }
-        if let Some(position_revcomp) = self.get_full_forward(hash_revcomp) {
-            if self.is_too_frequent_forward(position_revcomp, cutoff) {
+        if let Some(entry_revcomp) = self.strobemer_index.get_full_forward(hash_revcomp) {
+            if entry_revcomp.is_too_frequent_forward(cutoff) {
                 return true;
             }
-            let count = self.get_count_full_forward(position)
-                + self.get_count_full_forward(position_revcomp);
+            let count = self.get_count_full_forward() + entry_revcomp.get_count_full_forward();
 
             return count > cutoff;
         }
@@ -265,18 +306,23 @@ impl StrobemerIndex {
         false
     }
 
-    pub fn is_too_frequent_forward_partial(&self, position: usize, cutoff: usize) -> bool {
-        if position + cutoff < self.randstrobes.len() {
-            self.randstrobes[position].hash() & self.parameters.randstrobe.main_hash_mask
-                == self.randstrobes[position + cutoff].hash()
-                    & self.parameters.randstrobe.main_hash_mask
+    pub fn is_too_frequent_forward_partial(&self, cutoff: usize) -> bool {
+        if self.position + cutoff < self.strobemer_index.randstrobes.len() {
+            self.strobemer_index.randstrobes[self.position].hash()
+                & self.strobemer_index.parameters.randstrobe.main_hash_mask
+                == self.strobemer_index.randstrobes[self.position + cutoff].hash()
+                    & self.strobemer_index.parameters.randstrobe.main_hash_mask
         } else {
             false
         }
     }
 
-    pub fn is_too_frequent_partial(&self, position: usize, cutoff: usize) -> bool {
-        self.is_too_frequent_forward_partial(position, cutoff)
+    pub fn is_too_frequent_partial(&self, cutoff: usize) -> bool {
+        self.is_too_frequent_forward_partial(cutoff)
+    }
+
+    fn k(&self) -> usize {
+        self.strobemer_index.k()
     }
 }
 
@@ -547,11 +593,12 @@ mod tests {
 
             let rev_pos_result = rc_index.get_partial(fwd_hash);
             assert!(rev_pos_result.is_some());
-            let rev_pos = rev_pos_result.unwrap();
+            let rev_entry = rev_pos_result.unwrap();
 
             let rc_partial_query = fwd_index.randstrobes[i].hash()
                 ^ ((1 as u64) << rc_index.parameters.randstrobe.partial_orientation_pos);
-            let rev_pos_forward = rc_index.get_partial_forward_from(rc_partial_query, rev_pos);
+            let rev_pos_forward =
+                rc_index.get_partial_forward_from(rc_partial_query, rev_entry.position);
             assert!(rev_pos_forward.is_some());
         }
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -75,15 +75,15 @@ pub struct StrobemerIndex {
     filter_cutoff: usize,
 
     /// The randstrobes vector contains all randstrobes sorted by hash.
-    /// The randstrobe_start_indices vector points to entries in the
-    /// randstrobes vector. `randstrobe_start_indices[x]` is the index of the
+    /// The bucket_starts vector points to entries in the
+    /// randstrobes vector. `bucket_starts[x]` is the index of the
     /// first entry in randstrobes whose top *bits* bits of its hash value are
     /// greater than or equal to x.
     ///
-    /// randstrobe_start_indices has one extra guard entry at the end that
+    /// bucket_starts has one extra guard entry at the end that
     /// is always randstrobes.len().
     randstrobes: Vec<RefRandstrobe>,
-    randstrobe_start_indices: Vec<BucketIndex>,
+    bucket_starts: Vec<BucketIndex>,
 }
 
 pub struct IndexEntry<'a> {
@@ -97,14 +97,14 @@ impl StrobemerIndex {
         bits: u8,
         filter_cutoff: usize,
         randstrobes: Vec<RefRandstrobe>,
-        randstrobe_start_indices: Vec<BucketIndex>,
+        bucket_starts: Vec<BucketIndex>,
     ) -> Self {
         StrobemerIndex {
             parameters,
             bits,
             filter_cutoff,
             randstrobes,
-            randstrobe_start_indices,
+            bucket_starts,
         }
     }
 
@@ -164,9 +164,8 @@ impl StrobemerIndex {
         let masked_hash = hash & hash_mask;
         const MAX_LINEAR_SEARCH: usize = 4;
         let top_n = (hash >> (64 - self.bits)) as usize;
-        let position_start =
-            start_position.unwrap_or(self.randstrobe_start_indices[top_n] as usize);
-        let position_end = self.randstrobe_start_indices[top_n + 1];
+        let position_start = start_position.unwrap_or(self.bucket_starts[top_n] as usize);
+        let position_end = self.bucket_starts[top_n + 1];
         let bucket = &self.randstrobes[position_start as usize..position_end as usize];
         if bucket.is_empty() {
             return None;
@@ -259,7 +258,7 @@ impl<'a> IndexEntry<'a> {
         let key = self.strobemer_index.randstrobes[position].hash();
         let masked_key = key & hash_mask;
         let top_n = (key >> (64 - self.strobemer_index.bits)) as usize;
-        let position_end = self.strobemer_index.randstrobe_start_indices[top_n + 1] as usize;
+        let position_end = self.strobemer_index.bucket_starts[top_n + 1] as usize;
 
         if position_end - position < MAX_LINEAR_SEARCH {
             let mut count = 1;
@@ -387,7 +386,7 @@ impl StrobemerIndex {
         file.write_all(&(rp.main_hash_mask as u64).to_ne_bytes())?;
 
         write_vec(&mut file, &self.randstrobes)?;
-        write_vec(&mut file, &self.randstrobe_start_indices)?;
+        write_vec(&mut file, &self.bucket_starts)?;
 
         Ok(())
     }
@@ -463,9 +462,9 @@ pub fn read_index<'a, P: AsRef<Path>>(
     }
 
     let randstrobes = read_vec(&mut reader)?;
-    let randstrobe_start_indices = read_vec(&mut reader)?;
+    let bucket_starts = read_vec(&mut reader)?;
 
-    if randstrobe_start_indices.len() != (1 << bits) + 1 {
+    if bucket_starts.len() != (1 << bits) + 1 {
         return Err(IndexReadingError::RandstrobeStartIndicesWrongSize);
     }
 
@@ -474,7 +473,7 @@ pub fn read_index<'a, P: AsRef<Path>>(
         bits,
         filter_cutoff,
         randstrobes,
-        randstrobe_start_indices,
+        bucket_starts,
     })
 }
 


### PR DESCRIPTION
This makes the `StrobemerIndex::randstrobes` vector private. Currently, this attribute is public, and the Chainer relies on that when it iterates over it to collect matches. For an experiment, I replaced the `randstrobes` vector with a `hashes` and `positions` vector, and then I had to update the `Chainer` as well. I was hoping to get an improvement in speed, but did not observe any advantages (it actually seemed to be slower). In any case, in order to make changes like these asier, this PR makes the `randstrobes` attribute private and introduces an `IndexEntry` struct that represents a looked-up position in the randstrobes vector. It has various methods to access the hash, position, etc., so if the memory layout changes, only `IndexEntry` and the `StrobemerIndex` need to be updated.

This is a bit inspired by [HashMap::entry](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.entry).

Runtime and accuracy do not change.