### PR TITLE
Fix various complaints that Clippy has

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
     - uses: actions/checkout@v5
     - name: Check formatting
       run: cargo fmt --check
+    - name: Run clippy
+      run: cargo clippy -- -D warnings
+    - name: Run clippy on tests
+      run: cargo clippy --tests -- -D warnings
     - name: Build
       run: cargo build --verbose
     - name: Run cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ lto = true
 [profile.profiling]
 inherits = "release"
 debug = true
+
+[lints.clippy]
+redundant_test_prefix = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ debug = true
 
 [lints.clippy]
 redundant_test_prefix = "deny"
+too_many_arguments = "allow"

--- a/src/aligner.rs
+++ b/src/aligner.rs
@@ -297,7 +297,7 @@ mod test {
     };
 
     #[test]
-    fn test_ssw_align_no_result() {
+    fn ssw_align_no_result() {
         let aligner = Aligner::new(Scores::default(), 0, 0);
         let query = b"TCTCTCCCTCTCTCTCTCTCCCTCCCTCTCTCTCCCTCTCTCTCTCTCTCTCCCTCCCTT";
         let refseq = b"GAGGGAGAGAGAGAGAGGGAGAGAGAGAGAGAG";
@@ -306,7 +306,7 @@ mod test {
     }
 
     #[test]
-    fn test_call_count() {
+    fn call_count() {
         let aligner = Aligner::new(Scores::default(), 0, 0);
         assert_eq!(aligner.call_count(), 0);
         let refseq = b"AAAAAACCCCCGGGGG";
@@ -319,7 +319,7 @@ mod test {
     }
 
     #[test]
-    fn test_highest_scoring_segment() {
+    fn highest_scoring_segment_works() {
         let (start, end, _score) = highest_scoring_segment(b"", b"", 5, 7, 0);
         assert_eq!(start, 0);
         assert_eq!(end, 0);
@@ -350,7 +350,7 @@ mod test {
     }
 
     #[test]
-    fn test_highest_scoring_segment_with_soft_clipping() {
+    fn highest_scoring_segment_with_soft_clipping() {
         assert_eq!(highest_scoring_segment(b"", b"", 2, 4, 5), (0, 0, 10));
         assert_eq!(
             highest_scoring_segment(b"TAAT", b"TAAA", 2, 4, 5),
@@ -375,7 +375,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_align_empty_sequences() {
+    fn hamming_align_empty_sequences() {
         let info = hamming_align(b"", b"", 7, 5, 0).unwrap();
         assert!(info.cigar.is_empty());
         assert_eq!(info.edit_distance, 0);
@@ -387,7 +387,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_align_one_mismatch() {
+    fn hamming_align_one_mismatch() {
         let info = hamming_align(b"AAXGGG", b"AAYGGG", 1, 1, 0).unwrap();
         assert_eq!(info.cigar.to_string(), "2=1X3=");
         assert_eq!(info.edit_distance, 1);
@@ -399,7 +399,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_align_soft_clipped() {
+    fn hamming_align_soft_clipped() {
         let info = hamming_align(b"AXGGG", b"AYGGG", 1, 4, 0).unwrap();
         assert_eq!(info.cigar.to_string(), "3=");
         assert_eq!(info.edit_distance, 0);
@@ -411,7 +411,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_align_wildcard() {
+    fn hamming_align_wildcard() {
         let info = hamming_align(b"NAACCG", b"TAACCG", 3, 7, 0).unwrap();
         assert_eq!(info.cigar.to_string(), "5=");
         assert_eq!(info.edit_distance, 0);
@@ -423,7 +423,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_align_wildcard_at_end() {
+    fn hamming_align_wildcard_at_end() {
         let info = hamming_align(b"AACCGN", b"AACCGT", 3, 7, 0).unwrap();
         assert_eq!(info.cigar.to_string(), "5=");
         assert_eq!(info.edit_distance, 0);
@@ -435,7 +435,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_align_both_ends_soft_clipped() {
+    fn hamming_align_both_ends_soft_clipped() {
         // negative total score, soft clipping on both ends
         let info = hamming_align(b"NAAAAAAAAAAAAAA", b"TAAAATTTTTTTTTT", 3, 7, 0).unwrap();
         assert_eq!(info.cigar.to_string(), "4=");
@@ -448,7 +448,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_align_long_soft_clipping() {
+    fn hamming_align_long_soft_clipping() {
         let info = hamming_align(b"NAAAAAAAAAAAAAA", b"TAAAATTTAAAAAAT", 3, 7, 0).unwrap();
         assert_eq!(info.cigar.to_string(), "6=");
         assert_eq!(info.edit_distance, 0);
@@ -460,7 +460,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_align_short_soft_clipping() {
+    fn hamming_align_short_soft_clipping() {
         let info = hamming_align(b"AAAAAAAAAAAAAAA", b"TAAAAAATTTAAAAT", 3, 7, 0).unwrap();
         assert_eq!(info.cigar.to_string(), "6=");
         assert_eq!(info.edit_distance, 0);
@@ -472,7 +472,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_global_perfect_match() {
+    fn hamming_global_perfect_match() {
         let info = hamming_align_global(b"ACGT", b"ACGT", 3, 7);
         assert_eq!(info.cigar.to_string(), "4=");
         assert_eq!(info.edit_distance, 0);
@@ -484,7 +484,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_global_all_mismatches() {
+    fn hamming_global_all_mismatches() {
         let info = hamming_align_global(b"AAAA", b"TTTT", 3, 7);
         assert_eq!(info.cigar.to_string(), "4X");
         assert_eq!(info.edit_distance, 4);
@@ -492,7 +492,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_global_mixed_matches_and_mismatches() {
+    fn hamming_global_mixed_matches_and_mismatches() {
         let info = hamming_align_global(b"ACGT", b"AGGT", 3, 7);
         assert_eq!(info.cigar.to_string(), "1=1X2=");
         assert_eq!(info.edit_distance, 1);
@@ -500,7 +500,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_global_single_base_mismatch() {
+    fn hamming_global_single_base_mismatch() {
         let info = hamming_align_global(b"A", b"C", 3, 7);
         assert_eq!(info.cigar.to_string(), "1X");
         assert_eq!(info.edit_distance, 1);
@@ -508,7 +508,7 @@ mod test {
     }
 
     #[test]
-    fn test_hamming_global_score_floored_with_mixed_alignment() {
+    fn hamming_global_score_floored_with_mixed_alignment() {
         let info = hamming_align_global(b"ACGT", b"AGGA", 3, 7);
         assert_eq!(info.cigar.to_string(), "1=1X1=1X");
         assert_eq!(info.edit_distance, 2);

--- a/src/aligner.rs
+++ b/src/aligner.rs
@@ -350,6 +350,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::identity_op)]
     fn highest_scoring_segment_with_soft_clipping() {
         assert_eq!(highest_scoring_segment(b"", b"", 2, 4, 5), (0, 0, 10));
         assert_eq!(

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -452,7 +452,7 @@ mod test {
     use super::{Anchor, Chainer, ChainingParameters};
 
     #[test]
-    fn test_chainer_early_break() {
+    fn chainer_early_break() {
         let chainer = Chainer::new(20, ChainingParameters::default());
         #[rustfmt::skip]
         let anchors = vec![
@@ -472,7 +472,7 @@ mod test {
     }
 
     #[test]
-    fn test_linear_score_adjacent_anchors() {
+    fn linear_score_adjacent_anchors() {
         let chainer = Chainer::new(20, ChainingParameters::default());
         #[rustfmt::skip]
         let anchors = [
@@ -497,7 +497,7 @@ mod test {
     }
 
     #[test]
-    fn test_diagonal_ratio_exceeded() {
+    fn diagonal_ratio_exceeded() {
         let chainer = Chainer::new(20, ChainingParameters::default());
         #[rustfmt::skip]
         let anchors = vec![

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -62,6 +62,7 @@ pub struct Chainer {
 impl Chainer {
     pub fn new(k: usize, parameters: ChainingParameters) -> Self {
         let mut precomputed_scores = [0f32; N_PRECOMPUTED];
+        #[allow(clippy::needless_range_loop)]
         for i in 0..N_PRECOMPUTED {
             precomputed_scores[i] = compute_score(i, i, k, &parameters);
         }

--- a/src/cigar.rs
+++ b/src/cigar.rs
@@ -261,7 +261,7 @@ mod test {
     }
 
     #[test]
-    fn test_construct() {
+    fn construct() {
         let cigar = Cigar::new();
         assert_eq!(cigar.to_string(), "");
 
@@ -332,7 +332,7 @@ mod test {
     }
 
     #[test]
-    fn test_reverse() {
+    fn reverse() {
         let c = Cigar::from_str("3=1X4D5I7=").unwrap();
         assert_eq!(c.reversed(), Cigar::from_str("7=5I4D1X3=").unwrap());
     }

--- a/src/hit.rs
+++ b/src/hit.rs
@@ -99,6 +99,7 @@ fn rescue_least_frequent(
 
     // Index and hit count
     let mut hit_counts = vec![];
+    #[allow(clippy::needless_range_loop)]
     for i in start..end {
         let entry = index.entry(hits[i].position);
         let cnt = if hits[i].is_partial {
@@ -249,11 +250,11 @@ fn rescue_all_least_frequent(
         first_filtered = i + 1;
     }
     // Ensure we consider the end as well
-    if let Some(last_hit) = hits.last() {
-        if last_hit.query_start - last_unfiltered_start > rescue_distance {
-            let to_rescue = (last_hit.query_start - last_unfiltered_start) / rescue_distance;
-            intervals.push((first_filtered, hits.len(), to_rescue));
-        }
+    if let Some(last_hit) = hits.last()
+        && last_hit.query_start - last_unfiltered_start > rescue_distance
+    {
+        let to_rescue = (last_hit.query_start - last_unfiltered_start) / rescue_distance;
+        intervals.push((first_filtered, hits.len(), to_rescue));
     }
 
     let mut rescued = 0;

--- a/src/index.rs
+++ b/src/index.rs
@@ -546,7 +546,7 @@ mod tests {
     use crate::revcomp::reverse_complement;
 
     #[test]
-    fn test_ref_randstrobe() {
+    fn ref_randstrobe() {
         let hash: u64 = 0x1234567890ABCDEFu64 & REF_RANDSTROBE_HASH_MASK;
         let ref_index: u32 = (REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES - 1) as u32;
         let offset = 255;
@@ -560,7 +560,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sti_parameters_mismatch() {
+    fn sti_parameters_mismatch() {
         use temp_dir::TempDir;
 
         let dir = TempDir::new().unwrap();
@@ -585,7 +585,7 @@ mod tests {
     }
 
     #[test]
-    fn test_partial_orientation() {
+    fn partial_orientation() {
         let references = read_ref("tests/phix.fasta").unwrap();
         let seq_decoded = references[0].sequence.decode_all();
         let rc_seq = reverse_complement(&seq_decoded);

--- a/src/index.rs
+++ b/src/index.rs
@@ -91,6 +91,7 @@ pub struct IndexEntry<'a> {
     pub position: usize,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl StrobemerIndex {
     pub fn new(
         parameters: SeedingParameters,
@@ -165,8 +166,8 @@ impl StrobemerIndex {
         const MAX_LINEAR_SEARCH: usize = 4;
         let top_n = (hash >> (64 - self.bits)) as usize;
         let position_start = start_position.unwrap_or(self.bucket_starts[top_n] as usize);
-        let position_end = self.bucket_starts[top_n + 1];
-        let bucket = &self.randstrobes[position_start as usize..position_end as usize];
+        let position_end = self.bucket_starts[top_n + 1] as usize;
+        let bucket = &self.randstrobes[position_start..position_end];
         if bucket.is_empty() {
             return None;
         } else if bucket.len() < MAX_LINEAR_SEARCH {
@@ -174,7 +175,7 @@ impl StrobemerIndex {
                 if randstrobe.hash() & hash_mask == masked_hash {
                     return Some(IndexEntry {
                         strobemer_index: self,
-                        position: position_start as usize + pos,
+                        position: position_start + pos,
                     });
                 }
                 if randstrobe.hash() & hash_mask > masked_hash {
@@ -188,7 +189,7 @@ impl StrobemerIndex {
         if pos < bucket.len() && bucket[pos].hash() & hash_mask == masked_hash {
             Some(IndexEntry {
                 strobemer_index: self,
-                position: position_start as usize + pos,
+                position: position_start + pos,
             })
         } else {
             None
@@ -383,7 +384,7 @@ impl StrobemerIndex {
         file.write_all(&(self.filter_cutoff as u32).to_ne_bytes())?;
         file.write_all(&(self.bits as u32).to_ne_bytes())?;
 
-        file.write_all(&(self.parameters.profile.clone() as u32).to_ne_bytes())?;
+        file.write_all(&(self.parameters.profile as u32).to_ne_bytes())?;
         let sp = &self.parameters.syncmer;
         for val in [sp.k, sp.s].iter() {
             file.write_all(&(*val as u32).to_ne_bytes())?
@@ -399,7 +400,7 @@ impl StrobemerIndex {
         {
             file.write_all(&val.to_ne_bytes())?;
         }
-        file.write_all(&(rp.main_hash_mask as u64).to_ne_bytes())?;
+        file.write_all(&rp.main_hash_mask.to_ne_bytes())?;
 
         write_vec(&mut file, &self.randstrobes)?;
         write_vec(&mut file, &self.bucket_starts)?;
@@ -408,7 +409,7 @@ impl StrobemerIndex {
     }
 }
 
-pub fn read_index<'a, P: AsRef<Path>>(
+pub fn read_index<P: AsRef<Path>>(
     path: P,
     parameters: SeedingParameters,
     bits: u8,
@@ -530,7 +531,7 @@ fn write_vec<T>(file: &mut File, data: &[T]) -> Result<(), Error> {
     file.write_all(&(data.len().to_ne_bytes()))?;
     // write data
     let data: &[u8] = unsafe {
-        std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * size_of::<T>())
+        std::slice::from_raw_parts(data.as_ptr() as *const u8, std::mem::size_of_val(data))
     };
 
     file.write_all(data)
@@ -612,7 +613,7 @@ mod tests {
             let rev_entry = rev_pos_result.unwrap();
 
             let rc_partial_query = fwd_index.randstrobes[i].hash()
-                ^ ((1 as u64) << rc_index.parameters.randstrobe.partial_orientation_pos);
+                ^ (1u64 << rc_index.parameters.randstrobe.partial_orientation_pos);
             let rev_pos_forward =
                 rc_index.get_partial_forward_from(rc_partial_query, rev_entry.position);
             assert!(rev_pos_forward.is_some());

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -15,8 +15,8 @@ use rayon;
 use rayon::slice::ParallelSliceMut;
 
 /// Create a StrobemerIndex
-pub fn make_index<'a>(
-    references: &'a [RefSequence],
+pub fn make_index(
+    references: &[RefSequence],
     parameters: SeedingParameters,
     bits: u8,
     filter_fraction: f64,
@@ -92,6 +92,7 @@ pub fn make_index<'a>(
     if !randstrobes.is_empty() {
         randstrobe_start_indices.push(0);
     }
+    #[allow(clippy::needless_range_loop)]
     for position in 1..randstrobes.len() {
         let cur_hash = randstrobes[position].hash();
         if cur_hash == prev_hash {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -364,14 +364,14 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_pick_bits() {
+    fn pick_bits() {
         let parameters = SyncmerParameters::try_new(20, 16).unwrap();
         let references = read_ref("tests/phix.fasta").unwrap();
         assert_eq!(parameters.pick_bits(&references), 9);
     }
 
     #[test]
-    fn test_index_phix() {
+    fn index_phix() {
         let references = read_ref("tests/phix.fasta").unwrap();
         let parameters = SeedingParameters::new(150);
         let bits = parameters.syncmer.pick_bits(&references);
@@ -380,7 +380,7 @@ mod test {
     }
 
     #[test]
-    fn test_index_empty_reference() {
+    fn index_empty_reference() {
         let references = vec![RefSequence {
             name: "name".to_string(),
             sequence: PackedSeq::new(),

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -124,7 +124,7 @@ pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<Vec<RefSequence>, Sequen
         match reader.read_line(&mut line) {
             Ok(0) => break,
             Ok(_) => {
-                if line.starts_with('>') {
+                if let Some(header) = line.strip_prefix('>') {
                     if let Some(name) = current_name.take() {
                         records.push(RefSequence {
                             name,
@@ -132,7 +132,7 @@ pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<Vec<RefSequence>, Sequen
                         });
                         current_seq = PackedSeq::new();
                     }
-                    let (name, _comment) = split_header(&line[1..]);
+                    let (name, _comment) = split_header(header);
                     current_name = Some(name.to_string());
                 } else if current_name.is_some() {
                     for c in line.trim_ascii_end().bytes() {

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -178,7 +178,7 @@ mod tests {
     use std::io::BufReader;
 
     #[test]
-    fn test_read_fasta() {
+    fn read_ref_works() {
         let records = read_ref("tests/phix.fasta").unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].name, "NC_001422.1");
@@ -187,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fasta_reader_empty_file() {
+    fn fasta_reader_empty_file() {
         let buf = BufReader::new(b"".as_slice());
         let reader = FastaReader::new(buf);
         let records = reader.collect::<Result<Vec<_>, _>>().unwrap();
@@ -196,7 +196,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fasta_reader() {
+    fn fasta_reader() {
         let f = File::open("tests/phix.fasta").unwrap();
         let mut bufreader = BufReader::new(f);
         let reader = FastaReader::new(&mut bufreader);
@@ -210,7 +210,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fasta_reader_only_name() {
+    fn fasta_reader_only_name() {
         let mut buf = BufReader::new(b">name\n".as_slice());
         let records = FastaReader::new(&mut buf)
             .collect::<Result<Vec<_>, _>>()
@@ -222,7 +222,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fasta_reader_uppercase() {
+    fn fasta_reader_uppercase() {
         let mut buf = BufReader::new(b">name\r\nacgt\n>name2\nTgCa".as_slice());
         let records = FastaReader::new(&mut buf)
             .collect::<Result<Vec<_>, _>>()
@@ -237,14 +237,14 @@ mod tests {
     }
 
     #[test]
-    fn test_fasta_must_start_with_greater_than() {
+    fn fasta_must_start_with_greater_than() {
         let mut buf = BufReader::new(b"bla".as_slice());
         let result = FastaReader::new(&mut buf).next().unwrap();
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_parse() {
+    fn parse() {
         let tmp = temp_file::with_contents(
             b">ref1 a comment\nacgt\n\n>ref2\naacc\ngg\n\ntt\n>empty\n>empty_at_end_of_file",
         );
@@ -261,7 +261,7 @@ mod tests {
     }
 
     #[test]
-    fn test_some_special_characters() {
+    fn some_special_characters() {
         let mut reader = BufReader::new(b"><>;abc\nAAAA\n>abc\nCCCC\n".as_slice());
         let records = read_fasta(&mut reader).unwrap();
         assert_eq!(records.len(), 2);
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    fn test_whitespace_in_header() {
+    fn whitespace_in_header() {
         let mut reader = BufReader::new(b">ab c\nACGT\n>de\tf\nACGT\n".as_slice());
         let records = read_fasta(&mut reader).unwrap();
         assert_eq!(records.len(), 2);
@@ -279,26 +279,26 @@ mod tests {
     }
 
     #[test]
-    fn test_fasta_error_on_fastq() {
+    fn fasta_error_on_fastq() {
         assert!(read_ref("tests/phix.1.fastq").is_err());
     }
 
     #[test]
-    fn test_invalid_contig_name() {
+    fn invalid_contig_name() {
         let mut reader = BufReader::new(b">name\x08\n".as_slice());
         let result = read_fasta(&mut reader);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_invalid_contig_name2() {
+    fn invalid_contig_name2() {
         let mut reader = BufReader::new(b">\0x80\nACGT\n".as_slice());
         let result = read_fasta(&mut reader);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_duplicate_contig_names() {
+    fn duplicate_contig_names() {
         let mut reader = BufReader::new(b">abc\nAAAA\n>abc\nCCCC\n".as_slice());
         let result = read_fasta(&mut reader);
         assert!(result.is_err());

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -101,7 +101,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn test_invalid_record_start() {
+    fn invalid_record_start() {
         let f = Cursor::new(b"@a\nA\n+\n#\n>b");
         let reader = FastqReader::new(f);
         let result = reader.collect::<Result<Vec<SequenceRecord>, SequenceIOError>>();
@@ -110,7 +110,7 @@ mod tests {
     }
 
     #[test]
-    fn test_too_few_quality_values() {
+    fn too_few_quality_values() {
         let f = Cursor::new(b"@a\nA\n+\n#\n>b");
         let reader = FastqReader::new(f);
         let result = reader.collect::<Result<Vec<SequenceRecord>, SequenceIOError>>();

--- a/src/io/fastq.rs
+++ b/src/io/fastq.rs
@@ -35,7 +35,7 @@ impl<B: BufRead> Iterator for FastqReader<B> {
             }
         }
         if !name.starts_with('@') {
-            let start = name.bytes().nth(0).unwrap() as char;
+            let start = name.as_bytes()[0] as char;
             let msg = format!("Record must start with '@', but found '{}'.", start);
             self.err = true;
             return Some(Err(SequenceIOError::Fastq(msg)));

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -31,7 +31,7 @@ pub enum SequenceIOError {
 /// Split header into name and comment
 pub fn split_header(header: &str) -> (String, Option<String>) {
     let header = header.trim_ascii_end();
-    match header.split_once(&[' ', '\t']) {
+    match header.split_once([' ', '\t']) {
         Some((name, comment)) => (name.to_string(), Some(comment.to_string())),
         None => (header.to_string(), None),
     }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -42,7 +42,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_split_header() {
+    fn split_header_works() {
         assert_eq!(
             split_header("id comment"),
             ("id".to_string(), Some("comment".to_string()))

--- a/src/io/reads.rs
+++ b/src/io/reads.rs
@@ -141,7 +141,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_open_reads_fastq() {
+    fn open_reads_fastq() {
         let f = File::open("tests/phix.1.fastq").unwrap();
         let mut reader = open_reads(f);
         let record1 = reader.next().unwrap().unwrap();
@@ -149,7 +149,7 @@ mod test {
     }
 
     #[test]
-    fn test_open_reads_fasta() {
+    fn open_reads_fasta() {
         let f = File::open("tests/phix.fasta").unwrap();
         let mut reader = open_reads(f);
         let record1 = reader.next().unwrap().unwrap();
@@ -157,7 +157,7 @@ mod test {
     }
 
     #[test]
-    fn test_peekable_sequence_reader() {
+    fn peekable_sequence_reader() {
         let f = File::open("tests/phix.1.fastq").unwrap();
         let mut reader = PeekableSequenceReader::new(open_reads(f));
 
@@ -175,7 +175,7 @@ mod test {
     }
 
     #[test]
-    fn test_interleaved_record_iterator() {
+    fn interleaved_record_iterator_works() {
         let f = File::open("tests/interleaved.fq").unwrap();
         let reader = PeekableSequenceReader::new(Box::new(FastqReader::new(BufReader::new(f))));
         let it = interleaved_record_iterator(reader);
@@ -204,7 +204,7 @@ mod test {
     }
 
     #[test]
-    fn test_interleaved_records_with_slash12() {
+    fn interleaved_records_with_slash12() {
         // Record name a/1 followed by a/2 should be recognized as a
         // paired-end read
         let f = Cursor::new(b"@a/1\nAACC\n+\n####\n@a/2\nGGTT\n+n\n####\n");

--- a/src/io/reads.rs
+++ b/src/io/reads.rs
@@ -118,14 +118,14 @@ pub fn interleaved_record_iterator(
     Box::new(InterleavedIterator::new(reader))
 }
 
-pub fn open_reads<'a, R: Read + Send + 'static>(
+pub fn open_reads<R: Read + Send + 'static>(
     f: R,
 ) -> Box<dyn Iterator<Item = Result<SequenceRecord, SequenceIOError>> + Send> {
     let mut br = BufReader::new(f);
-    if let Ok(_) = br.fill_buf() {
-        if let Some(b'>') = br.buffer().first() {
-            return Box::new(FastaReader::new(br));
-        }
+    if let Ok(_) = br.fill_buf()
+        && let Some(b'>') = br.buffer().first()
+    {
+        return Box::new(FastaReader::new(br));
     }
 
     Box::new(FastqReader::new(br))

--- a/src/io/record.rs
+++ b/src/io/record.rs
@@ -7,7 +7,7 @@ use std::fmt;
 /// and strip it. To retain the information, it is stored as part of a
 /// SequenceRecord. This is only used when pairing up 'mixed' reads
 /// (readname/1 followed by readname/2 is considered to be a paired-end read).
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub enum End {
     /// First read in a pair
     One,
@@ -16,13 +16,8 @@ pub enum End {
     Two,
 
     /// Read did not have a /1 or /2 suffix in the input file
+    #[default]
     None,
-}
-
-impl Default for End {
-    fn default() -> Self {
-        End::None
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/io/xopen.rs
+++ b/src/io/xopen.rs
@@ -29,7 +29,7 @@ mod test {
     use temp_file::TempFileBuilder;
 
     #[test]
-    fn test_open_multi_block_gzip() -> Result<(), Box<dyn Error>> {
+    fn open_multi_block_gzip() -> Result<(), Box<dyn Error>> {
         // Create a multi-block gzip
         let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
         encoder.write_all(b"abc")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -642,6 +642,7 @@ fn run() -> Result<(), CliError> {
     });
     let chunks_rx = Arc::new(Mutex::new(chunks_rx));
 
+    #[allow(clippy::type_complexity)]
     let (out_tx, out_rx): (
         Sender<(usize, (Vec<u8>, Details))>,
         Receiver<(usize, (Vec<u8>, Details))>,
@@ -892,7 +893,7 @@ impl Mapper<'_> {
                             self.sam_output,
                             self.seeding_parameters,
                             &mut isizedist,
-                            &self.chainer,
+                            self.chainer,
                             &self.aligner,
                             &mut rng,
                         );
@@ -911,7 +912,7 @@ impl Mapper<'_> {
                             self.references,
                             self.mapping_parameters,
                             self.sam_output,
-                            &self.chainer,
+                            self.chainer,
                             &self.aligner,
                             &mut rng,
                         );
@@ -937,7 +938,7 @@ impl Mapper<'_> {
                             self.mapping_parameters.rescue_distance,
                             &mut isizedist,
                             self.mapping_parameters.mcs_strategy,
-                            &self.chainer,
+                            self.chainer,
                             &mut rng,
                         )
                     } else {
@@ -947,7 +948,7 @@ impl Mapper<'_> {
                             self.references,
                             self.mapping_parameters.rescue_distance,
                             self.mapping_parameters.mcs_strategy,
-                            &self.chainer,
+                            self.chainer,
                             &mut rng,
                         )
                     };
@@ -966,7 +967,7 @@ impl Mapper<'_> {
                             self.mapping_parameters.rescue_distance,
                             &mut isizedist,
                             self.mapping_parameters.mcs_strategy,
-                            &self.chainer,
+                            self.chainer,
                             &mut rng,
                         );
                     } else {
@@ -976,7 +977,7 @@ impl Mapper<'_> {
                             &mut self.abundances,
                             self.mapping_parameters.rescue_distance,
                             self.mapping_parameters.mcs_strategy,
-                            &self.chainer,
+                            self.chainer,
                             &mut rng,
                         );
                     }
@@ -1007,19 +1008,18 @@ fn estimate_read_length(records: &[SequenceRecord]) -> usize {
         n += 1;
     }
 
-    if n == 0 { 0 } else { s / n }
+    s.checked_div(n).unwrap_or(0)
 }
 
 fn warn_clocksource() {
     if let Ok(result) =
         std::fs::read("/sys/devices/system/clocksource/clocksource0/current_clocksource")
+        && result == b"hpet\n"
     {
-        if result == b"hpet\n" {
-            warn!(
-                "\nWARNING: This system uses the 'hpet' clocksource, which can \
+        warn!(
+            "\nWARNING: This system uses the 'hpet' clocksource, which can \
                 slow down strobealign significantly. If possible, prefer 'tsc' instead.\n"
-            );
-        }
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1039,7 +1039,7 @@ mod test {
     }
 
     #[test]
-    fn test_estimate_read_length_phix_r1() {
+    fn estimate_read_length_phix_r1() {
         let f = xopen("tests/phix.1.fastq").unwrap();
         let mut reads_reader = PeekableSequenceReader::new(open_reads(f));
         assert_eq!(estimate_read_length(&reads_reader.peek(500).unwrap()), 289);

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -561,20 +561,20 @@ fn extend_seed(
     let mut gapped = true;
     if projected_ref_start + query.len() == projected_ref_end && consistent_nam {
         let ref_segm_ham = refseq.decode(projected_ref_start, projected_ref_end);
-        if let Some(hamming_dist) = hamming_distance(query, &ref_segm_ham) {
-            if (hamming_dist as f32 / query.len() as f32) < 0.05 {
-                // ungapped worked fine, no need to do gapped alignment
-                info = hamming_align(
-                    query,
-                    &ref_segm_ham,
-                    aligner.scores.match_,
-                    aligner.scores.mismatch,
-                    aligner.scores.end_bonus,
-                )
-                .expect("hamming_dist was successful, this should be as well");
-                result_ref_start = projected_ref_start + info.ref_start;
-                gapped = false;
-            }
+        if let Some(hamming_dist) = hamming_distance(query, &ref_segm_ham)
+            && (hamming_dist as f32 / query.len() as f32) < 0.05
+        {
+            // ungapped worked fine, no need to do gapped alignment
+            info = hamming_align(
+                query,
+                &ref_segm_ham,
+                aligner.scores.match_,
+                aligner.scores.mismatch,
+                aligner.scores.end_bonus,
+            )
+            .expect("hamming_dist was successful, this should be as well");
+            result_ref_start = projected_ref_start + info.ref_start;
+            gapped = false;
         }
     }
     if gapped {

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1510,7 +1510,7 @@ mod tests {
     }
 
     #[test]
-    fn test_count_best_alignment_pairs() {
+    fn count_best_alignment_pairs_works() {
         let mut pairs = vec![];
         fn add_alignment(pairs: &mut Vec<ScoredAlignmentPair>, score: f64) {
             pairs.push(ScoredAlignmentPair {
@@ -1535,7 +1535,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deduplicate_scored_pairs() {
+    fn deduplicate_scored_pairs_works() {
         let a1 = Some(Alignment {
             reference_id: 0,
             ref_start: 1906,
@@ -1583,7 +1583,7 @@ mod tests {
     }
 
     #[test]
-    fn test_has_shared_substring() {
+    fn has_shared_substring_works() {
         assert!(!has_shared_substring(
             "GGGGGGGGGGGGGGGGG".as_bytes(),
             "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT".as_bytes(),

--- a/src/mcsstrategy.rs
+++ b/src/mcsstrategy.rs
@@ -1,9 +1,10 @@
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, clap::ValueEnum)]
+#[derive(Default, Debug, PartialEq, Eq, Copy, Clone, clap::ValueEnum)]
 pub enum McsStrategy {
     // For each strobemer, do a full lookup. If that did not generate a hit,
     // try a partial lookup.
+    #[default]
     Always,
 
     // For each strobemer, do a full lookup. If after processing the entire
@@ -15,12 +16,6 @@ pub enum McsStrategy {
 
     // Do partial lookups only, that is, use only the first strobe.
     FirstStrobe,
-}
-
-impl Default for McsStrategy {
-    fn default() -> Self {
-        Self::Always
-    }
 }
 
 impl Display for McsStrategy {

--- a/src/piecewisealigner.rs
+++ b/src/piecewisealigner.rs
@@ -723,7 +723,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_global_perfect_match() {
+    fn global_perfect_match() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -745,7 +745,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_complete_mismatch() {
+    fn global_complete_mismatch() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -767,7 +767,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_single_mismatch() {
+    fn global_single_mismatch() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -789,7 +789,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_gap_in_query() {
+    fn global_gap_in_query() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -811,7 +811,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_gap_in_reference() {
+    fn global_gap_in_reference() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -833,7 +833,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_gap_at_query_start() {
+    fn global_gap_at_query_start() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -855,7 +855,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_gap_at_query_end() {
+    fn global_gap_at_query_end() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -878,7 +878,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_gap_at_reference_start() {
+    fn global_gap_at_reference_start() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -901,7 +901,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_gap_at_reference_end() {
+    fn global_gap_at_reference_end() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -924,7 +924,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_multiple_mismatches() {
+    fn global_multiple_mismatches() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -947,7 +947,7 @@ mod tests {
     }
 
     #[test]
-    fn test_global_complex_alignment() {
+    fn global_complex_alignment() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -969,7 +969,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_forward_perfect_match() {
+    fn xdrop_forward_perfect_match() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -991,7 +991,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_forward_with_mismatch() {
+    fn xdrop_forward_with_mismatch() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1013,7 +1013,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_forward_early_termination() {
+    fn xdrop_forward_early_termination() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1039,7 +1039,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_forward_end_bonus_extends_alignment() {
+    fn xdrop_forward_end_bonus_extends_alignment() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1062,7 +1062,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_forward_with_gap() {
+    fn xdrop_forward_with_gap() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1085,7 +1085,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_forward_gap_in_reference() {
+    fn xdrop_forward_gap_in_reference() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1108,7 +1108,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_reverse_perfect_match() {
+    fn xdrop_reverse_perfect_match() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1130,7 +1130,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_reverse_with_mismatch() {
+    fn xdrop_reverse_with_mismatch() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1152,7 +1152,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_reverse_early_termination() {
+    fn xdrop_reverse_early_termination() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1178,7 +1178,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_reverse_end_bonus_extends_alignment() {
+    fn xdrop_reverse_end_bonus_extends_alignment() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1201,7 +1201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_reverse_with_gap() {
+    fn xdrop_reverse_with_gap() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1224,7 +1224,7 @@ mod tests {
     }
 
     #[test]
-    fn test_xdrop_reverse_gap_in_reference() {
+    fn xdrop_reverse_gap_in_reference() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1247,7 +1247,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_spurious_anchors_control() {
+    fn remove_spurious_anchors_control() {
         let expected = vec![
             Anchor {
                 ref_id: 0,
@@ -1311,7 +1311,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_spurious_anchors_inside_trim() {
+    fn remove_spurious_anchors_inside_trim() {
         let mut result = vec![
             Anchor {
                 ref_id: 0,
@@ -1411,7 +1411,7 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_spurious_anchors_ends_trim() {
+    fn remove_spurious_anchors_ends_trim() {
         let mut result = vec![
             Anchor {
                 ref_id: 0,
@@ -1511,7 +1511,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extend_piecewise_matching() {
+    fn extend_piecewise_matching() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1560,7 +1560,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extend_piecewise_unmappable() {
+    fn extend_piecewise_unmappable() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1596,7 +1596,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extend_piecewise_overlapping_anchors() {
+    fn extend_piecewise_overlapping_anchors() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,
@@ -1661,7 +1661,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extend_piecewise_complex() {
+    fn extend_piecewise_complex() {
         let aligner = PiecewiseAligner::new(
             Scores {
                 match_: 2,

--- a/src/piecewisealigner.rs
+++ b/src/piecewisealigner.rs
@@ -1039,6 +1039,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::identity_op)]
     fn xdrop_forward_end_bonus_extends_alignment() {
         let aligner = PiecewiseAligner::new(
             Scores {
@@ -1178,6 +1179,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::identity_op)]
     fn xdrop_reverse_end_bonus_extends_alignment() {
         let aligner = PiecewiseAligner::new(
             Scores {
@@ -1525,7 +1527,7 @@ mod tests {
         );
         let query = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let refseq = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let mut anchors = vec![
+        let anchors = vec![
             Anchor {
                 ref_id: 0,
                 ref_start: 40,
@@ -1548,7 +1550,7 @@ mod tests {
             },
         ];
         let result = aligner
-            .extend_piecewise(query, refseq, &mut anchors, 5)
+            .extend_piecewise(query, refseq, &anchors, 5)
             .unwrap();
         assert_eq!(result.score, 50 * 2 + 10 * 2);
         assert_eq!(result.edit_distance, 0);
@@ -1574,7 +1576,7 @@ mod tests {
         );
         let query = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let refseq = b"TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT";
-        let mut anchors = vec![
+        let anchors = vec![
             Anchor {
                 ref_id: 0,
                 ref_start: 30,
@@ -1591,11 +1593,12 @@ mod tests {
                 query_start: 10,
             },
         ];
-        let result = aligner.extend_piecewise(query, refseq, &mut anchors, 5);
+        let result = aligner.extend_piecewise(query, refseq, &anchors, 5);
         assert!(result.is_none());
     }
 
     #[test]
+    #[allow(clippy::identity_op)]
     fn extend_piecewise_overlapping_anchors() {
         let aligner = PiecewiseAligner::new(
             Scores {
@@ -1611,7 +1614,7 @@ mod tests {
         let query = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let refseq =
             b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        let mut anchors = vec![
+        let anchors = vec![
             Anchor {
                 ref_id: 0,
                 ref_start: 40,
@@ -1649,7 +1652,7 @@ mod tests {
             },
         ];
         let result = aligner
-            .extend_piecewise(query, refseq, &mut anchors, 5)
+            .extend_piecewise(query, refseq, &anchors, 5)
             .unwrap();
         assert_eq!(result.score, 50 * 2 + 10 * 2 - 12 - 4 * 1);
         assert_eq!(result.edit_distance, 5);
@@ -1675,7 +1678,7 @@ mod tests {
         );
         let query = b"CTTTTAAAAATTTTAAAAATGGTTTCAAAAATTCCTAAAAATTTTTCCCCC";
         let refseq = b"TTTTTAAAAATTTTTAAAAATTTTTAAAAATTTTTAAAAATTTTTAAAAA";
-        let mut anchors = vec![
+        let anchors = vec![
             Anchor {
                 ref_id: 0,
                 ref_start: 35,
@@ -1693,7 +1696,7 @@ mod tests {
             },
         ];
         let result = aligner
-            .extend_piecewise(query, refseq, &mut anchors, 5)
+            .extend_piecewise(query, refseq, &anchors, 5)
             .unwrap();
         assert_eq!(
             result.score,

--- a/src/revcomp.rs
+++ b/src/revcomp.rs
@@ -33,7 +33,7 @@ mod test {
     use crate::revcomp::reverse_complement;
 
     #[test]
-    fn test_reverse_complement() {
+    fn reverse_complement_works() {
         assert_eq!(reverse_complement(b""), b"");
         assert_eq!(reverse_complement(b""), b"");
         assert_eq!(reverse_complement(b"A"), b"T");

--- a/src/seeding/mod.rs
+++ b/src/seeding/mod.rs
@@ -51,9 +51,9 @@ pub fn randstrobes_query(seq: &[u8], parameters: &SeedingParameters) -> [Vec<Que
     // sequence because canonical syncmers are invariant under reverse
     // complementing. Only the coordinates need to be adjusted.
     syncmers.reverse();
-    for i in 0..syncmers.len() {
-        syncmers[i].position = seq.len() - syncmers[i].position - parameters.syncmer.k;
-        syncmers[i].toggle_orientation();
+    for syncmer in &mut syncmers {
+        syncmer.position = seq.len() - syncmer.position - parameters.syncmer.k;
+        syncmer.toggle_orientation();
     }
 
     // Randstrobes cannot be re-used for the reverse complement:

--- a/src/seeding/parameters.rs
+++ b/src/seeding/parameters.rs
@@ -333,7 +333,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_seeding_parameters() {
+    fn seeding_parameters() {
         let canonical_read_length = 250;
         let k = 22;
         let s = 18;
@@ -376,7 +376,7 @@ mod test {
     }
 
     #[test]
-    fn test_seeding_parameters_similar_read_length() {
+    fn seeding_parameters_similar_read_length() {
         let sp150 = SeedingParameters::new(150);
         let sp149 = SeedingParameters::new(149);
         let sp151 = SeedingParameters::new(151);
@@ -386,7 +386,7 @@ mod test {
     }
 
     #[test]
-    fn test_seeding_parameters_is_custom() {
+    fn seeding_parameters_is_custom() {
         assert!(!SeedingParameters::new(100).is_custom());
         assert!(
             !SeedingParameters::new(100)

--- a/src/seeding/parameters.rs
+++ b/src/seeding/parameters.rs
@@ -30,7 +30,6 @@ impl From<usize> for Profile {
             .find(|&profile| read_length <= profile.r_threshold)
             .unwrap()
             .profile
-            .clone()
     }
 }
 
@@ -66,7 +65,7 @@ impl TryFrom<u32> for Profile {
     type Error = ();
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        match value as u32 {
+        match value {
             x if x == Profile::Noisy as u32 => Ok(Profile::Noisy),
             x if x == Profile::ReadLength50 as u32 => Ok(Profile::ReadLength50),
             x if x == Profile::ReadLength75 as u32 => Ok(Profile::ReadLength75),
@@ -187,7 +186,7 @@ impl SeedingParameters {
 
         match profile {
             Profile::Noisy => SeedingParameters {
-                profile: profile.clone(),
+                profile,
                 syncmer: SyncmerParameters::try_new(16, 12).unwrap(),
                 randstrobe: RandstrobeParameters::try_new(2, 2, q, 84, main_hash_mask).unwrap(),
             },
@@ -202,7 +201,7 @@ impl SeedingParameters {
                     usize::clamp(read_length.saturating_sub(70), read_length_profile.k, 255) as u8;
 
                 SeedingParameters {
-                    profile: profile.clone(),
+                    profile,
                     syncmer: SyncmerParameters::try_new(
                         read_length_profile.k,
                         read_length_profile.s,
@@ -298,7 +297,7 @@ impl SeedingParameters {
 
     /// Returns parameters with updated q mask, computed from bitcount.
     pub fn with_bitcount(mut self, bitcount: u32) -> Result<Self, InvalidSeedingParameter> {
-        if bitcount < 2 || bitcount > 63 {
+        if !(2..64).contains(&bitcount) {
             return Err(InvalidSeedingParameter::InvalidParameter(
                 "bitcount must be between 2 and 63",
             ));

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -192,7 +192,7 @@ mod test {
     }
 
     #[test]
-    fn test_randstrobe_iterator() {
+    fn randstrobe_iterator() {
         let refseq = read_phix().sequence;
         let parameters = SeedingParameters::new(300);
         let syncmer_iter = SyncmerIterator::new(
@@ -214,7 +214,7 @@ mod test {
     // Ensure SyncmerIterator and RandstrobeIterator return the same number of
     // items. We need this to hold for `count_randstrobes()`.
     #[test]
-    fn test_syncmer_and_randstrobe_iterator_same_count() {
+    fn syncmer_and_randstrobe_iterator_same_count() {
         let refseq = read_phix().sequence;
         let parameters = SeedingParameters::new(100);
         let syncmer_iter = SyncmerIterator::new(

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -243,7 +243,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_invalid_parameters() {
+    fn invalid_parameters() {
         // k-s not even
         assert!(SyncmerParameters::try_new(20, 17).is_err());
         // s larger than k
@@ -254,7 +254,7 @@ mod test {
     }
 
     #[test]
-    fn test_syncmer_iterator() {
+    fn syncmer_iterator() {
         let seq = "AAAAAAAAAAAAAAAAAAAA";
         assert_eq!(seq.len(), 20);
 
@@ -272,7 +272,7 @@ mod test {
     }
 
     #[test]
-    fn test_canonical_syncmers() {
+    fn canonical_syncmers() {
         let parameters = SyncmerParameters::try_new(20, 16).unwrap();
         let seq: Vec<u8> = read_ref("tests/phix.fasta")
             .unwrap()

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -10,6 +10,7 @@ use crate::packed_seq::PackedSeq;
 /// `nucleotide_bits` returns the nucleotide as a 2-bit value (0=A, 1=C, 2=G, 3=T,
 /// 4=N/ambiguous). This is what the syncmer hash machinery needs directly,
 /// so implementations should avoid going through ASCII as an intermediate.
+#[allow(clippy::len_without_is_empty)]
 pub trait SeqAccess {
     fn nucleotide_bits(&self, i: usize) -> u8;
     fn len(&self) -> usize;
@@ -69,7 +70,7 @@ pub struct SyncmerParameters {
 
 impl SyncmerParameters {
     pub fn try_new(k: usize, s: usize) -> Result<Self, InvalidSeedingParameter> {
-        if k < 8 || k > 32 {
+        if !(8..=32).contains(&k) {
             return Err(InvalidSeedingParameter::InvalidParameter(
                 "k must be at least 8 and at most 32",
             ));
@@ -79,7 +80,7 @@ impl SyncmerParameters {
                 "s must not be larger than k",
             ));
         }
-        if (k - s) % 2 != 0 {
+        if !(k - s).is_multiple_of(2) {
             return Err(InvalidSeedingParameter::InvalidParameter(
                 "(k - s) must be an even number to create canonical syncmers. Please set s to e.g. k-2, k-4, k-6, ...",
             ));

--- a/src/ssw.rs
+++ b/src/ssw.rs
@@ -192,7 +192,7 @@ impl SswAligner {
 mod tests {
     use super::*;
     #[test]
-    fn test_ssw_align_no_result() {
+    fn ssw_align_no_result() {
         let aligner = SswAligner::new(2, 8, 12, 1);
         let query = b"TCTCTCCCTCTCTCTCTCTCCCTCCCTCTCTCTCCCTCTCTCTCTCTCTCTCCCTCCCTT";
         let refseq = b"GAGGGAGAGAGAGAGAGGGAGAGAGAGAGAGAG";

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -48,7 +48,7 @@ fn success_when_printing_help() {
 #[test]
 fn single_end_sam_m_cigar() {
     let mut cmd = cmd();
-    let p = cmd.args(&["tests/phix.fasta", "tests/phix.1.fastq"]);
+    let p = cmd.args(["tests/phix.fasta", "tests/phix.1.fastq"]);
     let a = p.assert().success();
     let stdout = &a.get_output().stdout;
     for line in str::from_utf8(stdout).unwrap().lines() {
@@ -67,7 +67,7 @@ fn single_end_sam() {
     // TODO -v
     let expected = String::from_utf8(read("tests/phix.se.sam").unwrap()).unwrap();
     let mut cmd = cmd();
-    let p = cmd.args(&[
+    let p = cmd.args([
         "--chunk-size=3",
         "--no-PG",
         "--eqx",
@@ -85,7 +85,7 @@ fn single_end_sam() {
 fn paired_end_sam() {
     let expected = String::from_utf8(read("tests/phix.pe.sam").unwrap()).unwrap();
     let mut cmd = cmd();
-    let p = cmd.args(&[
+    let p = cmd.args([
         "--no-PG",
         "--eqx",
         "--rg-id=1",
@@ -111,7 +111,7 @@ fn compressed_reference() -> Result<(), Box<dyn Error>> {
         .build()?
         .with_contents(&compressed_fasta)?;
 
-    cmd.args(&[
+    cmd.args([
         tmp.path().as_os_str().to_str().unwrap(),
         "tests/empty.fastq",
     ])
@@ -125,7 +125,7 @@ fn compressed_reference() -> Result<(), Box<dyn Error>> {
 fn fail_when_create_index_is_used_without_read_length() {
     // Create index requires -r or reads file
     cmd()
-        .args(&["--create-index", "tests/phix.fasta"])
+        .args(["--create-index", "tests/phix.fasta"])
         .assert()
         .failure();
 }


### PR DESCRIPTION
Clippy is a Rust linter (built into Cargo) that detects a lot of issues where the code could be more idiomatic (and/or more efficient). Here, I’ve applied a lot of the suggestions that it makes to our code or added an `#[allow(...)]` attribute where I thought the code should remain as it is (to silence the warning).

I’ve not had the routine of using Clippy, but I learned a bit going through all the complaints that it had.

Also, this now runs `cargo clippy` and `cargo clippy --tests` during CI. If we think this leads to too many complaints, we can disable it again.

I have also explicitly enabled an otherwise optional lint that ensures that the names of test functions do not start with `test_`. This is the naming convention for tests in Python, but in Rust, we already have the `#[test]` attribute. We also already had some tests that used the `test_` prefix and some that didn’t, so it makes sense to just drop it everywhere for consistency.