### PR TITLE
Compute single-end MAPQ score better by considering at least two mappings. 

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -391,8 +391,10 @@ pub fn align_single_end_read(
         // Use score-based dropoff: chains are sorted by score.
         let score_dropoff = chain.score / chain_max.score;
 
-        if (tries > 1 && best_edit_distance == 0)
-            || score_dropoff < mapping_parameters.dropoff_threshold
+        // Always extend at least the top-2 NAMs so that second_best_score is
+        // meaningful when computing MAPQ score.
+        if tries > 1
+            && (best_edit_distance == 0 || score_dropoff < mapping_parameters.dropoff_threshold)
         {
             break;
         }


### PR DESCRIPTION
We knew for a long time that our MAPQ assignments have not always been the most representative. We should consider whether we want to make such an effort (see also the PE mapq fix in PR https://github.com/ksahlin/strobealign/pull/596).

This commit prevents most (but not all) of the false MAPQ=60 assignments. In some cases, we also get a couple of more correct alignments (although very few).

It does slow down the mapping a tad, I did some preliminary benchmark below based on some datasets I had generated for other analyses (diagnosing the sweep PR). The outlier of -18% in runtime is just an anomaly because I benchmarked on my laptop. Overall, it seems we fix 40–98% of false MAPQ=60 assignments, at a cost of <2% increease in runtime.

However, I also looked at 10,000 bp reads, and the runtime increased by 6%, while we corrected nearly none of the (much fewer) false mapq=60 assignments. So this is an example where we may not want to do the same for long reads, as discussed here: https://github.com/ksahlin/strobealign/issues/599 

## Corrected MAPQ
| genome | length | tag | correct | wrong | false_mapq60 | unmapped |
|--------|--------|-----|---------|-------|------------|----------|
| chrY | 100bp sim0 | main | 20,237 | 29,727 | 416 | 36 |
| chrY | 100bp sim0 | main_fix | 20,320 | 29,644 | 183 | 36 |
| chrY | 250bp sim0 | main | 24,089 | 25,908 | 526 | 3 |
| chrY | 250bp sim0 | main_fix | 24,023 | 25,974 | 13 | 3 |
| chrY | 1000bp sim0 | main | 34,016 | 15,983 | 223 | 1 |
| chrY | 1000bp sim0 | main_fix | 34,066 | 15,933 | 1 | 1 |
| CHM13 | 100bp | main | 457,556 | 41,801 | 798 | 643 |
| CHM13 | 100bp | main_fix | 457,588 | 41,769 | 460 | 643 |
| CHM13 | 1000bp | main | 484,434 | 15,559 | 170 | 7 |
| CHM13 | 1000bp | main_fix | 484,431 | 15,562 | 83 | 7 |
| maize | 100bp | main | 36,010 | 13,958 | 134 | 32 |
| maize | 100bp | main_fix | 36,025 | 13,943 | 25 | 32 |
| maize | 250bp | main | 45,258 | 4,742 | 44 | 0 |
| maize | 250bp | main_fix | 45,255 | 4,745 | 2 | 0 |

## Runtime
| genome | length | main | main_fix | delta |
|--------|--------|-------|-----------|-------|
| chrY | 100bp | 3,540 ms | 3,558 ms | +0.5% |
| chrY | 250bp | 4,528 ms | 4,504 ms | −0.5% |
| chrY | 1000bp | 15,553 ms | 15,839 ms | +1.8% |
| CHM13 | 100bp | 15,008 ms | 12,334 ms | −18% |
| CHM13 | 1000bp | 39,287 ms | 40,152 ms | +2.2% |
| maize | 100bp | 53,884 ms | 54,385 ms | +0.9% |
| maize | 250bp | 55,083 ms | 55,218 ms | +0.2% |

