### PR TITLE
Also adds the score dropoff to PE path

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1454,10 +1454,9 @@ where
 /// compute dropoff of the first (top) NAM
 fn top_dropoff(nams: &[Nam]) -> f32 {
     let n_max = &nams[0];
-    if n_max.anchors.len() <= 2 {
-        1.0
-    } else if nams.len() > 1 {
-        nams[1].anchors.len() as f32 / n_max.anchors.len() as f32
+    if nams.len() > 1 {
+        debug_assert!(n_max.score > 0.0);
+        nams[1].score / n_max.score
     } else {
         0.0
     }


### PR DESCRIPTION
PR #601 fixed only for the SE path, plus for rescue function in PE mode. This PR completes the changes to also use score-based dropoff for the pairing of NAMs(/chains).

Neither runtime nor accuracy changes significantly (see accuracy experiment below). The fix is for consistency in approach.


## Paired-end alignment, 200k PE reads 

Genome | Len | Tool | Acc% | Δ vs main
-- | -- | -- | -- | --
chrY | 100 | main | 44.259% |  
chrY | 100 | score-dropoff | 44.279% | +0.020%
chrY | 250 | main | 55.867% |  
chrY | 250 | score-dropoff | 55.870% | +0.004%
chrY | 500 | main | 67.846% |  
chrY | 500 | score-dropoff | 67.842% | −0.004%
CHM13 | 100 | main | 93.525% |  
CHM13 | 100 | score-dropoff | 93.527% | +0.002%
CHM13 | 250 | main | 95.396% |  
CHM13 | 250 | score-dropoff | 95.396% | +0.000%
CHM13 | 500 | main | 96.919% |  
CHM13 | 500 | score-dropoff | 96.919% | +0.000%
Maize | 100 | main | 87.396% |  
Maize | 100 | score-dropoff | 87.378% | −0.018%
Maize | 250 | main | 95.942% |  
Maize | 250 | score-dropoff | 95.943% | +0.001%
Maize | 500 | main | 98.442% |  
Maize | 500 | score-dropoff | 98.444% | +0.002%

</body></html>