### PR TITLE
Implement 2-bit representation of reference sequences.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@
   If you need one of the above features, use version 0.17.0.
 * #550: Introduce piecewise extension for single-end reads. The previous 
   SSW extension can be enabled with `--ssw`.
+* #595: The in-memory representation of the reference sequence now uses two bits
+  per nucleotide, reducing memory usage of the reference to 25% of its previous
+  size. This change does not affect runtime.
 * #539: Add a "noisy" read profile. Use `-P noisy` on the command line to
   select it. This is equivalent to `-k 16 -s 12 -l 2 -u 2 -m 100`.
   We found these settings to increase accuracy on error-prone reads at the cost

--- a/src/index.rs
+++ b/src/index.rs
@@ -542,6 +542,7 @@ mod tests {
 
     use crate::indexer::make_index;
     use crate::io::fasta::{RefSequence, read_ref};
+    use crate::packed_seq::PackedSeq;
     use crate::revcomp::reverse_complement;
 
     #[test]
@@ -590,7 +591,7 @@ mod tests {
         let rc_seq = reverse_complement(&seq_decoded);
         let rc_references = vec![RefSequence {
             name: "phix_rc".to_string(),
-            sequence: crate::packed_seq::PackedSeq::from_slice(&rc_seq),
+            sequence: PackedSeq::from_slice(&rc_seq),
         }];
 
         let parameters = SeedingParameters::new(300);

--- a/src/index.rs
+++ b/src/index.rs
@@ -586,11 +586,11 @@ mod tests {
     #[test]
     fn test_partial_orientation() {
         let references = read_ref("tests/phix.fasta").unwrap();
-        let seq = &references[0].sequence;
-        let rc_seq = reverse_complement(seq);
+        let seq_decoded = references[0].sequence.decode_all();
+        let rc_seq = reverse_complement(&seq_decoded);
         let rc_references = vec![RefSequence {
             name: "phix_rc".to_string(),
-            sequence: rc_seq,
+            sequence: crate::packed_seq::PackedSeq::from_slice(&rc_seq),
         }];
 
         let parameters = SeedingParameters::new(300);

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,5 +1,6 @@
 use crate::index::{BucketIndex, RandstrobeHash, RefRandstrobe, StrobemerIndex};
 use crate::io::fasta::RefSequence;
+use crate::packed_seq::PackedSeq;
 use crate::seeding::{RandstrobeIterator, SeedingParameters, SyncmerIterator, SyncmerParameters};
 
 use std::cmp::Reverse;
@@ -223,7 +224,7 @@ fn assign_randstrobes(
     ref_index: usize,
     randstrobes: &mut [RefRandstrobe],
 ) {
-    let seq = &references[ref_index].sequence;
+    let seq: &PackedSeq = &references[ref_index].sequence;
     if seq.len() < parameters.randstrobe.w_max {
         return;
     }
@@ -276,16 +277,15 @@ fn count_all_randstrobes(
     mutex.into_inner().unwrap()
 }
 
-/// Count randstrobes by counting syncmers
-fn count_randstrobes(seq: &[u8], parameters: &SeedingParameters) -> usize {
-    let syncmer_iterator = SyncmerIterator::new(
+/// Count randstrobes by counting syncmers (operates directly on PackedSeq)
+fn count_randstrobes(seq: &PackedSeq, parameters: &SeedingParameters) -> usize {
+    SyncmerIterator::new(
         seq,
         parameters.syncmer.k,
         parameters.syncmer.s,
         parameters.syncmer.t,
-    );
-
-    syncmer_iterator.count()
+    )
+    .count()
 }
 
 impl SyncmerParameters {
@@ -359,6 +359,7 @@ impl Display for IndexCreationStatistics {
 #[cfg(test)]
 mod test {
     use crate::io::fasta::read_ref;
+    use crate::packed_seq::PackedSeq;
 
     use super::*;
 
@@ -382,7 +383,7 @@ mod test {
     fn test_index_empty_reference() {
         let references = vec![RefSequence {
             name: "name".to_string(),
-            sequence: vec![],
+            sequence: PackedSeq::new(),
         }];
         let parameters = SeedingParameters::new(150);
         let bits = parameters.syncmer.pick_bits(&references);

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -126,7 +126,10 @@ pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<Vec<RefSequence>, Sequen
             Ok(_) => {
                 if line.starts_with('>') {
                     if let Some(name) = current_name.take() {
-                        records.push(RefSequence { name, sequence: current_seq });
+                        records.push(RefSequence {
+                            name,
+                            sequence: current_seq,
+                        });
                         current_seq = PackedSeq::new();
                     }
                     let (name, _comment) = split_header(&line[1..]);
@@ -145,7 +148,10 @@ pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<Vec<RefSequence>, Sequen
         }
     }
     if let Some(name) = current_name {
-        records.push(RefSequence { name, sequence: current_seq });
+        records.push(RefSequence {
+            name,
+            sequence: current_seq,
+        });
     }
 
     for record in &records {

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -4,11 +4,12 @@ use std::path::Path;
 
 use crate::io::record::{End, SequenceRecord};
 use crate::io::{SequenceIOError, split_header};
+use crate::packed_seq::PackedSeq;
 
 #[derive(Debug, Clone)]
 pub struct RefSequence {
     pub name: String,
-    pub sequence: Vec<u8>,
+    pub sequence: PackedSeq,
 }
 
 /// Check whether a name is fine to use in SAM output.
@@ -113,18 +114,42 @@ impl<B: BufRead> Iterator for FastaReader<B> {
 }
 
 pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<Vec<RefSequence>, SequenceIOError> {
-    let fasta_reader = FastaReader::new(reader);
-    let records = fasta_reader
-        .map(|result| {
-            result.map(|record| RefSequence {
-                name: record.name,
-                sequence: record.sequence,
-            })
-        })
-        .collect::<Result<Vec<RefSequence>, SequenceIOError>>()?;
+    let mut records: Vec<RefSequence> = Vec::new();
+    let mut current_name: Option<String> = None;
+    let mut current_seq = PackedSeq::new();
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                if line.starts_with('>') {
+                    if let Some(name) = current_name.take() {
+                        records.push(RefSequence { name, sequence: current_seq });
+                        current_seq = PackedSeq::new();
+                    }
+                    let (name, _comment) = split_header(&line[1..]);
+                    current_name = Some(name.to_string());
+                } else if current_name.is_some() {
+                    for c in line.trim_ascii_end().bytes() {
+                        current_seq.push(c);
+                    }
+                } else if !line.trim_ascii().is_empty() {
+                    return Err(SequenceIOError::Fasta(
+                        "FASTA file must start with '>'".to_string(),
+                    ));
+                }
+            }
+            Err(e) => return Err(SequenceIOError::IO(e)),
+        }
+    }
+    if let Some(name) = current_name {
+        records.push(RefSequence { name, sequence: current_seq });
+    }
 
     for record in &records {
-        if !is_valid_name(&record.name.as_bytes()) {
+        if !is_valid_name(record.name.as_bytes()) {
             return Err(SequenceIOError::Name);
         }
     }
@@ -152,7 +177,7 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].name, "NC_001422.1");
         assert_eq!(records[0].sequence.len(), 5386);
-        assert_eq!(&records[0].sequence[..5], b"GAGTT");
+        assert_eq!(records[0].sequence.decode(0, 5), b"GAGTT");
     }
 
     #[test]
@@ -220,13 +245,13 @@ mod tests {
         let records = read_ref(tmp.path()).unwrap();
         assert_eq!(records.len(), 4);
         assert_eq!(records[0].name, "ref1");
-        assert_eq!(records[0].sequence, b"ACGT");
+        assert_eq!(records[0].sequence.decode_all(), b"ACGT");
         assert_eq!(records[1].name, "ref2");
-        assert_eq!(records[1].sequence, b"AACCGGTT");
+        assert_eq!(records[1].sequence.decode_all(), b"AACCGGTT");
         assert_eq!(records[2].name, "empty");
-        assert_eq!(records[2].sequence, b"");
+        assert_eq!(records[2].sequence.decode_all(), b"");
         assert_eq!(records[3].name, "empty_at_end_of_file");
-        assert_eq!(records[3].sequence, b"");
+        assert_eq!(records[3].sequence.decode_all(), b"");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod aligner;
+pub mod packed_seq;
 pub mod chainer;
 pub mod cigar;
 pub mod details;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod aligner;
-pub mod packed_seq;
 pub mod chainer;
 pub mod cigar;
 pub mod details;
@@ -13,6 +12,7 @@ pub mod mapper;
 pub mod math;
 pub mod mcsstrategy;
 pub mod nam;
+pub mod packed_seq;
 pub mod partition;
 pub mod piecewisealigner;
 pub mod read;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -591,11 +591,15 @@ fn extend_seed(
             let decode_start = nam.ref_start.saturating_sub(query.len() + padding);
             let decode_end = (nam.ref_end + query.len() + padding).min(refseq.len());
             let decoded_ref = refseq.decode(decode_start, decode_end);
-            let adjusted_anchors: Vec<Anchor> = nam.anchors.iter().map(|a| Anchor {
-                ref_id: a.ref_id,
-                ref_start: a.ref_start - decode_start,
-                query_start: a.query_start,
-            }).collect();
+            let adjusted_anchors: Vec<Anchor> = nam
+                .anchors
+                .iter()
+                .map(|a| Anchor {
+                    ref_id: a.ref_id,
+                    ref_start: a.ref_start - decode_start,
+                    query_start: a.query_start,
+                })
+                .collect();
             info = aligner.align_piecewise(query, &decoded_ref, &adjusted_anchors, padding)?;
             result_ref_start = info.ref_start + decode_start;
         }
@@ -1093,7 +1097,9 @@ fn rescue_align(
         //        std::cerr << "RESCUE: Caught Bug3! ref start: " << ref_start << " ref end: " << ref_end << " ref len:  " << ref_len << std::endl;
         return None;
     }
-    let ref_segm = references[mate_nam.ref_id].sequence.decode(ref_start, ref_end);
+    let ref_segm = references[mate_nam.ref_id]
+        .sequence
+        .decode(ref_start, ref_end);
 
     if !has_shared_substring(r_tmp, &ref_segm, k) {
         return None;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -9,7 +9,7 @@ use memchr::memmem;
 
 use crate::aligner::Aligner;
 use crate::aligner::{AlignmentInfo, hamming_align, hamming_distance};
-use crate::chainer::Chainer;
+use crate::chainer::{Anchor, Chainer};
 use crate::cigar::{Cigar, CigarOperation};
 use crate::details::Details;
 use crate::index::StrobemerIndex;
@@ -559,13 +559,13 @@ fn extend_seed(
     let mut result_ref_start = 0;
     let mut gapped = true;
     if projected_ref_start + query.len() == projected_ref_end && consistent_nam {
-        let ref_segm_ham = &refseq[projected_ref_start..projected_ref_end];
-        if let Some(hamming_dist) = hamming_distance(query, ref_segm_ham) {
+        let ref_segm_ham = refseq.decode(projected_ref_start, projected_ref_end);
+        if let Some(hamming_dist) = hamming_distance(query, &ref_segm_ham) {
             if (hamming_dist as f32 / query.len() as f32) < 0.05 {
                 // ungapped worked fine, no need to do gapped alignment
                 info = hamming_align(
                     query,
-                    ref_segm_ham,
+                    &ref_segm_ham,
                     aligner.scores.match_,
                     aligner.scores.mismatch,
                     aligner.scores.end_bonus,
@@ -581,13 +581,23 @@ fn extend_seed(
         if use_ssw {
             let ref_start = projected_ref_start.saturating_sub(padding);
             let ref_end = min(projected_ref_end + padding, refseq.len());
-            let segment = &refseq[ref_start..ref_end];
-            info = aligner.align(query, segment)?;
+            let segment = refseq.decode(ref_start, ref_end);
+            info = aligner.align(query, &segment)?;
             result_ref_start = ref_start + info.ref_start;
         } else {
             remove_spurious_anchors(&mut nam.anchors);
-            info = aligner.align_piecewise(query, refseq, &nam.anchors, padding)?;
-            result_ref_start = info.ref_start;
+            // Decode the reference region needed by the piecewise aligner.
+            // Use a generous range so all anchor-relative slices stay in bounds.
+            let decode_start = nam.ref_start.saturating_sub(query.len() + padding);
+            let decode_end = (nam.ref_end + query.len() + padding).min(refseq.len());
+            let decoded_ref = refseq.decode(decode_start, decode_end);
+            let adjusted_anchors: Vec<Anchor> = nam.anchors.iter().map(|a| Anchor {
+                ref_id: a.ref_id,
+                ref_start: a.ref_start - decode_start,
+                query_start: a.query_start,
+            }).collect();
+            info = aligner.align_piecewise(query, &decoded_ref, &adjusted_anchors, padding)?;
+            result_ref_start = info.ref_start + decode_start;
         }
     }
     Some(Alignment {
@@ -1083,12 +1093,12 @@ fn rescue_align(
         //        std::cerr << "RESCUE: Caught Bug3! ref start: " << ref_start << " ref end: " << ref_end << " ref len:  " << ref_len << std::endl;
         return None;
     }
-    let ref_segm = &references[mate_nam.ref_id].sequence[ref_start..ref_end];
+    let ref_segm = references[mate_nam.ref_id].sequence.decode(ref_start, ref_end);
 
-    if !has_shared_substring(r_tmp, ref_segm, k) {
+    if !has_shared_substring(r_tmp, &ref_segm, k) {
         return None;
     }
-    let info = aligner.align(r_tmp, ref_segm);
+    let info = aligner.align(r_tmp, &ref_segm);
     if let Some(info) = info {
         Some(Alignment {
             reference_id: mate_nam.ref_id,

--- a/src/nam.rs
+++ b/src/nam.rs
@@ -47,8 +47,12 @@ impl Nam {
     /// reference by comparing the nucleotide sequences of the first and last
     /// strobe (taking orientation into account).
     pub fn is_consistent(&self, read: &Read, references: &[RefSequence], k: usize) -> bool {
-        let ref_start_kmer = references[self.ref_id].sequence.decode(self.ref_start, self.ref_start + k);
-        let ref_end_kmer = references[self.ref_id].sequence.decode(self.ref_end - k, self.ref_end);
+        let ref_start_kmer = references[self.ref_id]
+            .sequence
+            .decode(self.ref_start, self.ref_start + k);
+        let ref_end_kmer = references[self.ref_id]
+            .sequence
+            .decode(self.ref_end - k, self.ref_end);
 
         let seq = if self.is_revcomp {
             read.rc()
@@ -93,8 +97,12 @@ pub fn reverse_nam_if_needed(
     references: &[RefSequence],
     k: usize,
 ) -> bool {
-    let ref_start_kmer = references[nam.ref_id].sequence.decode(nam.ref_start, nam.ref_start + k);
-    let ref_end_kmer = references[nam.ref_id].sequence.decode(nam.ref_end - k, nam.ref_end);
+    let ref_start_kmer = references[nam.ref_id]
+        .sequence
+        .decode(nam.ref_start, nam.ref_start + k);
+    let ref_end_kmer = references[nam.ref_id]
+        .sequence
+        .decode(nam.ref_end - k, nam.ref_end);
 
     let (seq, seq_rc) = if nam.is_revcomp {
         (read.rc(), read.seq())

--- a/src/nam.rs
+++ b/src/nam.rs
@@ -47,8 +47,8 @@ impl Nam {
     /// reference by comparing the nucleotide sequences of the first and last
     /// strobe (taking orientation into account).
     pub fn is_consistent(&self, read: &Read, references: &[RefSequence], k: usize) -> bool {
-        let ref_start_kmer = &references[self.ref_id].sequence[self.ref_start..self.ref_start + k];
-        let ref_end_kmer = &references[self.ref_id].sequence[self.ref_end - k..self.ref_end];
+        let ref_start_kmer = references[self.ref_id].sequence.decode(self.ref_start, self.ref_start + k);
+        let ref_end_kmer = references[self.ref_id].sequence.decode(self.ref_end - k, self.ref_end);
 
         let seq = if self.is_revcomp {
             read.rc()
@@ -93,8 +93,8 @@ pub fn reverse_nam_if_needed(
     references: &[RefSequence],
     k: usize,
 ) -> bool {
-    let ref_start_kmer = &references[nam.ref_id].sequence[nam.ref_start..nam.ref_start + k];
-    let ref_end_kmer = &references[nam.ref_id].sequence[nam.ref_end - k..nam.ref_end];
+    let ref_start_kmer = references[nam.ref_id].sequence.decode(nam.ref_start, nam.ref_start + k);
+    let ref_end_kmer = references[nam.ref_id].sequence.decode(nam.ref_end - k, nam.ref_end);
 
     let (seq, seq_rc) = if nam.is_revcomp {
         (read.rc(), read.seq())

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -1,6 +1,6 @@
 /// 2-bit packed nucleotide sequence.
 ///
-/// Encoding: A=0, C=1, G=2, T/U=3.  Ambiguous/unknown bases (N, R, Y, …)
+/// Encoding: A=0, C=1, G=2, T/U=3.  Ambiguous/unknown bases (N, R, Y, ...)
 /// are replaced by a deterministic pseudo-random 2-bit value derived from
 /// their position (following BWA's convention), so that syncmers spanning
 /// an ambiguous region have effectively random hashes and will not
@@ -14,37 +14,46 @@ pub struct PackedSeq {
     len: usize,
 }
 
-const fn make_pack_table() -> [u8; 256] {
+const fn make_encode_table() -> [u8; 256] {
     let mut t = [0u8; 256];
-    t[b'C' as usize] = 1; t[b'c' as usize] = 1;
-    t[b'G' as usize] = 2; t[b'g' as usize] = 2;
-    t[b'T' as usize] = 3; t[b't' as usize] = 3;
-    t[b'U' as usize] = 3; t[b'u' as usize] = 3;
+    t[b'C' as usize] = 1;
+    t[b'c' as usize] = 1;
+    t[b'G' as usize] = 2;
+    t[b'g' as usize] = 2;
+    t[b'T' as usize] = 3;
+    t[b't' as usize] = 3;
+    t[b'U' as usize] = 3;
+    t[b'u' as usize] = 3;
     t
 }
 
-/// IS_AMBIG[c] = 1 for any byte that is not a standard ACGTU nucleotide.
-const fn make_is_ambig_table() -> [u8; 256] {
+/// IS_WILDCARD[c] = 1 for any ASCII byte c that is not a standard ACGTU nucleotide.
+const fn make_is_wildcard_table() -> [u8; 256] {
     let mut t = [1u8; 256];
-    t[b'A' as usize] = 0; t[b'a' as usize] = 0;
-    t[b'C' as usize] = 0; t[b'c' as usize] = 0;
-    t[b'G' as usize] = 0; t[b'g' as usize] = 0;
-    t[b'T' as usize] = 0; t[b't' as usize] = 0;
-    t[b'U' as usize] = 0; t[b'u' as usize] = 0;
+    t[b'A' as usize] = 0;
+    t[b'a' as usize] = 0;
+    t[b'C' as usize] = 0;
+    t[b'c' as usize] = 0;
+    t[b'G' as usize] = 0;
+    t[b'g' as usize] = 0;
+    t[b'T' as usize] = 0;
+    t[b't' as usize] = 0;
+    t[b'U' as usize] = 0;
+    t[b'u' as usize] = 0;
     t
 }
 
-static PACK: [u8; 256] = make_pack_table();
-static IS_AMBIG: [u8; 256] = make_is_ambig_table();
+static ENCODE: [u8; 256] = make_encode_table();
+static IS_WILDCARD: [u8; 256] = make_is_wildcard_table();
 static DECODE: [u8; 4] = [b'A', b'C', b'G', b'T'];
 
 /// Deterministic pseudo-random 2-bit value for position `pos`.
 ///
-/// Uses a Fibonacci/Knuth multiplicative hash so every ambiguous base at a
-/// distinct position maps to a distinct-looking 2-bit value, making syncmers
+/// This uses a Fibonacci/Knuth multiplicative hash so every ambiguous base at a
+/// distinct position maps to a random-looking 2-bit value, making syncmers
 /// that span N runs have effectively random hashes (following BWA's approach).
 #[inline]
-fn ambig_bits(pos: usize) -> u64 {
+fn encode_wildcard(pos: usize) -> u64 {
     let h = (pos as u64).wrapping_mul(0x9e3779b97f4a7c15);
     (h ^ (h >> 30)) & 3
 }
@@ -54,16 +63,24 @@ impl PackedSeq {
         Self::default()
     }
 
-    /// Append one byte (upper or lowercase ASCII nucleotide).
-    /// ACGTU → packed 2-bit value; any other byte (N, R, Y, …) →
+    /// Build a `PackedSeq` by packing every byte of a slice.
+    pub fn from_slice(s: &[u8]) -> Self {
+        let mut seq = PackedSeq::new();
+        for &c in s {
+            seq.push(c);
+        }
+        seq
+    }
+
+    /// Append one byte (upper- or lowercase ASCII nucleotide).
+    /// ACGTU → packed 2-bit value; any other byte (N, R, Y, ...) →
     /// deterministic pseudo-random 2-bit value derived from its position,
     /// so that syncmers spanning ambiguous regions get random hashes
-    /// rather than systematic A-biased ones.
     pub fn push(&mut self, c: u8) {
-        let bits = if IS_AMBIG[c as usize] == 0 {
-            PACK[c as usize] as u64
+        let bits = if IS_WILDCARD[c as usize] == 0 {
+            ENCODE[c as usize] as u64
         } else {
-            ambig_bits(self.len)
+            encode_wildcard(self.len)
         };
         let bit = (self.len & 31) * 2;
         if bit == 0 {
@@ -84,8 +101,8 @@ impl PackedSeq {
 
     /// Return the raw 2-bit value of base `i` (0=A, 1=C, 2=G, 3=T).
     /// Ambiguous positions return a pseudo-random value in 0..=3 (never 4).
-    /// No table lookups — use this in inner loops.
-    pub fn base_bits(&self, i: usize) -> u8 {
+    /// No table lookups - use this in inner loops.
+    pub fn nucleotide_bits(&self, i: usize) -> u8 {
         let word = i >> 5;
         let bit = (i & 31) * 2;
         ((self.data[word] >> bit) & 3) as u8
@@ -93,26 +110,17 @@ impl PackedSeq {
 
     /// Decode base `i` as an ASCII byte (A/C/G/T).
     /// Ambiguous positions decode to a pseudo-random nucleotide, not 'N'.
-    pub fn get_ascii(&self, i: usize) -> u8 {
-        DECODE[self.base_bits(i) as usize]
+    pub fn decode_at(&self, i: usize) -> u8 {
+        DECODE[self.nucleotide_bits(i) as usize]
     }
 
     /// Decode bases `start..end` as ASCII bytes.
     pub fn decode(&self, start: usize, end: usize) -> Vec<u8> {
-        (start..end).map(|i| self.get_ascii(i)).collect()
+        (start..end).map(|i| self.decode_at(i)).collect()
     }
 
     /// Decode the full sequence as ASCII bytes.
     pub fn decode_all(&self) -> Vec<u8> {
         self.decode(0, self.len)
-    }
-
-    /// Build a `PackedSeq` by packing every byte of a slice.
-    pub fn from_slice(s: &[u8]) -> Self {
-        let mut seq = PackedSeq::new();
-        for &c in s {
-            seq.push(c);
-        }
-        seq
     }
 }

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -1,0 +1,118 @@
+/// 2-bit packed nucleotide sequence.
+///
+/// Encoding: A=0, C=1, G=2, T/U=3.  Ambiguous/unknown bases (N, R, Y, …)
+/// are replaced by a deterministic pseudo-random 2-bit value derived from
+/// their position (following BWA's convention), so that syncmers spanning
+/// an ambiguous region have effectively random hashes and will not
+/// systematically collide with real read k-mers.
+///
+/// 32 bases are packed per u64, little-endian within each word
+/// (base i occupies bits 2*(i%32)+1 : 2*(i%32) of word i/32).
+#[derive(Debug, Clone, Default)]
+pub struct PackedSeq {
+    data: Vec<u64>,
+    len: usize,
+}
+
+const fn make_pack_table() -> [u8; 256] {
+    let mut t = [0u8; 256];
+    t[b'C' as usize] = 1; t[b'c' as usize] = 1;
+    t[b'G' as usize] = 2; t[b'g' as usize] = 2;
+    t[b'T' as usize] = 3; t[b't' as usize] = 3;
+    t[b'U' as usize] = 3; t[b'u' as usize] = 3;
+    t
+}
+
+/// IS_AMBIG[c] = 1 for any byte that is not a standard ACGTU nucleotide.
+const fn make_is_ambig_table() -> [u8; 256] {
+    let mut t = [1u8; 256];
+    t[b'A' as usize] = 0; t[b'a' as usize] = 0;
+    t[b'C' as usize] = 0; t[b'c' as usize] = 0;
+    t[b'G' as usize] = 0; t[b'g' as usize] = 0;
+    t[b'T' as usize] = 0; t[b't' as usize] = 0;
+    t[b'U' as usize] = 0; t[b'u' as usize] = 0;
+    t
+}
+
+static PACK: [u8; 256] = make_pack_table();
+static IS_AMBIG: [u8; 256] = make_is_ambig_table();
+static DECODE: [u8; 4] = [b'A', b'C', b'G', b'T'];
+
+/// Deterministic pseudo-random 2-bit value for position `pos`.
+///
+/// Uses a Fibonacci/Knuth multiplicative hash so every ambiguous base at a
+/// distinct position maps to a distinct-looking 2-bit value, making syncmers
+/// that span N runs have effectively random hashes (following BWA's approach).
+#[inline]
+fn ambig_bits(pos: usize) -> u64 {
+    let h = (pos as u64).wrapping_mul(0x9e3779b97f4a7c15);
+    (h ^ (h >> 30)) & 3
+}
+
+impl PackedSeq {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append one byte (upper or lowercase ASCII nucleotide).
+    /// ACGTU → packed 2-bit value; any other byte (N, R, Y, …) →
+    /// deterministic pseudo-random 2-bit value derived from its position,
+    /// so that syncmers spanning ambiguous regions get random hashes
+    /// rather than systematic A-biased ones.
+    pub fn push(&mut self, c: u8) {
+        let bits = if IS_AMBIG[c as usize] == 0 {
+            PACK[c as usize] as u64
+        } else {
+            ambig_bits(self.len)
+        };
+        let bit = (self.len & 31) * 2;
+        if bit == 0 {
+            self.data.push(bits);
+        } else {
+            *self.data.last_mut().unwrap() |= bits << bit;
+        }
+        self.len += 1;
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Return the raw 2-bit value of base `i` (0=A, 1=C, 2=G, 3=T).
+    /// Ambiguous positions return a pseudo-random value in 0..=3 (never 4).
+    /// No table lookups — use this in inner loops.
+    pub fn base_bits(&self, i: usize) -> u8 {
+        let word = i >> 5;
+        let bit = (i & 31) * 2;
+        ((self.data[word] >> bit) & 3) as u8
+    }
+
+    /// Decode base `i` as an ASCII byte (A/C/G/T).
+    /// Ambiguous positions decode to a pseudo-random nucleotide, not 'N'.
+    pub fn get_ascii(&self, i: usize) -> u8 {
+        DECODE[self.base_bits(i) as usize]
+    }
+
+    /// Decode bases `start..end` as ASCII bytes.
+    pub fn decode(&self, start: usize, end: usize) -> Vec<u8> {
+        (start..end).map(|i| self.get_ascii(i)).collect()
+    }
+
+    /// Decode the full sequence as ASCII bytes.
+    pub fn decode_all(&self) -> Vec<u8> {
+        self.decode(0, self.len)
+    }
+
+    /// Build a `PackedSeq` by packing every byte of a slice.
+    pub fn from_slice(s: &[u8]) -> Self {
+        let mut seq = PackedSeq::new();
+        for &c in s {
+            seq.push(c);
+        }
+        seq
+    }
+}

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -3,6 +3,31 @@ use std::collections::VecDeque;
 
 use super::InvalidSeedingParameter;
 use super::hash::xxh64;
+use crate::packed_seq::PackedSeq;
+
+/// Trait for types that can serve as a sequence source for `SyncmerIterator`.
+///
+/// `base_bits` returns the nucleotide as a 2-bit value (0=A, 1=C, 2=G, 3=T,
+/// 4=N/ambiguous). This is what the syncmer hash machinery needs directly,
+/// so implementations should avoid going through ASCII as an intermediate.
+pub trait SeqAccess {
+    fn base_bits(&self, i: usize) -> u8;
+    fn seq_len(&self) -> usize;
+}
+
+impl SeqAccess for &[u8] {
+    /// ASCII byte → 2-bit (0-3) or 4 for N.
+    fn base_bits(&self, i: usize) -> u8 { NUCLEOTIDES[self[i] as usize] }
+    fn seq_len(&self) -> usize { self.len() }
+}
+
+impl SeqAccess for &PackedSeq {
+    /// Direct 2-bit extract — no table lookups, never returns 4.
+    /// `**self` reaches `PackedSeq` so Rust resolves the inherent method,
+    /// not this trait method (no recursion).
+    fn base_bits(&self, i: usize) -> u8 { (**self).base_bits(i) }
+    fn seq_len(&self) -> usize { (**self).len() }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Syncmer {
@@ -57,8 +82,8 @@ impl SyncmerParameters {
     }
 }
 
-pub struct SyncmerIterator<'a> {
-    seq: &'a [u8],
+pub struct SyncmerIterator<S: SeqAccess> {
+    seq: S,
     k: usize,
     s: usize,
     t: usize,
@@ -66,7 +91,7 @@ pub struct SyncmerIterator<'a> {
     smask: u64,
     kshift: usize,
     sshift: usize,
-    qs: VecDeque<u64>, // s-mer hashes
+    qs: VecDeque<u64>,
     qs_min_val: u64,
     l: usize,
     xk: [u64; 2],
@@ -75,8 +100,8 @@ pub struct SyncmerIterator<'a> {
     exhausted: bool,
 }
 
-impl<'a> SyncmerIterator<'a> {
-    pub fn new(seq: &'a [u8], k: usize, s: usize, t: usize) -> SyncmerIterator<'a> {
+impl<S: SeqAccess> SyncmerIterator<S> {
+    pub fn new(seq: S, k: usize, s: usize, t: usize) -> SyncmerIterator<S> {
         SyncmerIterator {
             seq,
             k,
@@ -129,16 +154,15 @@ fn syncmer_smer_hash(value: u64) -> u64 {
     xxh64(value)
 }
 
-impl Iterator for SyncmerIterator<'_> {
+impl<S: SeqAccess> Iterator for SyncmerIterator<S> {
     type Item = Syncmer;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.exhausted {
             return None;
         }
-        for i in self.i..self.seq.len() {
-            let ch = self.seq[i];
-            let c = NUCLEOTIDES[ch as usize];
+        for i in self.i..self.seq.seq_len() {
+            let c = self.seq.base_bits(i);
             if c < 4 {
                 // not an "N" base
                 self.xk[0] = ((self.xk[0] << 2) | (c as u64)) & self.kmask; // forward strand
@@ -240,12 +264,13 @@ mod test {
     #[test]
     fn test_canonical_syncmers() {
         let parameters = SyncmerParameters::try_new(20, 16).unwrap();
-        let seq = read_ref("tests/phix.fasta")
+        let seq: Vec<u8> = read_ref("tests/phix.fasta")
             .unwrap()
             .pop()
             .unwrap()
-            .sequence;
-        let sequences = ["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".into(), seq];
+            .sequence
+            .decode_all();
+        let sequences: [Vec<u8>; 2] = [b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_vec(), seq];
         for s in sequences {
             let seq_revcomp = reverse_complement(&s);
             let syncmers_forward = syncmers_of(&s, &parameters);

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -7,26 +7,36 @@ use crate::packed_seq::PackedSeq;
 
 /// Trait for types that can serve as a sequence source for `SyncmerIterator`.
 ///
-/// `base_bits` returns the nucleotide as a 2-bit value (0=A, 1=C, 2=G, 3=T,
+/// `nucleotide_bits` returns the nucleotide as a 2-bit value (0=A, 1=C, 2=G, 3=T,
 /// 4=N/ambiguous). This is what the syncmer hash machinery needs directly,
 /// so implementations should avoid going through ASCII as an intermediate.
 pub trait SeqAccess {
-    fn base_bits(&self, i: usize) -> u8;
-    fn seq_len(&self) -> usize;
+    fn nucleotide_bits(&self, i: usize) -> u8;
+    fn len(&self) -> usize;
 }
 
 impl SeqAccess for &[u8] {
     /// ASCII byte → 2-bit (0-3) or 4 for N.
-    fn base_bits(&self, i: usize) -> u8 { NUCLEOTIDES[self[i] as usize] }
-    fn seq_len(&self) -> usize { self.len() }
+    fn nucleotide_bits(&self, i: usize) -> u8 {
+        NUCLEOTIDES[self[i] as usize]
+    }
+
+    fn len(&self) -> usize {
+        (**self).len()
+    }
 }
 
 impl SeqAccess for &PackedSeq {
-    /// Direct 2-bit extract — no table lookups, never returns 4.
+    /// Direct 2-bit extract - no table lookups, never returns 4.
     /// `**self` reaches `PackedSeq` so Rust resolves the inherent method,
     /// not this trait method (no recursion).
-    fn base_bits(&self, i: usize) -> u8 { (**self).base_bits(i) }
-    fn seq_len(&self) -> usize { (**self).len() }
+    fn nucleotide_bits(&self, i: usize) -> u8 {
+        (**self).nucleotide_bits(i)
+    }
+
+    fn len(&self) -> usize {
+        (**self).len()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,7 +101,7 @@ pub struct SyncmerIterator<S: SeqAccess> {
     smask: u64,
     kshift: usize,
     sshift: usize,
-    qs: VecDeque<u64>,
+    qs: VecDeque<u64>, // s-mer hashes
     qs_min_val: u64,
     l: usize,
     xk: [u64; 2],
@@ -161,8 +171,8 @@ impl<S: SeqAccess> Iterator for SyncmerIterator<S> {
         if self.exhausted {
             return None;
         }
-        for i in self.i..self.seq.seq_len() {
-            let c = self.seq.base_bits(i);
+        for i in self.i..self.seq.len() {
+            let c = self.seq.nucleotide_bits(i);
             if c < 4 {
                 // not an "N" base
                 self.xk[0] = ((self.xk[0] << 2) | (c as u64)) & self.kmask; // forward strand


### PR DESCRIPTION
Replaces Vec<u8> (1 byte/base) with PackedSeq (2 bits/base) for reference sequences. 

Memory savings as expected and runtime appears unaffected. 

1. FASTA is packed byte-by-byte during reading — no intermediate Vec<u8> per chromosome. 
2. SyncmerIterator is generic over a SeqAccess trait, so indexing iterates PackedSeq directly with no decode step -- base_bits() returns 2-bit values straight from the packed word. 
3. Alignment hot paths decode only the needed subrange on demand via PackedSeq::decode(start, end).

Currently, N/ambiguous bases map to A. Should we make this pseudo-random instead? 