### PR TITLE
Fix unmapped secondary alignments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,9 +83,10 @@ jobs:
         run: tests/compare-baseline.sh
       - name: Validate with Picard
         run: |
-          PicardCommandLine ValidateSamFile IGNORE=RECORD_MISSING_READ_GROUP IGNORE=MISSING_READ_GROUP I=head.bam
+          # IGNORE=QUALITY_NOT_STORED because Picard incorrectly warns about missing qualities for secondary alignments
+          PicardCommandLine ValidateSamFile IGNORE=RECORD_MISSING_READ_GROUP IGNORE=MISSING_READ_GROUP IGNORE=QUALITY_NOT_STORED I=head.bam
       - name: Compare to baseline (single-end)
         run: tests/compare-baseline.sh -s
       - name: Validate with Picard
         run: |
-          PicardCommandLine ValidateSamFile IGNORE=RECORD_MISSING_READ_GROUP IGNORE=MISSING_READ_GROUP I=head.bam
+          PicardCommandLine ValidateSamFile IGNORE=RECORD_MISSING_READ_GROUP IGNORE=MISSING_READ_GROUP IGNORE=QUALITY_NOT_STORED I=head.bam

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -237,6 +237,11 @@ impl SamOutput {
         sam_records
     }
 
+    /// Create two SAM records, one for each end of a paired-end read.
+    /// At least one of the reads must have an `Alignment`
+    /// (use `make_unmapped_pair` otherwise).
+    /// No unmapped secondary alignments are returned (this is the only case
+    /// for which the returned vector can have one element).
     fn make_paired_records(
         &self,
         alignments: [Option<&Alignment>; 2],
@@ -246,9 +251,10 @@ impl SamOutput {
         details: &[Details; 2],
         alignment_status: AlignmentStatus,
         pair_status: PairStatus,
-    ) -> [SamRecord; 2] {
-        // Create single-end records
-        let mut sam_records = [
+    ) -> Vec<SamRecord> {
+        assert!(alignments[0].is_some() || alignments[1].is_some());
+        // Create single-end records ...
+        let mut sam_records = vec![
             self.make_record(
                 alignments[0],
                 references,
@@ -266,7 +272,7 @@ impl SamOutput {
                 details[1].clone(),
             ),
         ];
-        // Then make them paired
+        // ... then make them paired
         sam_records[0].flags |= READ1;
         sam_records[1].flags |= READ2;
 
@@ -323,6 +329,15 @@ impl SamOutput {
                     sam_records[i].mate_reference_name = Some("=".to_string());
                     sam_records[i].mate_pos = Some(this.ref_start as u32);
                 }
+            }
+        }
+
+        // Avoid unmapped secondary alignments
+        if alignment_status == AlignmentStatus::Secondary {
+            if !sam_records[1].is_mapped() {
+                sam_records.pop();
+            } else if !sam_records[0].is_mapped() {
+                sam_records.swap_remove(0);
             }
         }
 

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1161,12 +1161,7 @@ pub fn is_proper_nam_pair(nam1: &Nam, nam2: &Nam, mu: f32, sigma: f32) -> bool {
 /// Find high-scoring NAMs and NAM pairs. Proper pairs are preferred, but also
 /// high-scoring NAMs that could not be paired up are returned (these are paired
 /// with None in the returned vector).
-pub fn get_best_scoring_nam_pairs(
-    nams1: &[Nam],
-    nams2: &[Nam],
-    mu: f32,
-    sigma: f32,
-) -> Vec<NamPair> {
+fn get_best_scoring_nam_pairs(nams1: &[Nam], nams2: &[Nam], mu: f32, sigma: f32) -> Vec<NamPair> {
     let mut nam_pairs = vec![];
     if nams1.is_empty() && nams2.is_empty() {
         return nam_pairs;
@@ -1258,14 +1253,14 @@ pub fn mapping_quality(nams: &[Nam]) -> u8 {
 }
 
 #[derive(Debug)]
-pub struct NamPair {
+struct NamPair {
     pub score: f32,
     pub nam1: Option<Nam>,
     pub nam2: Option<Nam>,
 }
 
 #[derive(Debug, Clone)]
-pub struct ScoredAlignmentPair {
+struct ScoredAlignmentPair {
     score: f64,
     alignment1: Option<Alignment>,
     alignment2: Option<Alignment>,

--- a/tests/compare-baseline.sh
+++ b/tests/compare-baseline.sh
@@ -61,14 +61,14 @@ if ! test -f ${baseline_bam}; then
     mv ${srcdir}/target/release/strobealign ${baseline_binary}
     rm -rf "${srcdir}"
   fi
-  ${baseline_binary} -v -t ${threads} ${ref} ${reads[@]} | samtools view -o ${baseline_bam}.tmp.bam
+  ${baseline_binary} -N 2 -v -t ${threads} ${ref} ${reads[@]} | samtools view -o ${baseline_bam}.tmp.bam
   mv ${baseline_bam}.tmp.bam ${baseline_bam}
 fi
 
 # Build and run strobealign
 cargo build --release
 set -x
-target/release/strobealign -v -t ${threads} ${ref} ${reads[@]} | samtools view -o head.bam
+target/release/strobealign -N 2 -v -t ${threads} ${ref} ${reads[@]} | samtools view -o head.bam
 
 # Do the actual comparison
 tests/samdiff.py ${baseline_bam} head.bam

--- a/tests/samdiff.py
+++ b/tests/samdiff.py
@@ -9,6 +9,7 @@ Record identity is based on reference name and reference start position
 (RNAME, POS) only. Differences in the other SAM fields (flags, MAPQ, CIGAR,
 RNEXT, PNEXT, TLEN) are ignored.
 """
+
 import sys
 from argparse import ArgumentParser
 from contextlib import ExitStack
@@ -35,6 +36,8 @@ def main():
     with ExitStack() as stack:
         before = stack.enter_context(AlignmentFile(args.before))
         after = stack.enter_context(AlignmentFile(args.after))
+        before = skip_secondary(before)
+        after = skip_secondary(after)
         if has_truth:
             truth = stack.enter_context(AlignmentFile(args.truth))
         else:
@@ -162,6 +165,13 @@ def main():
 
     if unmapped_same + identical < single_total or single_total == 0:
         sys.exit(1)
+
+
+def skip_secondary(records):
+    for record in records:
+        if record.is_secondary:
+            continue
+        yield record
 
 
 def print_comparison(b: AlignedSegment, a: AlignedSegment):


### PR DESCRIPTION
When secondary alignments are enabled, we currently handle unmapped reads incorrectly. So for example, if we have a pair where R1 can be mapped and has multiple mappings but R2 cannot be mapped, we output these SAM records:
* R1 with primary mapping location
* R2 marked as unmapped
* R1 with alternative location, marked as secondary
* R2 as an unmapped read, *not marked as secondary* (this is the problematic record)

I first changed it so that the second time R2 is output it is also marked as secondary, but then we have a SAM record that is both unmapped and secondary, which `picard ValidateSamFile` rightfully complains about. The correct solution seems to be to just not output that last record, which is what this PR does.

Also, we now let strobealign generate secondary alignments within the baseline comparison script. They are ignored when actually comparing the records to the baseline version, but this allows us to run `ValidateSamFile` on a file with secondary alignments.

The last commit changes the baseline commit because running strobealign with `-N 5` and ignoring all secondary alignments does not give the same results as running it with `-N 0`.