### PR TITLE
Dropoff based on chain score instead on nr of anchors.

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -390,7 +390,8 @@ pub fn align_single_end_read(
         .take(mapping_parameters.max_tries)
         .enumerate()
     {
-        let score_dropoff = nam.anchors.len() as f32 / nam_max.anchors.len() as f32;
+        // Use score-based dropoff: NAMs are sorted by score.
+        let score_dropoff = nam.score / nam_max.score;
 
         if (tries > 1 && best_edit_distance == 0)
             || score_dropoff < mapping_parameters.dropoff_threshold
@@ -1000,12 +1001,13 @@ fn rescue_read(
     mu: f32,
     sigma: f32,
 ) -> Vec<ScoredAlignmentPair> {
-    let n_max1_hits = nams1[0].anchors.len();
+    let max_score1 = nams1[0].score;
 
     let mut alignments1 = vec![];
     let mut alignments2 = vec![];
     for nam in nams1.iter_mut().take(max_tries) {
-        let score_dropoff1 = nam.anchors.len() as f32 / n_max1_hits as f32;
+        // Use score-based dropoff for consistency with the sort key (NAMs are sorted by score).
+        let score_dropoff1 = nam.score / max_score1;
         // only consider top hits (as minimap2 does) and break if below dropoff cutoff.
         if score_dropoff1 < dropoff {
             break;


### PR DESCRIPTION
 Makes more sense based on the approach of sorting NAMs (chains) based on score.

Some benchmarks on single-end reads:

## Single-end alignment mode (8 threads)

| Genome      | Len | Tool | Reads   | Mapped% | Acc%    | Δ Acc   | Runtime  |
|-------------|-----|------|--------:|--------:|--------:|--------:|------:|
| chrY        | 100 | main |  50,000 | 47.640% | 33.458% |         |  1.5s |
| chrY        | 100 | fix  |  50,000 | 47.944% | 33.572% | +0.114% |  1.5s |
| chrY        | 250 | main |  50,000 | 52.776% | 38.712% |         |  1.5s |
| chrY        | 250 | fix  |  50,000 | 52.144% | 39.084% | +0.372% |  1.5s |
| CHM13 full  | 100 | main | 100,000 | 92.157% | 89.965% |         | 17.1s |
| CHM13 full  | 100 | fix  | 100,000 | 92.133% | 89.984% | +0.019% | 17.1s |
| CHM13 full  | 250 | main | 100,000 | 93.926% | 92.653% |         | 18.7s |
| CHM13 full  | 250 | fix  | 100,000 | 93.877% | 92.664% | +0.011% | 18.7s |
| Maize       | 100 | main |  50,000 | 75.940% | 67.474% |         | 10.9s |
| Maize       | 100 | fix  |  50,000 | 75.860% | 67.574% | +0.100% | 10.9s |
| Maize       | 250 | main |  50,000 | 89.550% | 87.722% |         | 11.1s |
| Maize       | 250 | fix  |  50,000 | 89.454% | 87.722% | +0.000% | 11.2s |

## Single-end mapping mode (-x, 8 threads)

Identical results for main and fix on all datasets — the fix only applies
to the alignment code path and does not affect mapping mode.