### PR TITLE
Add repetitive hits that are close to non-repetitive hits with a linear sweep

### DIFF
--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -205,6 +205,7 @@ impl Chainer {
         for &is_revcomp in &orientations {
             let hits_timer = Instant::now();
             let mut anchors = hits_to_anchors(&hits[is_revcomp], index);
+            add_repetitive_via_sweep(&mut anchors, &hits[is_revcomp], index);
             time_find_hits += hits_timer.elapsed().as_secs_f64();
             n_anchors += anchors.len();
             let chaining_timer = Instant::now();
@@ -340,6 +341,87 @@ fn add_to_anchors_partial(
             ref_start,
             query_start,
         });
+    }
+}
+
+/// For each filtered (repetitive) hit, add its reference positions that land on
+/// the same diagonal as an existing anchor (within `k` bp tolerance).
+///
+/// This lets repetitive seeds contribute to chaining without the N×R candidate
+/// explosion: only positions co-linear with at least one non-repetitive anchor
+/// are admitted.
+///
+/// # Sort-order note
+/// `RefRandstrobe` is now sorted by `(hash, ref_index, position)`, so within a
+/// hash group entries are grouped by chromosome and then sorted by position.
+/// `anchor_diags` is sorted by `(ref_id, diagonal)`.  Both sequences increase
+/// in the same (ref_id, value) order, enabling a single two-pointer sweep with
+/// no per-ref_id bookkeeping.
+fn add_repetitive_via_sweep(anchors: &mut Vec<Anchor>, hits: &[Hit], index: &StrobemerIndex) {
+    if anchors.is_empty() {
+        return;
+    }
+    // Fast path: nothing to do if no filtered non-partial hits exist.
+    if !hits.iter().any(|h| h.is_filtered && !h.is_partial) {
+        return;
+    }
+
+    // Build (ref_id, diagonal) sorted by (ref_id, diagonal).
+    // diagonal = ref_start - query_start; co-linear hits share the same value.
+    let mut anchor_diags: Vec<(usize, isize)> = anchors
+        .iter()
+        .map(|a| (a.ref_id, a.ref_start as isize - a.query_start as isize))
+        .collect();
+    anchor_diags.sort_unstable();
+    anchor_diags.dedup();
+
+    let tolerance = index.k() as isize;
+
+    for hit in hits {
+        if !hit.is_filtered || hit.is_partial {
+            continue;
+        }
+        let q = hit.query_start as isize;
+        let entry = index.entry(hit.position);
+        let forward_hash = entry.hash();
+
+        // Single anchor pointer — never goes backwards because:
+        // - index positions are now sorted by (ref_id, ref_start) within a hash group
+        // - anchor_diags is sorted by (ref_id, diagonal)
+        // - both sequences increase in the same (ref_id, value) direction
+        let mut ptr_anc = 0usize;
+
+        for pos in entry.position..index.len() {
+            let entry = index.entry(pos);
+            if entry.hash() != forward_hash {
+                break;
+            }
+            let ref_id = entry.reference_index();
+            let ref_start = entry.position();
+            let diag = ref_start as isize - q;
+            let lo = (ref_id, diag - tolerance);
+            let hi = (ref_id, diag + tolerance);
+
+            // Advance past anchor entries that are before the window.
+            // Tuple comparison handles both ref_id changes and diagonal range.
+            while ptr_anc < anchor_diags.len() && anchor_diags[ptr_anc] < lo {
+                ptr_anc += 1;
+            }
+
+            if ptr_anc < anchor_diags.len() && anchor_diags[ptr_anc] <= hi {
+                let ref_end = ref_start + entry.strobe2_offset() + index.k();
+                anchors.push(Anchor {
+                    ref_id,
+                    ref_start,
+                    query_start: hit.query_start,
+                });
+                anchors.push(Anchor {
+                    ref_id,
+                    ref_start: ref_end - index.k(),
+                    query_start: hit.query_end - index.k(),
+                });
+            }
+        }
     }
 }
 

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -168,7 +168,6 @@ impl Chainer {
         &self,
         query_randstrobes: &[Vec<QueryRandstrobe>; 2],
         index: &StrobemerIndex,
-        rescue_distance: usize,
         mcs_strategy: McsStrategy,
     ) -> (NamDetails, Vec<Nam>) {
         let hits_timer = Instant::now();
@@ -181,7 +180,6 @@ impl Chainer {
                 index,
                 mcs_strategy,
                 index.filter_cutoff(),
-                rescue_distance,
             );
         }
         let mut time_find_hits = hits_timer.elapsed().as_secs_f64();

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -385,6 +385,11 @@ fn add_repetitive_via_sweep(anchors: &mut Vec<Anchor>, hits: &[Hit], index: &Str
         let entry = index.entry(hit.position);
         let forward_hash = entry.hash();
 
+        // Skip seeds so repetitive that even co-linear filtering would flood the chainer.
+        if entry.get_count_full_forward() > 10_000 {
+            continue;
+        }
+
         // Single anchor pointer — never goes backwards because:
         // - index positions are now sorted by (ref_id, ref_start) within a hash group
         // - anchor_diags is sorted by (ref_id, diagonal)

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -366,6 +366,63 @@ fn add_repetitive_via_sweep(anchors: &mut Vec<Anchor>, hits: &[Hit], index: &Str
         return;
     }
 
+    // Select a minimum-cost non-overlapping tiling of filtered hits via
+    // Weighted Interval Scheduling (WIS) where weight = −count.
+    // Minimising total count (= maximising sum of −count) favours the least
+    // repetitive seeds while still covering distinct parts of the query.
+    // Two hits may overlap by at most OVERLAP_THRESHOLD bp on the query.
+    //
+    // DP (O(n log n)):
+    //   Sort by query_end.  For each hit i, p[i] = number of hits whose
+    //   query_end ≤ query_start[i] + OVERLAP_THRESHOLD (the compatible
+    //   prefix).  Then:
+    //     dp[i] = max(dp[i−1],  weight[i] + dp[p[i]])
+    //   where dp[0] = 0 and weight[i] = CAP − count[i] + 1 > 0.
+    let mut candidates: Vec<(&Hit, usize)> = hits
+        .iter()
+        .filter(|h| h.is_filtered && !h.is_partial)
+        .map(|h| (h, index.get_count_full_forward(h.position)))
+        .collect();
+    // Sort by query_end for the WIS DP; ties broken by count.
+    candidates.sort_unstable_by_key(|&(h, count)| (h.query_end, count));
+
+    const OVERLAP_THRESHOLD: usize = 10;
+    let n = candidates.len();
+
+    // p[i] = number of hits compatible with (i.e. not overlapping) hit i.
+    let p: Vec<usize> = (0..n)
+        .map(|i| {
+            let cutoff = candidates[i].0.query_start + OVERLAP_THRESHOLD;
+            candidates[..i].partition_point(|&(h, _)| h.query_end <= cutoff)
+        })
+        .collect();
+
+    // weight[i] = CAP - count[i] + 1: positive for all hits (count ≤ CAP),
+    // higher for less-repetitive seeds.  Ensures the DP always selects
+    // at least one hit (empty set has value 0 < any single hit's weight),
+    // while two non-overlapping low-count hits beat one high-count hit
+    // when their combined weight exceeds it.
+    const CAP: usize = 10_000;
+    let weight = |i: usize| (CAP + 1 - candidates[i].1.min(CAP)) as isize;
+
+    // dp[i] = maximum total weight over a valid tiling of hits 0..i.
+    let mut dp = vec![0isize; n + 1];
+    for i in 1..=n {
+        dp[i] = dp[i - 1].max(weight(i - 1) + dp[p[i - 1]]);
+    }
+
+    // Traceback to recover selected hits.
+    let mut selected: Vec<&Hit> = Vec::new();
+    let mut i = n;
+    while i > 0 {
+        if weight(i - 1) + dp[p[i - 1]] >= dp[i - 1] {
+            selected.push(candidates[i - 1].0);
+            i = p[i - 1];
+        } else {
+            i -= 1;
+        }
+    }
+
     // Build (ref_id, diagonal) sorted by (ref_id, diagonal).
     // diagonal = ref_start - query_start; co-linear hits share the same value.
     let mut anchor_diags: Vec<(usize, isize)> = anchors
@@ -377,10 +434,7 @@ fn add_repetitive_via_sweep(anchors: &mut Vec<Anchor>, hits: &[Hit], index: &Str
 
     let tolerance = index.k() as isize;
 
-    for hit in hits {
-        if !hit.is_filtered || hit.is_partial {
-            continue;
-        }
+    for hit in &selected {
         let q = hit.query_start as isize;
         let entry = index.entry(hit.position);
         let forward_hash = entry.hash();

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -202,10 +202,12 @@ impl Chainer {
         let mut n_anchors = 0;
         let mut time_chaining = 0.0;
         let mut chains = vec![];
+        // Allocate once and reuse across both orientations to avoid per-call heap alloc.
+        let mut anchor_diags: Vec<(usize, isize)> = Vec::new();
         for &is_revcomp in &orientations {
             let hits_timer = Instant::now();
             let mut anchors = hits_to_anchors(&hits[is_revcomp], index);
-            add_repetitive_via_sweep(&mut anchors, &hits[is_revcomp], index);
+            add_repetitive_via_sweep(&mut anchors, &hits[is_revcomp], index, &mut anchor_diags);
             time_find_hits += hits_timer.elapsed().as_secs_f64();
             n_anchors += anchors.len();
             let chaining_timer = Instant::now();
@@ -357,20 +359,21 @@ fn add_to_anchors_partial(
 /// `anchor_diags` is sorted by `(ref_id, diagonal)`.  Both sequences increase
 /// in the same (ref_id, value) order, enabling a single two-pointer sweep with
 /// no per-ref_id bookkeeping.
-fn add_repetitive_via_sweep(anchors: &mut Vec<Anchor>, hits: &[Hit], index: &StrobemerIndex) {
+fn add_repetitive_via_sweep(
+    anchors: &mut Vec<Anchor>,
+    hits: &[Hit],
+    index: &StrobemerIndex,
+    anchor_diags: &mut Vec<(usize, isize)>,
+) {
     if anchors.is_empty() {
-        return;
-    }
-    // Fast path: nothing to do if no filtered non-partial hits exist.
-    if !hits.iter().any(|h| h.is_filtered && !h.is_partial) {
         return;
     }
 
     // Select a minimum-cost non-overlapping tiling of filtered hits via
-    // Weighted Interval Scheduling (WIS) where weight = −count.
-    // Minimising total count (= maximising sum of −count) favours the least
-    // repetitive seeds while still covering distinct parts of the query.
+    // Weighted Interval Scheduling (WIS) where weight = CAP − count + 1.
     // Two hits may overlap by at most OVERLAP_THRESHOLD bp on the query.
+    // The cap is applied here — hits above it are excluded before WIS,
+    // avoiding a redundant get_count_full_forward call in the sweep loop.
     //
     // DP (O(n log n)):
     //   Sort by query_end.  For each hit i, p[i] = number of hits whose
@@ -378,11 +381,20 @@ fn add_repetitive_via_sweep(anchors: &mut Vec<Anchor>, hits: &[Hit], index: &Str
     //   prefix).  Then:
     //     dp[i] = max(dp[i−1],  weight[i] + dp[p[i]])
     //   where dp[0] = 0 and weight[i] = CAP − count[i] + 1 > 0.
+    const CAP: usize = 10_000;
     let mut candidates: Vec<(&Hit, usize)> = hits
         .iter()
         .filter(|h| h.is_filtered && !h.is_partial)
-        .map(|h| (h, index.get_count_full_forward(h.position)))
+        .filter_map(|h| {
+            let count = index.entry(h.position).get_count_full_forward();
+            if count <= CAP { Some((h, count)) } else { None }
+        })
         .collect();
+
+    // Fast path: nothing to do if no eligible filtered hits remain.
+    if candidates.is_empty() {
+        return;
+    }
     // Sort by query_end for the WIS DP; ties broken by count.
     candidates.sort_unstable_by_key(|&(h, count)| (h.query_end, count));
 
@@ -402,7 +414,6 @@ fn add_repetitive_via_sweep(anchors: &mut Vec<Anchor>, hits: &[Hit], index: &Str
     // at least one hit (empty set has value 0 < any single hit's weight),
     // while two non-overlapping low-count hits beat one high-count hit
     // when their combined weight exceeds it.
-    const CAP: usize = 10_000;
     let weight = |i: usize| (CAP + 1 - candidates[i].1.min(CAP)) as isize;
 
     // dp[i] = maximum total weight over a valid tiling of hits 0..i.
@@ -425,10 +436,13 @@ fn add_repetitive_via_sweep(anchors: &mut Vec<Anchor>, hits: &[Hit], index: &Str
 
     // Build (ref_id, diagonal) sorted by (ref_id, diagonal).
     // diagonal = ref_start - query_start; co-linear hits share the same value.
-    let mut anchor_diags: Vec<(usize, isize)> = anchors
-        .iter()
-        .map(|a| (a.ref_id, a.ref_start as isize - a.query_start as isize))
-        .collect();
+    // Reuse the caller-provided buffer to avoid per-call heap allocation.
+    anchor_diags.clear();
+    anchor_diags.extend(
+        anchors
+            .iter()
+            .map(|a| (a.ref_id, a.ref_start as isize - a.query_start as isize)),
+    );
     anchor_diags.sort_unstable();
     anchor_diags.dedup();
 

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -220,65 +220,17 @@ fn find_all_hits(
     (hits_details, hits)
 }
 
-/// Rescue seeds from filtered regions that have a given minimum length (in
-/// nucleotides)
-///
-/// All stretches of consecutive filtered hits are considered. For any stretch
-/// that is longer than rescue_distance, rescue_least_frequent is called.
-fn rescue_all_least_frequent(
-    index: &StrobemerIndex,
-    hits: &mut [Hit],
-    rescue_distance: usize,
-) -> usize {
-    let mut last_unfiltered_start = 0;
-    let mut first_filtered = 0;
-    let mut intervals = vec![];
-
-    for (i, hit) in hits.iter().enumerate() {
-        if hit.is_filtered {
-            continue;
-        }
-        if hit.query_start > last_unfiltered_start + rescue_distance {
-            let to_rescue = (hit.query_start - last_unfiltered_start) / rescue_distance;
-            intervals.push((first_filtered, i, to_rescue));
-        }
-        last_unfiltered_start = hit.query_start;
-        first_filtered = i + 1;
-    }
-    // Ensure we consider the end as well
-    if let Some(last_hit) = hits.last() {
-        if last_hit.query_start - last_unfiltered_start > rescue_distance {
-            let to_rescue = (last_hit.query_start - last_unfiltered_start) / rescue_distance;
-            intervals.push((first_filtered, hits.len(), to_rescue));
-        }
-    }
-
-    let mut rescued = 0;
-    for (start, end, to_rescue) in intervals {
-        rescued += rescue_least_frequent(index, hits, start, end, to_rescue, None);
-    }
-
-    rescued
-}
-
 /// Find a query’s hits
 pub fn find_hits(
     query_randstrobes: &[QueryRandstrobe],
     index: &StrobemerIndex,
     mcs_strategy: McsStrategy,
     filter_cutoff: usize,
-    rescue_distance: usize,
 ) -> (HitsDetails, Vec<Hit>) {
     let (mut details, mut hits) =
         find_all_hits(query_randstrobes, index, filter_cutoff, mcs_strategy);
 
-    let total_hits = details.total_hits();
     let nonrepetitive_hits = details.total_found();
-    let nonrepetitive_fraction = if total_hits > 0 {
-        nonrepetitive_hits as f32 / total_hits as f32
-    } else {
-        1.0
-    };
 
     // Repetitive seeds will be "rescued" during sweep
     if nonrepetitive_hits < GLOBAL_RESCUE_COUNT {

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -280,16 +280,12 @@ pub fn find_hits(
         1.0
     };
 
-    // rescue distance 0 disables both global and local rescue
-    if rescue_distance > 0 {
-        if nonrepetitive_fraction < 0.7 && nonrepetitive_hits < GLOBAL_RESCUE_COUNT {
-            // "global" rescue
-            let n = hits.len();
-            details.rescued +=
-                rescue_least_frequent(index, &mut hits, 0, n, GLOBAL_RESCUE_COUNT, Some(1000));
-        }
-        // "local" rescue
-        details.rescued += rescue_all_least_frequent(index, &mut hits, rescue_distance);
+    // Repetitive seeds will be "rescued" during sweep
+    if nonrepetitive_hits < GLOBAL_RESCUE_COUNT {
+        // "global" rescue
+        let n = hits.len();
+        details.rescued +=
+            rescue_least_frequent(index, &mut hits, 0, n, GLOBAL_RESCUE_COUNT, Some(1000));
     }
 
     if log::log_enabled!(Level::Trace) {

--- a/src/index.rs
+++ b/src/index.rs
@@ -15,18 +15,18 @@ pub type BucketIndex = u64;
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Default, Clone)]
 #[repr(C)]
 pub struct RefRandstrobe {
-    /// Packed representation of the hash and the strobe offset.  
+    /// Packed representation of the hash and the strobe offset.
     /// Has the following layout
     /// `<strobe1 hash><strobe1 orientation bit><strobe2 hash><strobe2 orientation bit><strobe2 offset from strobe1>`
     ///
-    /// [`RandstrobeParameters::partial_orientation_pos`] specifies the position of strobe1 orientation bit in the layout  
-    /// [`RandstrobeParameters::forward_main_hash_mask`] is the mask for strobe1 hash (without the orientation bit)  
-    /// [`RandstrobeParameters::main_hash_mask`] is the mask for strobe1 hash which includes the orientation bit  
-    /// [`REF_RANDSTROBE_HASH_MASK`] is the mask for strobe1 and strobe2 hashes (including their orientations)  
-    /// The [`STROBE2_OFFSET_BITS`] constant specifies the number of bits reserved for the offset  
+    /// [`RandstrobeParameters::partial_orientation_pos`] specifies the position of strobe1 orientation bit in the layout
+    /// [`RandstrobeParameters::forward_main_hash_mask`] is the mask for strobe1 hash (without the orientation bit)
+    /// [`RandstrobeParameters::main_hash_mask`] is the mask for strobe1 hash which includes the orientation bit
+    /// [`REF_RANDSTROBE_HASH_MASK`] is the mask for strobe1 and strobe2 hashes (including their orientations)
+    /// The [`STROBE2_OFFSET_BITS`] constant specifies the number of bits reserved for the offset
     hash_offset: u64,
-    position: u32,
     ref_index: u32,
+    position: u32,
 }
 
 /// Mask for the part of the randstrobe hash that includes individual strobe hashes and orientations
@@ -120,6 +120,10 @@ impl StrobemerIndex {
             strobemer_index: self,
             position,
         }
+    }
+
+    pub fn set_filter_cutoff(&mut self, cutoff: usize) {
+        self.filter_cutoff = cutoff;
     }
 
     // Find the first entry that matches the forwald full hash (including orientation bits)
@@ -341,7 +345,7 @@ impl<'a> IndexEntry<'a> {
     }
 }
 
-const STI_FILE_FORMAT_VERSION: u32 = 7;
+const STI_FILE_FORMAT_VERSION: u32 = 8;
 
 #[derive(Error, Debug)]
 pub enum IndexReadingError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,6 +197,10 @@ struct Args {
     #[arg(short, default_value_t = 0.0002, help_heading = "Search parameters")]
     filter_fraction: f64,
 
+    /// Directly override filter_cutoff (bypasses the [30,100] clamp; 0 = use default)
+    #[arg(long, default_value_t = 0, help_heading = "Search parameters")]
+    filter_cutoff: usize,
+
     /// Try candidate sites with mapping score at least S of maximum mapping score
     #[arg(short = 'S', default_value_t = 0.5, help_heading = "Search parameters")]
     dropoff_threshold: f32,
@@ -453,7 +457,7 @@ fn run() -> Result<(), CliError> {
         .unwrap_or_else(|| parameters.syncmer.pick_bits(&references));
     info!("Bits used to index buckets: {}", bits);
 
-    let index = if args.use_index {
+    let mut index = if args.use_index {
         // Read the index from a file
         assert!(!args.create_index);
         let read_index_timer = Instant::now();
@@ -490,6 +494,9 @@ fn run() -> Result<(), CliError> {
 
         index
     };
+    if args.filter_cutoff > 0 {
+        index.set_filter_cutoff(args.filter_cutoff);
+    }
     debug!("Filtered cutoff count: {}", index.filter_cutoff());
 
     if args.create_index {

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,12 +209,6 @@ struct Args {
     #[arg(short = 'M', default_value_t = MappingParameters::default().max_tries, help_heading = "Search parameters")]
     max_tries: usize,
 
-    /// Maximum distance (in nucleotides) that filtered seeds may span.
-    /// The lower the value, the more seeds are rescued.
-    /// Use 0 to disable rescue.
-    #[arg(short = 'R', default_value_t = MappingParameters::default().rescue_distance, help_heading = "Search parameters")]
-    rescue_distance: usize,
-
     /// Collinear chaining look back heuristic
     #[arg(short = 'H', default_value_t = ChainingParameters::default().max_lookback, value_name = "N", help_heading = "Collinear chaining")]
     max_lookback: usize,
@@ -517,7 +511,6 @@ fn run() -> Result<(), CliError> {
         max_secondary: args.max_secondary,
         max_tries: args.max_tries,
         dropoff_threshold: args.dropoff_threshold,
-        rescue_distance: args.rescue_distance,
         output_unmapped: !args.only_mapped,
         mcs_strategy: args.mcs_strategy,
         use_ssw: args.use_ssw,
@@ -936,7 +929,6 @@ impl Mapper<'_> {
                             &r2,
                             self.index,
                             self.references,
-                            self.mapping_parameters.rescue_distance,
                             &mut isizedist,
                             self.mapping_parameters.mcs_strategy,
                             &self.chainer,
@@ -947,7 +939,6 @@ impl Mapper<'_> {
                             &r1,
                             self.index,
                             self.references,
-                            self.mapping_parameters.rescue_distance,
                             self.mapping_parameters.mcs_strategy,
                             &self.chainer,
                             &mut rng,
@@ -965,7 +956,6 @@ impl Mapper<'_> {
                             &r2,
                             self.index,
                             &mut self.abundances,
-                            self.mapping_parameters.rescue_distance,
                             &mut isizedist,
                             self.mapping_parameters.mcs_strategy,
                             &self.chainer,
@@ -976,7 +966,6 @@ impl Mapper<'_> {
                             &r1,
                             self.index,
                             &mut self.abundances,
-                            self.mapping_parameters.rescue_distance,
                             self.mapping_parameters.mcs_strategy,
                             &self.chainer,
                             &mut rng,

--- a/src/maponly.rs
+++ b/src/maponly.rs
@@ -19,18 +19,12 @@ pub fn map_single_end_read(
     record: &SequenceRecord,
     index: &StrobemerIndex,
     references: &[RefSequence],
-    rescue_distance: usize,
     mcs_strategy: McsStrategy,
     chainer: &Chainer,
     rng: &mut Rng,
 ) -> (Vec<PafRecord>, Details) {
-    let (mut nam_details, mut nams) = get_nams_by_chaining(
-        &record.sequence,
-        index,
-        chainer,
-        rescue_distance,
-        mcs_strategy,
-    );
+    let (mut nam_details, mut nams) =
+        get_nams_by_chaining(&record.sequence, index, chainer, mcs_strategy);
     nam_details.time_sort_nams = sort_nams(&mut nams, rng);
 
     if nams.is_empty() {
@@ -58,18 +52,11 @@ pub fn abundances_single_end_read(
     record: &SequenceRecord,
     index: &StrobemerIndex,
     abundances: &mut [f64],
-    rescue_distance: usize,
     mcs_strategy: McsStrategy,
     chainer: &Chainer,
     rng: &mut Rng,
 ) {
-    let (_, mut nams) = get_nams_by_chaining(
-        &record.sequence,
-        index,
-        chainer,
-        rescue_distance,
-        mcs_strategy,
-    );
+    let (_, mut nams) = get_nams_by_chaining(&record.sequence, index, chainer, mcs_strategy);
     sort_nams(&mut nams, rng);
 
     let n_best = nams
@@ -116,16 +103,15 @@ pub fn map_paired_end_read(
     r2: &SequenceRecord,
     index: &StrobemerIndex,
     references: &[RefSequence],
-    rescue_distance: usize,
     insert_size_distribution: &mut InsertSizeDistribution,
     mcs_strategy: McsStrategy,
     chainer: &Chainer,
     rng: &mut Rng,
 ) -> (Vec<PafRecord>, Details) {
     let (mut nam_details1, mut nams1) =
-        get_nams_by_chaining(&r1.sequence, index, chainer, rescue_distance, mcs_strategy);
+        get_nams_by_chaining(&r1.sequence, index, chainer, mcs_strategy);
     let (mut nam_details2, mut nams2) =
-        get_nams_by_chaining(&r2.sequence, index, chainer, rescue_distance, mcs_strategy);
+        get_nams_by_chaining(&r2.sequence, index, chainer, mcs_strategy);
 
     if nams1.is_empty() && nams2.is_empty() {
         nam_details1 += nam_details2;
@@ -200,16 +186,15 @@ pub fn abundances_paired_end_read(
     r2: &SequenceRecord,
     index: &StrobemerIndex,
     abundances: &mut [f64],
-    rescue_distance: usize,
     insert_size_distribution: &mut InsertSizeDistribution,
     mcs_strategy: McsStrategy,
     chainer: &Chainer,
     rng: &mut Rng,
 ) {
     let (nam_details1, mut nams1) =
-        get_nams_by_chaining(&r1.sequence, index, chainer, rescue_distance, mcs_strategy);
+        get_nams_by_chaining(&r1.sequence, index, chainer, mcs_strategy);
     let (nam_details2, mut nams2) =
-        get_nams_by_chaining(&r2.sequence, index, chainer, rescue_distance, mcs_strategy);
+        get_nams_by_chaining(&r2.sequence, index, chainer, mcs_strategy);
 
     if nams1.is_empty() && nams2.is_empty() {
         return;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -33,7 +33,6 @@ const MAX_PAIR_NAMS: usize = 1000;
 pub struct MappingParameters {
     pub max_secondary: usize,
     pub dropoff_threshold: f32,
-    pub rescue_distance: usize,
     pub max_tries: usize,
     pub mcs_strategy: McsStrategy,
     pub output_unmapped: bool,
@@ -45,7 +44,6 @@ impl Default for MappingParameters {
         MappingParameters {
             max_secondary: 0,
             dropoff_threshold: 0.5,
-            rescue_distance: 100,
             max_tries: 20,
             mcs_strategy: McsStrategy::default(),
             output_unmapped: true,
@@ -360,7 +358,6 @@ pub fn align_single_end_read(
         &record.sequence,
         index,
         chainer,
-        mapping_parameters.rescue_distance,
         mapping_parameters.mcs_strategy,
     );
     nam_details.time_sort_nams = sort_nams(&mut nams, rng);
@@ -628,7 +625,6 @@ pub fn align_paired_end_read(
             &record.sequence,
             index,
             chainer,
-            mapping_parameters.rescue_distance,
             mapping_parameters.mcs_strategy,
         );
         nam_details.time_sort_nams = sort_nams(&mut nams, rng);

--- a/src/nam.rs
+++ b/src/nam.rs
@@ -131,7 +131,6 @@ pub fn get_nams_by_chaining(
     sequence: &[u8],
     index: &StrobemerIndex,
     chainer: &Chainer,
-    rescue_distance: usize,
     mcs_strategy: McsStrategy,
 ) -> (NamDetails, Vec<Nam>) {
     let timer = Instant::now();
@@ -144,8 +143,7 @@ pub fn get_nams_by_chaining(
         query_randstrobes[1].len()
     );
 
-    let (mut nam_details, nams) =
-        chainer.get_chains(&query_randstrobes, index, rescue_distance, mcs_strategy);
+    let (mut nam_details, nams) = chainer.get_chains(&query_randstrobes, index, mcs_strategy);
 
     nam_details.time_randstrobes = time_randstrobes;
 


### PR DESCRIPTION
Implemented a sweep between non-repetitive hits (anchors) and filtered hits to recover relevant filtered hits before chaining. Do not add all filtered reads, but only select largely non-overlapping ones with a minimum hit-count with a Weighted Interval Scheduling (WIS) algorithm.

When adding nearly all seeds with the sweep algorithm (commit [1eefd33](https://github.com/ksahlin/strobealign/pull/590/commits/1eefd337bad38dcdafaafa9206ae6779f90a6baf)), the accuracy further increases, but does so at a large runtime cost (1.2-2.5x compared to main for 50-250nt reads, SE and PE). 

The WIS selection of seeds reduces runtime overhead to be, on average, about 10-20% slower than main (but sometimes also 5-10% faster). However, it improves accuracy on nearly all instances in both extension and mapping-only modes. In particular, the mapping-only accuracy is substantially improved; see the benchmark below. 

## General idea

After building the standard (non-repetitive) anchor set, filtered hit's reference positions are added back if they are on the same rough diagonal as at least one existing non-repetitive anchor, within a tolerance of `k` bp.

The diagonal of a seed hit is `ref_start - query_start`. Co-linear seeds share the same
diagonal, so this filter admits exactly the repetitive positions that are consistent with
"trusted" non-repetitive anchors.

Instead of adding back all filtered seeds (runtime), we add those with the lowest count that are also not overlapping too much (on the query), so this selects a subset of seeds to add back. We do this with WIS.

## Implementation

Three changes are made:

### 1. `RefRandstrobe` field reorder (`src/index.rs`)

The order of the fields in `RefRandstrobe` controls how the index is sorted. The field order is changed from `(hash_offset, position, ref_index)` to `(hash_offset, ref_index, position)`, so within a hash group entries are now sorted by **(ref_id, ref_start)**. This enables an efficient pure two-pointer sweep, as described below. The `.sti` file format version is bumped from 7 to 8; existing cached index files must be regenerated.

(Note: the algorithm also works with the old order `(ref_start, ref_id)`, but then one must maintain a hash table keyed on ref_id with separate sweep pointers per chromosome. This adds complexity and would perform poorly on genomes with thousands of contigs such as metagenomic assemblies. The field reorder eliminates this entirely.)

### 2. `add_repetitive_via_sweep` in `src/chainer.rs`

Called after `hits_to_anchors()` and before chaining. The algorithm:

**Step 1 — Build the eligible diagonal set.**
Collect all anchors from non-repetitive (non-filtered) hits, compute each anchor's diagonal `d = ref_start − query_start`, and sort the resulting `anchor_diags: Vec<(ref_id, diagonal)>`. Co-linear seeds share the same diagonal value, so this set encodes trusted mapping regions.

**Step 2 — Select filtered hits via Weighted Interval Scheduling (WIS).**
Rather than sweeping all filtered hits, we first select a non-overlapping tiling on the query. Hits are treated as intervals `[query_start, query_end]` with weight `CAP − count + 1` (higher weight for less-repetitive seeds; all weights are positive so the DP always selects at least one hit). The standard WIS DP runs in **O(n log n)** and recovers the maximum-weight subset of hits whose query intervals do not overlap by more than 10 bp. Seeds with more than 10,000 genomic positions are excluded before selection. This tiling step is critical: without it, overlapping filtered hits produce nearly-identical anchors that inflate the anchor set and double chaining time without improving accuracy.

**Step 3 — Two-pointer sweep.**
For each selected filtered hit at query position `q`, iterate its positions in the index (now sorted by `(ref_id, ref_start)` within the hash group). Maintain a single pointer into `anchor_diags`. Because both sequences increase in the same `(ref_id, value)` order, the pointer **never goes backwards** — a pure **O(N + A)** two-pointer sweep per selected hit, where N = repetitive positions and A = non-repetitive anchors. Any repetitive position whose diagonal falls within `tolerance = k` bp of an anchor diagonal is added to the anchor set.

This sweep is closely related to the paired-chain sweeping approach of @NicolasBuchin used in strobealign's PE mapping mode.

**Complexity per read:** O(A log A) for sorting `anchor_diags` once; O(n log n) for WIS selection over the typically 2–5 filtered hits; O(N + A) amortised per selected hit for the sweep. An early-exit skips the entire function when no filtered hits exist (the common case for reads in unique regions).

### 3. Removal of local rescue

The existing local rescue mechanism (rescuing filtered seeds in stretches longer than `rescue_distance`) is removed. The sweep now covers what rescue previously handled for reads in repetitive regions. A minimal global rescue is retained only for reads with fewer than 5 non-repetitive hits.

### 4. Added `--filter-cutoff` command-line parameter

Allows directly overriding the filter cutoff at runtime without recompiling, which proved useful for testing the effect of including more or fewer repetitive seeds.

## Breaking change

`STI_FILE_FORMAT_VERSION` is bumped from 7 to 8 due to the `RefRandstrobe` field reorder.
Existing `.sti` index files will be rejected with a clear version-mismatch error and must
be regenerated with `strobealign --create-index`.


# Benchmarks 

WIS solution percent point (pp) change in accuracy (left) and percent change in runtime (right) compared to baseline. Upper panels are extension, lower mapping-only. Red lines for PE blue for SE. 

## SIM1 (--snp-rate 0.001 --small-indel-rate 0.0001 --max-small-indel-size 50)

#### CHM13

<img width="1934" height="1384" alt="lowvar_CHM13_delta" src="https://github.com/user-attachments/assets/3de3588f-e9c3-4c3a-8fbd-68310d7e60fb" />

#### Maize

<img width="1934" height="1384" alt="lowvar_Maize_delta" src="https://github.com/user-attachments/assets/54795715-787d-4ade-9259-782c1d03b56c" />


## SIM5 (--snp-rate 0.01 --small-indel-rate 0.002 --max-small-indel-size 100)

#### CHM13

<img width="1934" height="1384" alt="highvar_CHM13_delta" src="https://github.com/user-attachments/assets/bef2a68d-7c9f-40ca-86d8-785413e745cb" />


#### Maize

<img width="1934" height="1384" alt="highvar_Maize_delta" src="https://github.com/user-attachments/assets/85b333f1-e58f-4964-9212-d8e189f079d2" />

