### PR TITLE
Concatenate the reference contigs into one "flat" reference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,15 @@
   Please report any other regressions!
 
   If you need one of the above features, use version 0.17.0.
-* #550: Introduce piecewise extension for single-end reads. The previous 
+* #550: Introduce piecewise extension alignment for single-end reads. The previous
   SSW extension can be enabled with `--ssw`.
 * #595: The in-memory representation of the reference sequence now uses two bits
   per nucleotide, reducing memory usage of the reference to 25% of its previous
   size. This change does not affect runtime.
+* #607: The reference is now stored as a single concatentade string of all
+  contigs. Reference coordinates now use a single 64-bit value. This means that
+  there are no longer any (relevant) limitations on the number and length of
+  contigs.
 * #539: Add a "noisy" read profile. Use `-P noisy` on the command line to
   select it. This is equivalent to `-k 16 -s 12 -l 2 -u 2 -m 100`.
   We found these settings to increase accuracy on error-prone reads at the cost

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -19,12 +19,13 @@ use crate::shuffle::shuffle_best;
 #[derive(Clone, Debug, Default)]
 pub struct Chain {
     pub id: usize,
+    /// Start coordinate of the contig containing `ref_start`.
+    pub ref_contig_start: usize,
     pub ref_start: usize,
     pub ref_end: usize,
     pub query_start: usize,
     pub query_end: usize,
     pub matching_bases: usize,
-    pub ref_id: usize,
     pub score: f32,
     pub is_revcomp: bool,
     pub anchors: Vec<Anchor>,
@@ -40,19 +41,17 @@ impl Chain {
     }
 
     pub fn projected_ref_start(&self) -> usize {
-        self.ref_start.saturating_sub(self.query_start)
+        self.ref_start
+            .saturating_sub(self.query_start)
+            .max(self.ref_contig_start)
     }
 
     /// Returns whether a chain represents a consistent match between read and
     /// reference by comparing the nucleotide sequences of the first and last
     /// strobe (taking orientation into account).
     pub fn is_consistent(&self, read: &Read, refseq: &RefSequence, k: usize) -> bool {
-        let ref_start_kmer = refseq
-            .contig(self.ref_id)
-            .decode(self.ref_start, self.ref_start + k);
-        let ref_end_kmer = refseq
-            .contig(self.ref_id)
-            .decode(self.ref_end - k, self.ref_end);
+        let ref_start_kmer = refseq.decode(self.ref_start, self.ref_start + k);
+        let ref_end_kmer = refseq.decode(self.ref_end - k, self.ref_end);
 
         let seq = if self.is_revcomp {
             read.rc()
@@ -70,8 +69,7 @@ impl Display for Chain {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Chain(ref_id={}, query: {}..{}, ref: {}..{}, rc={}, score={})",
-            self.ref_id,
+            "Chain(query: {}..{}, ref: {}..{}, rc={}, score={})",
             self.query_start,
             self.query_end,
             self.ref_start,
@@ -97,12 +95,8 @@ pub fn reverse_chain_if_needed(
     refseq: &RefSequence,
     k: usize,
 ) -> bool {
-    let ref_start_kmer = refseq
-        .contig(chain.ref_id)
-        .decode(chain.ref_start, chain.ref_start + k);
-    let ref_end_kmer = refseq
-        .contig(chain.ref_id)
-        .decode(chain.ref_end - k, chain.ref_end);
+    let ref_start_kmer = refseq.decode(chain.ref_start, chain.ref_start + k);
+    let ref_end_kmer = refseq.decode(chain.ref_end - k, chain.ref_end);
 
     let (seq, seq_rc) = if chain.is_revcomp {
         (read.rc(), read.seq())

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -7,13 +7,13 @@ use crate::details::ChainDetails;
 use crate::hit::{Hit, HitsDetails, find_hits};
 use crate::index::{IndexEntry, StrobemerIndex};
 use crate::mcsstrategy::McsStrategy;
+use crate::refseq::ContigStarts;
 use crate::seeding::QueryRandstrobe;
 
 const N_PRECOMPUTED: usize = 1024;
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Copy)]
 pub struct Anchor {
-    pub ref_id: usize,
     pub ref_start: usize,
     pub query_start: usize,
 }
@@ -82,7 +82,12 @@ impl Chainer {
         }
     }
 
-    fn collinear_chaining(&self, anchors: Vec<Anchor>, read_len: usize) -> ChainingResult {
+    fn collinear_chaining(
+        &self,
+        anchors: Vec<Anchor>,
+        contig_starts: &ContigStarts,
+        read_len: usize,
+    ) -> ChainingResult {
         let n = anchors.len();
         if n == 0 {
             return ChainingResult::default();
@@ -101,10 +106,15 @@ impl Chainer {
         for i in 0..n {
             let lookup_end = i.saturating_sub(max_lookback);
             let ai = &anchors[i];
+
+            // Flat start position of the contig that a[i] is on
+            let ref_contig_start = contig_starts.ref_contig_start(ai.ref_start);
             for j in (lookup_end..i).rev() {
                 let aj = &anchors[j];
 
-                if ai.ref_id != aj.ref_id {
+                // Do not attempt to chain to an anchor on a different contig.
+                // This check works because we go through anchors in reverse.
+                if aj.ref_start < ref_contig_start {
                     break;
                 }
 
@@ -145,9 +155,10 @@ impl Chainer {
             // The above runtime heuristic sometimes skips the anchor that
             // represents the so-far optimal chain and can then give suboptimal
             // results. To mitigate the issue, we explicitly check that anchor.
-            if best_index != usize::MAX && ai.ref_id == anchors[best_index].ref_id {
+            if best_index != usize::MAX {
                 let aj = &anchors[best_index];
-                if ai.query_start > aj.query_start {
+
+                if aj.ref_start >= ref_contig_start && ai.query_start > aj.query_start {
                     let dq = ai.query_start - aj.query_start;
                     let dr = ai.ref_start - aj.ref_start;
 
@@ -227,7 +238,7 @@ impl Chainer {
             n_anchors += anchors.len();
             let chaining_timer = Instant::now();
             trace!("Chaining {} anchors", anchors.len());
-            anchors.sort_unstable_by_key(|a| (a.ref_id, a.ref_start, a.query_start));
+            anchors.sort_unstable_by_key(|a| (a.ref_start, a.query_start));
             anchors.dedup();
 
             // trace!(
@@ -244,9 +255,14 @@ impl Chainer {
             //         .join(",")
             // );
 
-            let chaining_result = self.collinear_chaining(anchors, read_len);
+            let chaining_result = self.collinear_chaining(anchors, &index.contig_starts, read_len);
 
-            chaining_result.extract_chains(index.k(), is_revcomp == 1, &mut chains);
+            chaining_result.extract_chains(
+                index.k(),
+                is_revcomp == 1,
+                &index.contig_starts,
+                &mut chains,
+            );
             time_chaining += chaining_timer.elapsed().as_secs_f64();
         }
         let mut hits_details12 = hits_details[0].clone();
@@ -317,18 +333,15 @@ fn add_to_anchors_full(
         if entry.hash() != forward_hash {
             break;
         }
-        let ref_start = entry.position();
+        let ref_start = entry.ref_start();
         let ref_end = ref_start + entry.strobe2_offset() + index.k();
         let length_diff = (query_end - query_start).abs_diff(ref_end - ref_start);
         if length_diff <= min_length_diff {
-            let ref_id = entry.reference_index();
             anchors.push(Anchor {
-                ref_id,
                 ref_start,
                 query_start,
             });
             anchors.push(Anchor {
-                ref_id,
                 ref_start: ref_end - index.k(),
                 query_start: query_end - index.k(),
             });
@@ -350,11 +363,9 @@ fn add_to_anchors_partial(
         if entry.get_hash_partial_forward() != forward_hash {
             break;
         }
-        let ref_id = entry.reference_index();
         let ref_start = entry.strobe_extent_partial().0;
 
         anchors.push(Anchor {
-            ref_id,
             ref_start,
             query_start,
         });
@@ -386,7 +397,13 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
 }
 
 impl ChainingResult {
-    fn extract_chains(&self, k: usize, is_revcomp: bool, chains: &mut Vec<Chain>) {
+    fn extract_chains(
+        &self,
+        k: usize,
+        is_revcomp: bool,
+        contig_starts: &ContigStarts,
+        chains: &mut Vec<Chain>,
+    ) {
         let n = self.anchors.len();
         let valid_score = self.best_score * self.parameters.valid_score_threshold;
 
@@ -438,10 +455,10 @@ impl ChainingResult {
                 id: chains.len(),
                 query_start: first.query_start,
                 query_end: last.query_start + k,
+                ref_contig_start: contig_starts.ref_contig_start(first.ref_start),
                 ref_start: first.ref_start,
                 ref_end: last.ref_start + k,
                 matching_bases,
-                ref_id: last.ref_id,
                 score: score + chain_anchors.len() as f32 * self.parameters.matches_weight,
                 is_revcomp,
                 anchors: chain_anchors,
@@ -452,6 +469,8 @@ impl ChainingResult {
 
 #[cfg(test)]
 mod test {
+    use crate::refseq::ContigStarts;
+
     use super::{Anchor, Chainer, ChainingParameters};
 
     #[test]
@@ -459,13 +478,13 @@ mod test {
         let chainer = Chainer::new(20, ChainingParameters::default());
         #[rustfmt::skip]
         let anchors = vec![
-            Anchor { ref_id: 0, ref_start:  0, query_start:  0, },
-            Anchor { ref_id: 0, ref_start: 30, query_start: 20, },
-            Anchor { ref_id: 0, ref_start: 60, query_start:  0, },
-            Anchor { ref_id: 0, ref_start: 95, query_start: 35, },
+            Anchor { ref_start:  0, query_start:  0, },
+            Anchor { ref_start: 30, query_start: 20, },
+            Anchor { ref_start: 60, query_start:  0, },
+            Anchor { ref_start: 95, query_start: 35, },
         ];
-
-        let chaining_result = chainer.collinear_chaining(anchors, 2000);
+        let starts = ContigStarts::new(vec![0], 200);
+        let chaining_result = chainer.collinear_chaining(anchors, &starts, 2000);
 
         // The best chain has score 42.342842 and uses anchors 0, 1, 3.
         // When using the heuristic that breaks early if the predecessor is on the
@@ -479,21 +498,22 @@ mod test {
         let chainer = Chainer::new(20, ChainingParameters::default());
         #[rustfmt::skip]
         let anchors = [
-            Anchor { ref_id: 0, ref_start:   0, query_start:  0, },
-            Anchor { ref_id: 0, ref_start:  20, query_start: 20, },
-            Anchor { ref_id: 0, ref_start:  40, query_start: 40, },
+            Anchor { ref_start:   0, query_start:  0, },
+            Anchor { ref_start:  20, query_start: 20, },
+            Anchor { ref_start:  40, query_start: 40, },
         ];
-        let chaining_result = chainer.collinear_chaining(anchors[0..1].to_vec(), 200);
+        let starts = ContigStarts::new(vec![0], 200);
+        let chaining_result = chainer.collinear_chaining(anchors[0..1].to_vec(), &starts, 200);
         let score1 = chaining_result.best_score;
         assert_eq!(
             chainer
-                .collinear_chaining(anchors[0..2].to_vec(), 200)
+                .collinear_chaining(anchors[0..2].to_vec(), &starts, 200)
                 .best_score,
             score1 * 2.0
         );
         assert_eq!(
             chainer
-                .collinear_chaining(anchors[0..3].to_vec(), 200)
+                .collinear_chaining(anchors[0..3].to_vec(), &starts, 200)
                 .best_score,
             score1 * 3.0
         );
@@ -504,10 +524,11 @@ mod test {
         let chainer = Chainer::new(20, ChainingParameters::default());
         #[rustfmt::skip]
         let anchors = vec![
-            Anchor { ref_id: 0, ref_start:  0, query_start:  0, },
-            Anchor { ref_id: 0, ref_start: 11, query_start:  1, },
+            Anchor { ref_start:  0, query_start:  0, },
+            Anchor { ref_start: 11, query_start:  1, },
         ];
-        let chaining_result = chainer.collinear_chaining(anchors, 2000);
+        let starts = ContigStarts::new(vec![0], 200);
+        let chaining_result = chainer.collinear_chaining(anchors, &starts, 2000);
         // dr=11, dq=1 gives a diagonal ratio of 11.0, exceeding the default max of 10.
         // The two anchors cannot be chained, so the best score is that of a single anchor.
         assert_eq!(chaining_result.best_score, chainer.k as f32);

--- a/src/index.rs
+++ b/src/index.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use thiserror::Error;
 
 use crate::partition::custom_partition_point;
+use crate::refseq::ContigStarts;
 use crate::seeding::{
     InvalidSeedingParameter, RandstrobeParameters, SeedingParameters, SyncmerParameters,
 };
@@ -25,8 +26,7 @@ pub struct RefRandstrobe {
     /// [`REF_RANDSTROBE_HASH_MASK`] is the mask for strobe1 and strobe2 hashes (including their orientations)  
     /// The [`STROBE2_OFFSET_BITS`] constant specifies the number of bits reserved for the offset  
     hash_offset: u64,
-    position: u32,
-    ref_index: u32,
+    ref_start: u64,
 }
 
 /// Mask for the part of the randstrobe hash that includes individual strobe hashes and orientations
@@ -35,15 +35,13 @@ pub const REF_RANDSTROBE_HASH_MASK: u64 = 0xFFFFFFFFFFFFFF00;
 pub const STROBE2_OFFSET_BITS: u32 = 8;
 /// Mask for the part of the randstrobe hash that includes the offset between first and second strobe
 pub const STROBE2_OFFSET_MASK: u64 = (1u64 << STROBE2_OFFSET_BITS) - 1;
-pub const REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES: usize = u32::MAX as usize;
 
 impl RefRandstrobe {
-    pub fn new(hash: RandstrobeHash, ref_index: u32, position: u32, offset: u8) -> Self {
+    pub fn new(hash: RandstrobeHash, ref_start: usize, offset: u8) -> Self {
         let hash_offset = (hash & REF_RANDSTROBE_HASH_MASK) | (offset as u64);
         RefRandstrobe {
             hash_offset,
-            position,
-            ref_index,
+            ref_start: ref_start as u64,
         }
     }
 
@@ -51,12 +49,8 @@ impl RefRandstrobe {
         self.hash_offset & REF_RANDSTROBE_HASH_MASK
     }
 
-    pub fn position(&self) -> usize {
-        self.position as usize
-    }
-
-    pub fn reference_index(&self) -> usize {
-        self.ref_index as usize
+    pub fn ref_start(&self) -> usize {
+        self.ref_start as usize
     }
 
     pub fn strobe2_offset(&self) -> usize {
@@ -84,10 +78,13 @@ pub struct StrobemerIndex {
     /// is always randstrobes.len().
     randstrobes: Vec<RefRandstrobe>,
     bucket_starts: Vec<BucketIndex>,
+    pub contig_starts: ContigStarts,
 }
 
 pub struct IndexEntry<'a> {
     strobemer_index: &'a StrobemerIndex,
+
+    /// An index that points to an item in the randstrobes vector
     pub position: usize,
 }
 
@@ -99,6 +96,7 @@ impl StrobemerIndex {
         filter_cutoff: usize,
         randstrobes: Vec<RefRandstrobe>,
         bucket_starts: Vec<BucketIndex>,
+        contig_starts: ContigStarts,
     ) -> Self {
         StrobemerIndex {
             parameters,
@@ -106,6 +104,7 @@ impl StrobemerIndex {
             filter_cutoff,
             randstrobes,
             bucket_starts,
+            contig_starts,
         }
     }
 
@@ -218,16 +217,12 @@ impl<'a> IndexEntry<'a> {
         self.randstrobe().hash()
     }
 
-    pub fn position(&self) -> usize {
-        self.randstrobe().position()
+    pub fn ref_start(&self) -> usize {
+        self.randstrobe().ref_start()
     }
 
     pub fn strobe2_offset(&self) -> usize {
         self.randstrobe().strobe2_offset()
-    }
-
-    pub fn reference_index(&self) -> usize {
-        self.randstrobe().reference_index()
     }
 
     pub fn get_hash_partial(&self) -> RandstrobeHash {
@@ -245,9 +240,9 @@ impl<'a> IndexEntry<'a> {
     }
 
     pub fn strobe_extent_partial(&self) -> (usize, usize) {
-        let p = self.strobemer_index.randstrobes[self.position].position;
+        let p = self.strobemer_index.randstrobes[self.position].ref_start();
 
-        (p as usize, p as usize + self.k())
+        (p, p + self.k())
     }
 
     /// Count number of hits for the randstrobe *and* its "reverse complement"
@@ -413,6 +408,7 @@ pub fn read_index<P: AsRef<Path>>(
     path: P,
     parameters: SeedingParameters,
     bits: u8,
+    contig_starts: ContigStarts,
 ) -> Result<StrobemerIndex, IndexReadingError> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
@@ -491,6 +487,7 @@ pub fn read_index<P: AsRef<Path>>(
         filter_cutoff,
         randstrobes,
         bucket_starts,
+        contig_starts,
     })
 }
 
@@ -550,14 +547,12 @@ mod tests {
     #[test]
     fn ref_randstrobe() {
         let hash: u64 = 0x1234567890ABCDEFu64 & REF_RANDSTROBE_HASH_MASK;
-        let ref_index: u32 = (REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES - 1) as u32;
+        let ref_start = u64::MAX as usize;
         let offset = 255;
-        let position = !0;
-        let rr = RefRandstrobe::new(hash, ref_index, position, offset);
+        let rr = RefRandstrobe::new(hash, ref_start, offset);
 
         assert_eq!(rr.hash(), hash);
-        assert_eq!(rr.position(), position as usize);
-        assert_eq!(rr.reference_index(), ref_index as usize);
+        assert_eq!(rr.ref_start(), ref_start);
         assert_eq!(rr.strobe2_offset(), offset as usize);
     }
 
@@ -576,7 +571,12 @@ mod tests {
         let sti_path = dir.path().join("index.sti");
         index.write(&sti_path).unwrap();
 
-        let read_index_result = read_index(&sti_path, SeedingParameters::new(50), bits);
+        let read_index_result = read_index(
+            &sti_path,
+            SeedingParameters::new(50),
+            bits,
+            references.starts.clone(),
+        );
 
         match read_index_result {
             Err(IndexReadingError::ParameterMismatch) => {}
@@ -591,9 +591,11 @@ mod tests {
         let refseq = read_ref("tests/phix.fasta").unwrap();
         let seq_decoded = refseq.contig(0).decode_all();
         let rc_seq = reverse_complement(&seq_decoded);
-        let mut rc_refseq = RefSequence::new();
-        rc_refseq.push("phix_rc".to_string(), PackedSeq::from_slice(&rc_seq));
-
+        let rc_refseq = RefSequence::new(
+            PackedSeq::from_slice(&rc_seq),
+            vec![0],
+            vec!["phix_rc".to_string()],
+        );
         let parameters = SeedingParameters::new(300);
         let bits = parameters.syncmer.pick_bits(&refseq);
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,5 +1,5 @@
 use crate::index::{BucketIndex, RandstrobeHash, RefRandstrobe, StrobemerIndex};
-use crate::packed_seq::PackedSeq;
+use crate::packed_seq::PackedSeqSlice;
 use crate::refseq::RefSequence;
 use crate::seeding::{RandstrobeIterator, SeedingParameters, SyncmerIterator, SyncmerParameters};
 
@@ -164,6 +164,7 @@ pub fn make_index(
             filter_cutoff,
             randstrobes,
             randstrobe_start_indices,
+            refseq.starts.clone(),
         ),
         stats,
     )
@@ -195,7 +196,13 @@ fn make_randstrobes_parallel(
                     if j >= refseq.names.len() {
                         break;
                     }
-                    assign_randstrobes(refseq, parameters, j, *slices[j].lock().unwrap());
+                    let start = refseq.contig_start(j);
+                    assign_randstrobes(
+                        &refseq.contig(j),
+                        parameters,
+                        start,
+                        *slices[j].lock().unwrap(),
+                    );
                 }
             });
         }
@@ -206,12 +213,11 @@ fn make_randstrobes_parallel(
 
 /// Compute randstrobes of one reference contig and assign them to the provided slice
 fn assign_randstrobes(
-    refseq: &RefSequence,
+    seq: &PackedSeqSlice,
     parameters: &SeedingParameters,
-    ref_index: usize,
+    start: usize,
     randstrobes: &mut [RefRandstrobe],
 ) {
-    let seq = refseq.contig(ref_index);
     if seq.len() < parameters.randstrobe.w_max {
         return;
     }
@@ -228,12 +234,8 @@ fn assign_randstrobes(
     for (i, randstrobe) in randstrobe_iter.enumerate() {
         n += 1;
         let offset = randstrobe.strobe2_pos - randstrobe.strobe1_pos;
-        randstrobes[i] = RefRandstrobe::new(
-            randstrobe.hash,
-            ref_index as u32,
-            randstrobe.strobe1_pos as u32,
-            offset as u8,
-        );
+        let strobe1_start = randstrobe.strobe1_pos + start;
+        randstrobes[i] = RefRandstrobe::new(randstrobe.hash, strobe1_start, offset as u8);
     }
     debug_assert_eq!(n, randstrobes.len());
 }
@@ -254,7 +256,7 @@ fn count_all_randstrobes(
                     if j >= refseq.names.len() {
                         break;
                     }
-                    let count = count_randstrobes(refseq.contig(j), parameters);
+                    let count = count_randstrobes(&refseq.contig(j), parameters);
                     mutex.lock().unwrap()[j] = count;
                 }
             });
@@ -265,7 +267,7 @@ fn count_all_randstrobes(
 }
 
 /// Count randstrobes by counting syncmers (operates directly on PackedSeq)
-fn count_randstrobes(seq: &PackedSeq, parameters: &SeedingParameters) -> usize {
+fn count_randstrobes(seq: &PackedSeqSlice, parameters: &SeedingParameters) -> usize {
     SyncmerIterator::new(
         seq,
         parameters.syncmer.k,
@@ -368,8 +370,7 @@ mod test {
 
     #[test]
     fn index_empty_reference() {
-        let mut refseq = RefSequence::new();
-        refseq.push("name".to_string(), PackedSeq::new());
+        let refseq = RefSequence::new(PackedSeq::new(), vec![0], vec!["name".to_string()]);
         let parameters = SeedingParameters::new(150);
         let bits = parameters.syncmer.pick_bits(&refseq);
         let (_index2, stats) = make_index(&refseq, parameters, bits, 0.1, 1);
@@ -381,6 +382,6 @@ mod test {
         let refseq = read_ref("tests/phix.fasta").unwrap();
         let parameters = SeedingParameters::new(150);
 
-        assert_eq!(count_randstrobes(refseq.contig(0), &parameters), 1090);
+        assert_eq!(count_randstrobes(&refseq.contig(0), &parameters), 1090);
     }
 }

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -26,8 +26,8 @@ fn is_valid_name(name: &[u8]) -> bool {
     true
 }
 
-fn check_duplicate_names(refseq: &RefSequence) -> Result<(), SequenceIOError> {
-    let mut names = refseq.names.clone();
+fn check_duplicate_names(names: &[String]) -> Result<(), SequenceIOError> {
+    let mut names: Vec<_> = names.iter().collect();
     names.sort();
     for window in names.windows(2) {
         if window[0] == window[1] {
@@ -109,9 +109,9 @@ impl<B: BufRead> Iterator for FastaReader<B> {
 }
 
 pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<RefSequence, SequenceIOError> {
-    let mut refseq = RefSequence::new();
-    let mut current_name: Option<String> = None;
-    let mut current_seq = PackedSeq::new();
+    let mut names = vec![];
+    let mut starts = vec![];
+    let mut seq = PackedSeq::new();
     let mut line = String::new();
 
     loop {
@@ -120,17 +120,14 @@ pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<RefSequence, SequenceIOE
             Ok(0) => break,
             Ok(_) => {
                 if let Some(header) = line.strip_prefix('>') {
-                    if let Some(name) = current_name.take() {
-                        refseq.push(name, current_seq);
-                        current_seq = PackedSeq::new();
-                    }
-                    let (name, _comment) = split_header(header);
-                    current_name = Some(name.to_string());
-                } else if current_name.is_some() {
-                    for c in line.trim_ascii_end().bytes() {
-                        current_seq.push(c);
-                    }
-                } else if !line.trim_ascii().is_empty() {
+                    starts.push(seq.len());
+                    names.push(split_header(header).0);
+                } else if !names.is_empty() {
+                    let line = line.trim_ascii_end();
+                    seq.extend(line.bytes());
+                } else if line.trim_ascii().is_empty() {
+                    // ignore empty lines
+                } else {
                     return Err(SequenceIOError::Fasta(
                         "FASTA file must start with '>'".to_string(),
                     ));
@@ -139,18 +136,16 @@ pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<RefSequence, SequenceIOE
             Err(e) => return Err(SequenceIOError::IO(e)),
         }
     }
-    if let Some(name) = current_name {
-        refseq.push(name, current_seq);
-    }
 
-    for name in &refseq.names {
+    for name in &names {
         if !is_valid_name(name.as_bytes()) {
             return Err(SequenceIOError::Name);
         }
     }
-    check_duplicate_names(&refseq)?;
+    check_duplicate_names(&names)?;
+    assert_eq!(names.len(), starts.len());
 
-    Ok(refseq)
+    Ok(RefSequence::new(seq, starts, names))
 }
 
 pub fn read_ref<P: AsRef<Path>>(path: P) -> Result<RefSequence, SequenceIOError> {
@@ -171,7 +166,7 @@ mod tests {
         let refseq = read_ref("tests/phix.fasta").unwrap();
         assert_eq!(refseq.names.len(), 1);
         assert_eq!(refseq.names[0], "NC_001422.1");
-        assert_eq!(refseq.contig_len(0), 5386);
+        assert_eq!(refseq.contig(0).len(), 5386);
         assert_eq!(refseq.contig(0).decode(0, 5), b"GAGTT");
     }
 

--- a/src/io/paf.rs
+++ b/src/io/paf.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::io::record::End;
+use crate::{io::record::End, refseq::ContigPosition};
 
 /* PAF columns (see https://github.com/lh3/miniasm/blob/master/PAF.md):
  * 1 query name
@@ -27,8 +27,8 @@ pub struct PafRecord {
     pub is_revcomp: bool,
     pub target_name: String,
     pub target_length: u64,
-    pub target_start: u64,
-    pub target_end: u64,
+    pub target_start: ContigPosition,
+    pub target_end: ContigPosition,
     pub matching_bases: u64,
     pub alignment_length: u64,
     pub mapping_quality: Option<u8>,
@@ -51,8 +51,8 @@ impl Display for PafRecord {
             if self.is_revcomp { "-" } else { "+" },
             self.target_name,
             self.target_length,
-            self.target_start,
-            self.target_end,
+            self.target_start.0,
+            self.target_end.0,
             self.matching_bases,
             self.alignment_length,
             self.mapping_quality.unwrap_or(255),

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use crate::cigar::Cigar;
 use crate::details::Details;
-use crate::refseq::RefSequence;
+use crate::refseq::{ContigPosition, RefSequence};
 
 pub const PAIRED: u16 = 1;
 pub const PROPER_PAIR: u16 = 2;
@@ -23,12 +23,11 @@ pub struct SamRecord {
     pub query_name: String,
     pub flags: u16,
     pub reference_name: Option<String>,
-    /// 0-based position, converted to 1-based for output
-    pub pos: Option<u32>,
+    pub pos: Option<ContigPosition>,
     pub mapq: u8,
     pub cigar: Option<Cigar>,
     pub mate_reference_name: Option<String>,
-    pub mate_pos: Option<u32>,
+    pub mate_pos: Option<ContigPosition>,
     pub template_len: Option<i32>,
     pub query_sequence: Option<Vec<u8>>,
     pub query_qualities: Option<Vec<u8>>,
@@ -68,7 +67,7 @@ impl Display for SamRecord {
         // 12 optional fields
 
         let mate_pos = match self.mate_pos {
-            Some(pos) => pos + 1,
+            Some(pos) => pos.0 + 1,
             None => 0,
         };
         let query_sequence = match &self.query_sequence {
@@ -84,7 +83,7 @@ impl Display for SamRecord {
             _ => "*",
         };
         let pos = match self.pos {
-            Some(pos) => pos + 1,
+            Some(pos) => pos.0 + 1,
             None => 0,
         };
         let cigar = match &self.cigar {
@@ -183,7 +182,7 @@ impl Display for SamHeader<'_> {
                 f,
                 "@SQ\tSN:{}\tLN:{}",
                 self.refseq.names[i],
-                self.refseq.contig_len(i)
+                self.refseq.contig(i).len()
             )?;
         }
         if let Some(read_group) = &self.read_group {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,7 @@ use thiserror::Error;
 use strobealign::aligner::{Aligner, Scores};
 use strobealign::chainer::{Chainer, ChainingParameters};
 use strobealign::details::Details;
-use strobealign::index::{
-    IndexReadingError, REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES, StrobemerIndex, read_index,
-};
+use strobealign::index::{IndexReadingError, StrobemerIndex, read_index};
 use strobealign::insertsize::InsertSizeDistribution;
 use strobealign::io::SequenceIOError;
 use strobealign::io::fasta;
@@ -437,13 +435,6 @@ fn run() -> Result<(), CliError> {
         if refseq.names.len() != 1 { "s" } else { "" },
         max_contig_size as f64 / 1E6
     );
-    if refseq.names.len() > REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES {
-        error!(
-            "Too many reference sequences. Current maximum is {}.",
-            REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES
-        );
-        exit(1);
-    }
 
     // Create the index
     debug!("Auxiliary hash length: {}", args.aux_len);
@@ -460,7 +451,7 @@ fn run() -> Result<(), CliError> {
         let mut sti_path = args.ref_path.clone();
         sti_path.push_str(&parameters.filename_extension());
         info!("Reading index from {}", sti_path);
-        let index = read_index(&sti_path, parameters.clone(), bits)?;
+        let index = read_index(&sti_path, parameters.clone(), bits, refseq.starts.clone())?;
         info!(
             "Total time reading index: {:.2} s",
             read_index_timer.elapsed().as_secs_f64()
@@ -959,6 +950,7 @@ impl Mapper<'_> {
                             &r1,
                             &r2,
                             self.index,
+                            self.refseq,
                             &mut self.abundances,
                             self.mapping_parameters.rescue_distance,
                             &mut isizedist,
@@ -969,6 +961,7 @@ impl Mapper<'_> {
                     } else {
                         abundances_single_end_read(
                             &r1,
+                            self.refseq,
                             self.index,
                             &mut self.abundances,
                             self.mapping_parameters.rescue_distance,
@@ -991,7 +984,7 @@ pub fn output_abundances<T: Write>(
 ) -> io::Result<()> {
     #[allow(clippy::needless_range_loop)]
     for i in 0..refseq.names.len() {
-        let normalized = abundances[i] / refseq.contig_len(i) as f64;
+        let normalized = abundances[i] / refseq.contig(i).len() as f64;
         writeln!(out, "{}\t{:.6}", refseq.names[i], normalized)?;
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ static GLOBAL: MiMalloc = MiMalloc;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const NAME: &str = env!("CARGO_PKG_NAME");
+const RUSTFLAGS: Option<&str> = option_env!("RUSTFLAGS");
 const STYLES: Styles = Styles::plain()
     .header(AnsiColor::Blue.on_default())
     .usage(AnsiColor::Blue.on_default())
@@ -332,6 +333,7 @@ fn run() -> Result<(), CliError> {
     if cfg!(target_os = "linux") {
         warn_clocksource();
     }
+    debug!("RUSTFLAGS='{}'", RUSTFLAGS.unwrap_or(""));
 
     // Open R1 FASTQ file and estimate read length if necessary
     let read_length;

--- a/src/maponly.rs
+++ b/src/maponly.rs
@@ -10,7 +10,7 @@ use crate::io::record::{End, SequenceRecord};
 use crate::mapper::mapping_quality;
 use crate::math::normal_pdf;
 use crate::mcsstrategy::McsStrategy;
-use crate::refseq::RefSequence;
+use crate::refseq::{ContigPosition, ContigStarts, RefSequence};
 
 /// Map a single-end read to the reference and return PAF records
 ///
@@ -38,14 +38,16 @@ pub fn map_single_end_read(
     } else {
         let mapq = mapping_quality(&chains);
         (
-            vec![paf_record_from_chain(
+            paf_record_from_chain(
                 &chains[0],
                 &record.name,
                 refseq,
                 record.sequence.len(),
                 Some(mapq),
                 End::None,
-            )],
+            )
+            .into_iter()
+            .collect::<Vec<_>>(),
             chain_details.into(),
         )
     }
@@ -56,6 +58,7 @@ pub fn map_single_end_read(
 /// This implements abundance estimation mode (`--aemb`)
 pub fn abundances_single_end_read(
     record: &SequenceRecord,
+    refseq: &RefSequence,
     index: &StrobemerIndex,
     abundances: &mut [f64],
     rescue_distance: usize,
@@ -78,7 +81,8 @@ pub fn abundances_single_end_read(
         .count();
     let weight = record.sequence.len() as f64 / n_best as f64;
     for chain in &chains[0..n_best] {
-        abundances[chain.ref_id] += weight;
+        let contig_id = refseq.unflatten(chain.ref_start).0;
+        abundances[contig_id] += weight;
     }
 }
 
@@ -90,22 +94,27 @@ fn paf_record_from_chain(
     query_length: usize,
     mapq: Option<u8>,
     end: End,
-) -> PafRecord {
-    PafRecord {
+) -> Option<PafRecord> {
+    let (contig_id, target_start) = refseq.unflatten(chain.ref_start);
+    let target_end = ContigPosition((target_start.0 as usize + chain.ref_span()) as u32);
+    let contig = refseq.contig(contig_id);
+    assert!(target_end.0 as usize <= contig.len());
+
+    Some(PafRecord {
         query_name: name.into(),
         end,
         query_length: query_length as u64,
         query_start: chain.query_start as u64,
         query_end: chain.query_end as u64,
         is_revcomp: chain.is_revcomp,
-        target_name: refseq.names[chain.ref_id].clone(),
-        target_length: refseq.contig_len(chain.ref_id) as u64,
-        target_start: chain.ref_start as u64,
-        target_end: chain.ref_end as u64,
+        target_name: refseq.names[contig_id].clone(),
+        target_length: contig.len() as u64,
+        target_start,
+        target_end,
         matching_bases: chain.matching_bases as u64,
         alignment_length: (chain.ref_end - chain.ref_start) as u64,
         mapping_quality: mapq,
-    }
+    })
 }
 
 /// Map a paired-end read pair to the reference and return PAF records
@@ -135,6 +144,7 @@ pub fn map_paired_end_read(
     let chain_pairs = get_chain_pairs(
         &mut chains1,
         &mut chains2,
+        &refseq.starts,
         insert_size_distribution.mu,
         insert_size_distribution.sigma,
         &chain_details1,
@@ -153,7 +163,7 @@ pub fn map_paired_end_read(
     ) {
         MappedChains::Individual(best1, best2) => {
             if let Some(chain1) = best1 {
-                records.push(paf_record_from_chain(
+                records.extend(paf_record_from_chain(
                     chain1,
                     &r1.name,
                     refseq,
@@ -163,7 +173,7 @@ pub fn map_paired_end_read(
                 ));
             }
             if let Some(chain2) = best2 {
-                records.push(paf_record_from_chain(
+                records.extend(paf_record_from_chain(
                     chain2,
                     &r2.name,
                     refseq,
@@ -174,7 +184,7 @@ pub fn map_paired_end_read(
             }
         }
         MappedChains::Pair(chain1, chain2, _) => {
-            records.push(paf_record_from_chain(
+            records.extend(paf_record_from_chain(
                 chain1,
                 &r1.name,
                 refseq,
@@ -182,7 +192,7 @@ pub fn map_paired_end_read(
                 None,
                 End::One,
             ));
-            records.push(paf_record_from_chain(
+            records.extend(paf_record_from_chain(
                 chain2,
                 &r2.name,
                 refseq,
@@ -194,6 +204,7 @@ pub fn map_paired_end_read(
     }
 
     chain_details1 += chain_details2;
+
     (records, chain_details1.into())
 }
 
@@ -204,6 +215,7 @@ pub fn abundances_paired_end_read(
     r1: &SequenceRecord,
     r2: &SequenceRecord,
     index: &StrobemerIndex,
+    refseq: &RefSequence,
     abundances: &mut [f64],
     rescue_distance: usize,
     insert_size_distribution: &mut InsertSizeDistribution,
@@ -223,6 +235,7 @@ pub fn abundances_paired_end_read(
     let chain_pairs = get_chain_pairs(
         &mut chains1,
         &mut chains2,
+        &refseq.starts,
         insert_size_distribution.mu,
         insert_size_distribution.sigma,
         &chain_details1,
@@ -247,7 +260,8 @@ pub fn abundances_paired_end_read(
                     .count();
                 let weight = read_len as f64 / n_best as f64;
                 for chain in &chains[0..n_best] {
-                    abundances[chain.ref_id] += weight;
+                    let contig_id = refseq.unflatten(chain.ref_start).0;
+                    abundances[contig_id] += weight;
                 }
             }
         }
@@ -264,8 +278,8 @@ pub fn abundances_paired_end_read(
                 score: _,
             } in &chain_pairs[..n_best]
             {
-                abundances[chain1.ref_id] += weight_r1;
-                abundances[chain2.ref_id] += weight_r2;
+                abundances[refseq.unflatten(chain1.ref_start).0] += weight_r1;
+                abundances[refseq.unflatten(chain2.ref_start).0] += weight_r2;
             }
         }
     }
@@ -329,6 +343,7 @@ pub struct ChainPair {
 fn get_chain_pairs(
     chains1: &mut [Chain],
     chains2: &mut [Chain],
+    contig_starts: &ContigStarts,
     mu: f32,
     sigma: f32,
     details1: &ChainDetails,
@@ -345,14 +360,14 @@ fn get_chain_pairs(
         split_chains_by_orientation_checked(chains2, details2.both_orientations);
 
     if !fwd1.is_empty() && !rev2.is_empty() {
-        fwd1.sort_unstable_by_key(|chain| (chain.ref_id, chain.projected_ref_start()));
-        rev2.sort_unstable_by_key(|chain| (chain.ref_id, chain.projected_ref_start()));
-        chain_pairs.extend(find_pairs(fwd1, rev2, mu, sigma, false));
+        fwd1.sort_unstable_by_key(|chain| chain.projected_ref_start());
+        rev2.sort_unstable_by_key(|chain| chain.projected_ref_start());
+        chain_pairs.extend(find_pairs(fwd1, rev2, contig_starts, mu, sigma, false));
     }
     if !fwd2.is_empty() && !rev1.is_empty() {
-        fwd2.sort_unstable_by_key(|chain| (chain.ref_id, chain.projected_ref_start()));
-        rev1.sort_unstable_by_key(|chain| (chain.ref_id, chain.projected_ref_start()));
-        chain_pairs.extend(find_pairs(fwd2, rev1, mu, sigma, true));
+        fwd2.sort_unstable_by_key(|chain| chain.projected_ref_start());
+        rev1.sort_unstable_by_key(|chain| chain.projected_ref_start());
+        chain_pairs.extend(find_pairs(fwd2, rev1, contig_starts, mu, sigma, true));
     }
 
     chain_pairs.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
@@ -394,10 +409,11 @@ fn split_chains_by_orientation(chains: &mut [Chain]) -> (&mut [Chain], &mut [Cha
 }
 
 /// Find most forward/revcomp pairs using a two-pointer scan.
-/// Assumes both slices are sorted by (ref_id, projected_ref_start).
+/// Assumes both slices are sorted by projected_ref_start.
 fn find_pairs(
     fwd: &[Chain],
     rev: &[Chain],
+    contig_starts: &ContigStarts,
     mu: f32,
     sigma: f32,
     swap_order: bool,
@@ -409,25 +425,20 @@ fn find_pairs(
 
     for f in fwd {
         // Advance revcomp pointer to the first possible candidate
-        while rev_ptr < rev.len()
-            && (rev[rev_ptr].ref_id < f.ref_id
-                || rev[rev_ptr].ref_id == f.ref_id
-                    && rev[rev_ptr].projected_ref_start() < f.projected_ref_start())
-        {
+        while rev_ptr < rev.len() && rev[rev_ptr].projected_ref_start() < f.projected_ref_start() {
             rev_ptr += 1;
         }
         if rev_ptr == rev.len() {
             break;
         }
-        if rev[rev_ptr].ref_id > f.ref_id {
-            continue;
-        }
+        let f_contig_id = contig_starts.index(f.projected_ref_start());
+        let f_contig_range = contig_starts.0[f_contig_id]..contig_starts.0[f_contig_id + 1];
 
         // Scan window of revcomp chains within distance limit.
         let mut best = None;
         let mut i = rev_ptr;
         while i < rev.len()
-            && rev[i].ref_id == f.ref_id
+            && f_contig_range.contains(&rev[i].projected_ref_start())
             && (rev[i].projected_ref_start() - f.projected_ref_start()) <= max_dist
         {
             let r = &rev[i];

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -23,7 +23,7 @@ use crate::math::normal_pdf;
 use crate::mcsstrategy::McsStrategy;
 use crate::piecewisealigner::remove_spurious_anchors;
 use crate::read::Read;
-use crate::refseq::RefSequence;
+use crate::refseq::{ContigPosition, RefSequence};
 use crate::revcomp::reverse_complement;
 use crate::seeding::SeedingParameters;
 
@@ -54,10 +54,17 @@ impl Default for MappingParameters {
     }
 }
 
+/// Representation of how a query was aligned against the reference
+/// (mostly reference coordinate and CIGAR). This is later converted to
+/// SAM format.
+///
+/// This uses contig-relative ("unflattened") coordinates because the
+/// conversion from the flat position needs to be done anyway before aligning
+/// to ensure we don’t align across contigs.
 #[derive(Debug, Clone)]
 struct Alignment {
-    reference_id: usize,
-    ref_start: usize,
+    contig_id: usize,
+    contig_start: usize,
     cigar: Cigar,
     edit_distance: usize,
     soft_clip_left: usize,
@@ -173,7 +180,8 @@ impl SamOutput {
         cigar.push(CigarOperation::Softclip, alignment.soft_clip_left);
         cigar.extend(&alignment.cigar);
         cigar.push(CigarOperation::Softclip, alignment.soft_clip_right);
-        let reference_name = Some(refseq.names[alignment.reference_id].clone());
+        let reference_name = Some(refseq.names[alignment.contig_id].clone());
+        let pos = Some(ContigPosition(alignment.contig_start as u32));
         let details = if self.details { Some(details) } else { None };
         let cigar = if self.cigar_eqx {
             Some(cigar)
@@ -189,7 +197,7 @@ impl SamOutput {
             query_name: record.name.clone(),
             flags,
             reference_name,
-            pos: Some(alignment.ref_start as u32),
+            pos,
             mapq,
             cigar,
             query_sequence: Some(query_sequence),
@@ -286,23 +294,24 @@ impl SamOutput {
                 if mate.is_revcomp {
                     sam_records[i].flags |= MREVERSE;
                 }
+
                 // PNEXT (position of mate)
-                sam_records[i].mate_pos = Some(mate.ref_start as u32);
+                sam_records[i].mate_pos = Some(ContigPosition(mate.contig_start as u32));
 
                 // RNEXT (reference name of mate)
-                sam_records[i].mate_reference_name = Some(refseq.names[mate.reference_id].clone());
+                sam_records[i].mate_reference_name = Some(refseq.names[mate.contig_id].clone());
                 if let Some(this) = alignments[i] {
                     // both aligned
 
-                    if this.reference_id == mate.reference_id {
+                    if this.contig_id == mate.contig_id {
                         // aligned to same reference
                         sam_records[i].mate_reference_name = Some("=".to_string());
 
                         // TLEN
-                        let template_length = if mate.ref_start > this.ref_start {
-                            (mate.ref_start - this.ref_start + mate.length) as isize
-                        } else if this.ref_start > mate.ref_start {
-                            -((this.ref_start - mate.ref_start + this.length) as isize)
+                        let template_length = if mate.contig_start > this.contig_start {
+                            (mate.contig_start - this.contig_start + mate.length) as isize
+                        } else if this.contig_start > mate.contig_start {
+                            -((this.contig_start - mate.contig_start + this.length) as isize)
                         } else if i == 0 {
                             -(mate.length as isize)
                         } else {
@@ -315,8 +324,8 @@ impl SamOutput {
                     // mate-pair read whose mate is mapped, the unmapped read should have
                     // RNAME and POS identical to its mate."
                     sam_records[i].mate_reference_name = Some("=".to_string());
-                    sam_records[i].reference_name = Some(refseq.names[mate.reference_id].clone());
-                    sam_records[i].pos = Some(mate.ref_start as u32);
+                    sam_records[i].reference_name = Some(refseq.names[mate.contig_id].clone());
+                    sam_records[i].pos = Some(ContigPosition(mate.contig_start as u32));
                 }
             } else {
                 // mate unmapped
@@ -325,7 +334,7 @@ impl SamOutput {
                 // Set RNAME and POS identical to mate
                 if let Some(this) = alignments[i] {
                     sam_records[i].mate_reference_name = Some("=".to_string());
-                    sam_records[i].mate_pos = Some(this.ref_start as u32);
+                    sam_records[i].mate_pos = Some(ContigPosition(this.contig_start as u32));
                 }
             }
         }
@@ -540,10 +549,14 @@ fn extend_seed(
     } else {
         read.seq()
     };
-    let seq = &refseq.contig(chain.ref_id);
+    let (contig_id, contig_start) = refseq.unflatten(chain.ref_start);
+    let contig_start = contig_start.0 as usize;
+    let contig_end = contig_start + chain.ref_span();
+    let contig = refseq.contig(contig_id);
+    assert!(contig_end <= contig.len());
 
-    let projected_ref_start = chain.ref_start.saturating_sub(chain.query_start);
-    let projected_ref_end = min(chain.ref_end + query.len() - chain.query_end, seq.len());
+    let projected_start = contig_start.saturating_sub(chain.query_start);
+    let projected_end = min(contig_end + query.len() - chain.query_end, contig.len());
 
     // TODO ugly
     let mut info = AlignmentInfo {
@@ -555,52 +568,51 @@ fn extend_seed(
         query_end: 0,
         score: 0,
     };
-    let mut result_ref_start = 0;
+    let mut result_start = 0;
     let mut gapped = true;
-    if projected_ref_start + query.len() == projected_ref_end && consistent_chain {
-        let ref_segm_ham = seq.decode(projected_ref_start, projected_ref_end);
-        if let Some(hamming_dist) = hamming_distance(query, &ref_segm_ham)
+    if projected_start + query.len() == projected_end && consistent_chain {
+        let segment = contig.decode(projected_start, projected_end);
+        if let Some(hamming_dist) = hamming_distance(query, &segment)
             && (hamming_dist as f32 / query.len() as f32) < 0.05
         {
             // ungapped worked fine, no need to do gapped alignment
             info = hamming_align(
                 query,
-                &ref_segm_ham,
+                &segment,
                 aligner.scores.match_,
                 aligner.scores.mismatch,
                 aligner.scores.end_bonus,
             )
             .expect("hamming_dist was successful, this should be as well");
-            result_ref_start = projected_ref_start + info.ref_start;
+            result_start = projected_start + info.ref_start;
             gapped = false;
         }
     }
     if gapped {
         let padding = read.len() / 10;
         if use_ssw {
-            let ref_start = projected_ref_start.saturating_sub(padding);
-            let ref_end = min(projected_ref_end + padding, seq.len());
-            let segment = seq.decode(ref_start, ref_end);
+            let decode_start = projected_start.saturating_sub(padding);
+            let decode_end = min(projected_end + padding, contig.len());
+            let segment = contig.decode(decode_start, decode_end);
             info = aligner.align(query, &segment)?;
-            result_ref_start = ref_start + info.ref_start;
+            result_start = decode_start + info.ref_start;
         } else {
             remove_spurious_anchors(&mut chain.anchors);
             // Decode the reference region needed by the piecewise aligner.
             // Use a generous range so all anchor-relative slices stay in bounds.
-            let decode_start = chain.ref_start.saturating_sub(query.len() + padding);
-            let decode_end = (chain.ref_end + query.len() + padding).min(seq.len());
-            let decoded_ref = seq.decode(decode_start, decode_end);
+            let decode_start = contig_start.saturating_sub(query.len() + padding);
+            let decode_end = (contig_end + query.len() + padding).min(contig.len());
+            let segment = contig.decode(decode_start, decode_end);
             let adjusted_anchors: Vec<Anchor> = chain
                 .anchors
                 .iter()
                 .map(|a| Anchor {
-                    ref_id: a.ref_id,
-                    ref_start: a.ref_start - decode_start,
+                    ref_start: a.ref_start - decode_start - refseq.starts.0[contig_id],
                     query_start: a.query_start,
                 })
                 .collect();
-            info = aligner.align_piecewise(query, &decoded_ref, &adjusted_anchors, padding)?;
-            result_ref_start = info.ref_start + decode_start;
+            info = aligner.align_piecewise(query, &segment, &adjusted_anchors, padding)?;
+            result_start = info.ref_start + decode_start;
         }
     }
     Some(Alignment {
@@ -609,10 +621,10 @@ fn extend_seed(
         soft_clip_left: info.query_start,
         soft_clip_right: query.len() - info.query_end,
         score: info.score,
-        ref_start: result_ref_start,
+        contig_id,
+        contig_start: result_start,
         length: info.ref_span(),
         is_revcomp: chain.is_revcomp,
-        reference_id: chain.ref_id,
         gapped,
     })
 }
@@ -682,7 +694,7 @@ pub fn align_paired_end_read(
                 && alignment1.edit_distance + alignment2.edit_distance < 3
             {
                 insert_size_distribution
-                    .update(alignment1.ref_start.abs_diff(alignment2.ref_start));
+                    .update(alignment1.contig_start.abs_diff(alignment2.contig_start));
             }
 
             let mapq1 = mapping_quality(&chains_pair[0]);
@@ -970,16 +982,16 @@ fn extend_paired_seeds(
         let a2 = alignments[1].as_ref().unwrap();
         let r1_r2 = a2.is_revcomp
             && !a1.is_revcomp
-            && (a1.ref_start <= a2.ref_start)
-            && ((a2.ref_start - a1.ref_start) < (mu + 10.0 * sigma) as usize); // r1 ---> <---- r2
+            && (a1.contig_start <= a2.contig_start)
+            && ((a2.contig_start - a1.contig_start) < (mu + 10.0 * sigma) as usize); // r1 ---> <---- r2
         let r2_r1 = a1.is_revcomp
             && !a2.is_revcomp
-            && (a2.ref_start <= a1.ref_start)
-            && ((a1.ref_start - a2.ref_start) < (mu + 10.0 * sigma) as usize); // r2 ---> <---- r1
+            && (a2.contig_start <= a1.contig_start)
+            && ((a1.contig_start - a2.contig_start) < (mu + 10.0 * sigma) as usize); // r2 ---> <---- r1
 
         let combined_score = if r1_r2 || r2_r1 {
             // Treat as a pair
-            let x = a1.ref_start.abs_diff(a2.ref_start);
+            let x = a1.contig_start.abs_diff(a2.contig_start);
             a1.score as f64
                 + a2.score as f64
                 + (-20.0f64 + 0.001).max(normal_pdf(x as f32, mu, sigma).ln() as f64)
@@ -1061,7 +1073,7 @@ fn rescue_read(
     for a1 in alignments1 {
         for a2 in &alignments2 {
             if let Some(a2) = a2 {
-                let dist = a1.ref_start.abs_diff(a2.ref_start);
+                let dist = a1.contig_start.abs_diff(a2.contig_start);
                 let mut score = (a1.score + a2.score) as f32;
                 if (a1.is_revcomp ^ a2.is_revcomp) && (dist as f32) < mu + 4.0 * sigma {
                     score += normal_pdf(dist as f32, mu, sigma).ln();
@@ -1100,40 +1112,45 @@ fn rescue_align(
 ) -> Option<Alignment> {
     let read_len = read.len();
 
-    let (r_tmp, ref_start, ref_end) = if mate_chain.is_revcomp {
+    let (contig_id, contig_start) = refseq.unflatten(mate_chain.ref_start);
+    let contig_start = contig_start.0 as usize;
+    let contig_end = contig_start + mate_chain.ref_span();
+    let contig = refseq.contig(contig_id);
+    assert!(contig_end <= contig.len());
+
+    let (read_seq, segment_start, segment_end) = if mate_chain.is_revcomp {
+        let projected_start = contig_start.saturating_sub(mate_chain.query_start);
         (
             read.seq(),
-            mate_chain
-                .projected_ref_start()
-                .saturating_sub((mu + 5.0 * sigma) as usize),
-            mate_chain.projected_ref_start() + read_len / 2, // at most half read overlap
+            projected_start.saturating_sub((mu + 5.0 * sigma) as usize),
+            projected_start + read_len / 2, // at most half read overlap
         )
     } else {
+        let projected_end = contig_end + read_len - mate_chain.query_end;
         (
-            read.rc(), // mate is rc since fr orientation
-            (mate_chain.ref_end + read_len - mate_chain.query_end).saturating_sub(read_len / 2), // at most half read overlap
-            mate_chain.ref_end + read_len - mate_chain.query_end + (mu + 5.0 * sigma) as usize,
+            read.rc(),                                  // mate is rc since fr orientation
+            projected_end.saturating_sub(read_len / 2), // at most half read overlap
+            projected_end + (mu + 5.0 * sigma) as usize,
         )
     };
 
-    let ref_len = refseq.contig_len(mate_chain.ref_id);
-    let ref_start = ref_start.min(ref_len);
-    let ref_end = ref_end.min(ref_len);
+    let segment_start = segment_start.min(contig.len());
+    let segment_end = segment_end.min(contig.len());
 
-    if ref_end < ref_start + k {
+    if segment_end < segment_start + k {
         //        std::cerr << "RESCUE: Caught Bug3! ref start: " << ref_start << " ref end: " << ref_end << " ref len:  " << ref_len << std::endl;
         return None;
     }
-    let ref_segm = refseq.contig(mate_chain.ref_id).decode(ref_start, ref_end);
+    let segment = contig.decode(segment_start, segment_end);
 
-    if !has_shared_substring(r_tmp, &ref_segm, k) {
+    if !has_shared_substring(read_seq, &segment, k) {
         return None;
     }
-    let info = aligner.align(r_tmp, &ref_segm);
+    let info = aligner.align(read_seq, &segment);
     if let Some(info) = info {
         Some(Alignment {
-            reference_id: mate_chain.ref_id,
-            ref_start: ref_start + info.ref_start,
+            contig_id,
+            contig_start: segment_start + info.ref_start,
             edit_distance: info.edit_distance,
             soft_clip_left: info.query_start,
             soft_clip_right: read_len - info.query_end,
@@ -1178,10 +1195,10 @@ fn is_proper_pair_opt(
 }
 
 /// Return true if the two alignments form a proper pair:
-/// on the same reference, in opposite orientations, within the expected insert size.
+/// on the same contig, in opposite orientations, within the expected insert size.
 fn is_proper_pair(a1: &Alignment, a2: &Alignment, mu: f32, sigma: f32) -> PairStatus {
-    let dist = a2.ref_start as isize - a1.ref_start as isize;
-    let same_reference = a1.reference_id == a2.reference_id;
+    let dist = a2.contig_start as isize - a1.contig_start as isize;
+    let same_reference = a1.contig_id == a2.contig_id;
     let r1_r2 = !a1.is_revcomp && a2.is_revcomp && dist >= 0; // r1 ---> <---- r2
     let r2_r1 = !a2.is_revcomp && a1.is_revcomp && dist <= 0; // r2 ---> <---- r1
     let rel_orientation_good = r1_r2 || r2_r1;
@@ -1195,7 +1212,8 @@ fn is_proper_pair(a1: &Alignment, a2: &Alignment, mu: f32, sigma: f32) -> PairSt
 }
 
 pub fn is_proper_chain_pair(chain1: &Chain, chain2: &Chain, mu: f32, sigma: f32) -> bool {
-    if chain1.ref_id != chain2.ref_id || chain1.is_revcomp == chain2.is_revcomp {
+    if chain1.ref_contig_start != chain2.ref_contig_start || chain1.is_revcomp == chain2.is_revcomp
+    {
         return false;
     }
     let r1_ref_start = chain1.projected_ref_start();
@@ -1340,7 +1358,7 @@ fn deduplicate_scored_pairs(pairs: &mut Vec<ScoredAlignmentPair>) {
             (Some(_), None) => false,
             (None, None) => true,
             (Some(a1), Some(a2)) => {
-                a1.ref_start == a2.ref_start && a1.reference_id == a2.reference_id
+                a1.contig_start == a2.contig_start && a1.contig_id == a2.contig_id
             }
         }
     }
@@ -1474,15 +1492,10 @@ mod tests {
     use super::*;
     use crate::cigar::Cigar;
 
-    pub fn make_alignment(
-        reference_id: usize,
-        ref_start: usize,
-        score: u32,
-        is_revcomp: bool,
-    ) -> Alignment {
+    pub fn make_alignment(contig_start: usize, score: u32, is_revcomp: bool) -> Alignment {
         Alignment {
-            reference_id,
-            ref_start,
+            contig_id: 0,
+            contig_start,
             score,
             is_revcomp,
             edit_distance: 0,
@@ -1496,8 +1509,8 @@ mod tests {
 
     fn dummy_alignment() -> Alignment {
         Alignment {
-            reference_id: 0,
-            ref_start: 0,
+            contig_id: 0,
+            contig_start: 0,
             cigar: Cigar::default(),
             edit_distance: 0,
             soft_clip_left: 0,
@@ -1537,13 +1550,11 @@ mod tests {
     #[test]
     fn deduplicate_scored_pairs_works() {
         let a1 = Some(Alignment {
-            reference_id: 0,
-            ref_start: 1906,
+            contig_start: 1906,
             ..dummy_alignment()
         });
         let a2 = Some(Alignment {
-            reference_id: 0,
-            ref_start: 123,
+            contig_start: 123,
             ..dummy_alignment()
         });
         let mut alignment_pairs = vec![
@@ -1595,8 +1606,8 @@ mod tests {
     fn is_proper_pair_within_distance() {
         let mu = 300.0_f32;
         let sigma = 50.0_f32;
-        let a1 = make_alignment(0, 100, 40, false);
-        let a2 = make_alignment(0, 350, 40, true);
+        let a1 = make_alignment(100, 40, false);
+        let a2 = make_alignment(350, 40, true);
         assert_eq!(is_proper_pair(&a1, &a2, mu, sigma), PairStatus::Proper);
     }
 
@@ -1604,8 +1615,8 @@ mod tests {
     fn is_proper_pair_rev_within_distance() {
         let mu = 300.0_f32;
         let sigma = 50.0_f32;
-        let a1 = make_alignment(0, 350, 40, true);
-        let a2 = make_alignment(0, 100, 40, false);
+        let a1 = make_alignment(350, 40, true);
+        let a2 = make_alignment(100, 40, false);
         assert_eq!(is_proper_pair(&a1, &a2, mu, sigma), PairStatus::Proper);
     }
 
@@ -1613,8 +1624,8 @@ mod tests {
     fn is_proper_pair_incompatible() {
         let mu = 300.0_f32;
         let sigma = 50.0_f32;
-        let a1 = make_alignment(0, 100, 40, false);
-        let a2 = make_alignment(0, 350, 40, false);
+        let a1 = make_alignment(100, 40, false);
+        let a2 = make_alignment(350, 40, false);
         assert_eq!(is_proper_pair(&a1, &a2, mu, sigma), PairStatus::NotProper);
     }
 
@@ -1622,8 +1633,8 @@ mod tests {
     fn is_proper_pair_too_far() {
         let mu = 300.0_f32;
         let sigma = 50.0_f32;
-        let a1 = make_alignment(0, 100, 40, false);
-        let a2 = make_alignment(0, 10_000, 40, true);
+        let a1 = make_alignment(100, 40, false);
+        let a2 = make_alignment(10_000, 40, true);
         assert_eq!(is_proper_pair(&a1, &a2, mu, sigma), PairStatus::NotProper);
     }
 }

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -14,6 +14,14 @@ pub struct PackedSeq {
     len: usize,
 }
 
+#[derive(Debug)]
+#[allow(clippy::len_without_is_empty)]
+pub struct PackedSeqSlice<'a> {
+    seq: &'a PackedSeq,
+    start: usize,
+    len: usize,
+}
+
 const fn make_encode_table() -> [u8; 256] {
     let mut t = [0u8; 256];
     t[b'C' as usize] = 1;
@@ -91,6 +99,12 @@ impl PackedSeq {
         self.len += 1;
     }
 
+    pub fn extend<I: IntoIterator<Item = u8>>(&mut self, bytes: I) {
+        for b in bytes.into_iter() {
+            self.push(b);
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.len
     }
@@ -122,5 +136,44 @@ impl PackedSeq {
     /// Decode the full sequence as ASCII bytes.
     pub fn decode_all(&self) -> Vec<u8> {
         self.decode(0, self.len)
+    }
+}
+
+impl<'a> PackedSeqSlice<'a> {
+    pub fn new(seq: &'a PackedSeq, start: usize, len: usize) -> Self {
+        PackedSeqSlice { seq, start, len }
+    }
+
+    pub fn nucleotide_bits(&self, i: usize) -> u8 {
+        self.seq.nucleotide_bits(self.start + i)
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Decode bases `start..end` as ASCII bytes.
+    pub fn decode(&self, start: usize, end: usize) -> Vec<u8> {
+        (start..end)
+            .map(|i| self.seq.decode_at(self.start + i))
+            .collect()
+    }
+
+    /// Decode bases `start..end` as ASCII bytes.
+    pub fn decode_all(&self) -> Vec<u8> {
+        (self.start..self.start + self.len)
+            .map(|i| self.seq.decode_at(i))
+            .collect()
+    }
+
+    pub fn to_owned(&self) -> PackedSeq {
+        // This is probably inefficient because it unpacks and then
+        // re-packs the sequence, but it is only used for testing
+        // with tiny references.
+        let mut ps = PackedSeq::new();
+        let decoded = self.decode_all();
+        ps.extend(decoded);
+
+        ps
     }
 }

--- a/src/piecewisealigner.rs
+++ b/src/piecewisealigner.rs
@@ -1252,57 +1252,46 @@ mod tests {
     fn remove_spurious_anchors_control() {
         let expected = vec![
             Anchor {
-                ref_id: 0,
                 ref_start: 0,
                 query_start: 0,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 10,
                 query_start: 10,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 20,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 30,
                 query_start: 30,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 40,
                 query_start: 40,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 50,
                 query_start: 50,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 60,
                 query_start: 60,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 70,
                 query_start: 70,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 80,
                 query_start: 80,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 90,
                 query_start: 90,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 100,
                 query_start: 100,
             },
@@ -1316,57 +1305,46 @@ mod tests {
     fn remove_spurious_anchors_inside_trim() {
         let mut result = vec![
             Anchor {
-                ref_id: 0,
                 ref_start: 0,
                 query_start: 0,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 10,
                 query_start: 10,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 20,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 130,
                 query_start: 30,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 140,
                 query_start: 40,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 150,
                 query_start: 50,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 60,
                 query_start: 60,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 70,
                 query_start: 50,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 80,
                 query_start: 80,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 90,
                 query_start: 90,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 100,
                 query_start: 100,
             },
@@ -1374,37 +1352,30 @@ mod tests {
         remove_spurious_anchors(&mut result);
         let expected = vec![
             Anchor {
-                ref_id: 0,
                 ref_start: 0,
                 query_start: 0,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 10,
                 query_start: 10,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 20,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 60,
                 query_start: 60,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 80,
                 query_start: 80,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 90,
                 query_start: 90,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 100,
                 query_start: 100,
             },
@@ -1416,57 +1387,46 @@ mod tests {
     fn remove_spurious_anchors_ends_trim() {
         let mut result = vec![
             Anchor {
-                ref_id: 0,
                 ref_start: 5,
                 query_start: 0,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 15,
                 query_start: 10,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 20,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 30,
                 query_start: 30,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 40,
                 query_start: 40,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 50,
                 query_start: 50,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 60,
                 query_start: 60,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 70,
                 query_start: 70,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 80,
                 query_start: 80,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 90,
                 query_start: 95,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 100,
                 query_start: 105,
             },
@@ -1474,37 +1434,30 @@ mod tests {
         remove_spurious_anchors(&mut result);
         let expected = vec![
             Anchor {
-                ref_id: 0,
                 ref_start: 20,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 30,
                 query_start: 30,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 40,
                 query_start: 40,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 50,
                 query_start: 50,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 60,
                 query_start: 60,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 70,
                 query_start: 70,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 80,
                 query_start: 80,
             },
@@ -1529,22 +1482,18 @@ mod tests {
         let refseq = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let anchors = vec![
             Anchor {
-                ref_id: 0,
                 ref_start: 40,
                 query_start: 30,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 30,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 20,
                 query_start: 10,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 10,
                 query_start: 0,
             },
@@ -1578,17 +1527,14 @@ mod tests {
         let refseq = b"TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT";
         let anchors = vec![
             Anchor {
-                ref_id: 0,
                 ref_start: 30,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 20,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 10,
                 query_start: 10,
             },
@@ -1616,37 +1562,30 @@ mod tests {
             b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let anchors = vec![
             Anchor {
-                ref_id: 0,
                 ref_start: 40,
                 query_start: 30,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 37,
                 query_start: 27,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 35,
                 query_start: 25,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 30,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 25,
                 query_start: 20,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 20,
                 query_start: 15,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 10,
                 query_start: 5,
             },
@@ -1680,17 +1619,14 @@ mod tests {
         let refseq = b"TTTTTAAAAATTTTTAAAAATTTTTAAAAATTTTTAAAAATTTTTAAAAA";
         let anchors = vec![
             Anchor {
-                ref_id: 0,
                 ref_start: 35,
                 query_start: 36,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 15,
                 query_start: 14,
             },
             Anchor {
-                ref_id: 0,
                 ref_start: 5,
                 query_start: 5,
             },

--- a/src/refseq.rs
+++ b/src/refseq.rs
@@ -1,37 +1,173 @@
-use crate::packed_seq::PackedSeq;
+use crate::packed_seq::{PackedSeq, PackedSeqSlice};
 
-#[derive(Default, Debug, Clone)]
-pub struct RefSequence {
-    pub names: Vec<String>,
-    sequences: Vec<PackedSeq>,
+/// A position on a contig. This separate type is here to prevent confusion
+/// with "flat" reference coordinates, which are used everywhere else.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct ContigPosition(pub u32);
+
+#[derive(Debug, Clone)]
+pub struct ContigStarts(
+    /// Start positions for all contigs. `starts[i]` is the start position of
+    /// contig with index `i` within `sequence`. This contains one more item
+    /// than there are contigs, which is set to the length of `sequence`.
+    pub Vec<usize>,
+);
+
+impl Default for ContigStarts {
+    fn default() -> Self {
+        Self(vec![0])
+    }
 }
 
-impl RefSequence {
-    pub fn new() -> Self {
-        RefSequence {
-            names: vec![],
-            sequences: vec![],
-        }
+/// Contig start positions within the concatenated reference.
+///
+/// Use this only to lookup *start* coordinates.
+/// Otherwise, when trying to lookup an end coordinate that happens to be
+/// the end of a contig i, this is found as position 0 of contig i + 1.
+impl ContigStarts {
+    pub fn new(mut starts: Vec<usize>, total_length: usize) -> Self {
+        starts.push(total_length);
+
+        Self(starts)
     }
 
-    pub fn push(&mut self, name: String, seq: PackedSeq) {
-        self.names.push(name);
-        self.sequences.push(seq);
+    /// Returns the index of the contig that contains the given position.
+    pub fn index(&self, start: usize) -> usize {
+        self.0[1..].partition_point(|&x| x <= start)
     }
 
-    pub fn contig(&self, index: usize) -> &PackedSeq {
-        &self.sequences[index]
+    /// Returns the start position of the contig that contains the given position.
+    pub fn ref_contig_start(&self, start: usize) -> usize {
+        self.0[self.index(start)]
     }
 
-    pub fn contig_len(&self, index: usize) -> usize {
-        self.sequences[index].len()
-    }
+    /// Returns (contig_index, contig_start)
+    pub fn unflatten(&self, start: usize) -> (usize, ContigPosition) {
+        let ref_index = self.index(start);
+        let start_within_contig = start - self.0[ref_index];
 
-    pub fn max_contig_len(&self) -> Option<usize> {
-        self.sequences.iter().map(|seq| seq.len()).max()
+        (ref_index, ContigPosition(start_within_contig as u32))
     }
 
     pub fn total_length(&self) -> usize {
-        self.sequences.iter().map(|seq| seq.len()).sum()
+        *self.0.last().unwrap()
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct RefSequence {
+    /// Contig names
+    pub names: Vec<String>,
+
+    /// Concatenated sequence of all contigs
+    sequence: PackedSeq,
+
+    pub starts: ContigStarts,
+}
+
+impl RefSequence {
+    pub fn new(sequence: PackedSeq, starts: Vec<usize>, names: Vec<String>) -> Self {
+        assert_eq!(starts.len(), names.len());
+        let total_length = sequence.len();
+
+        RefSequence {
+            sequence,
+            starts: ContigStarts::new(starts, total_length),
+            names,
+        }
+    }
+
+    pub fn sequence(&self) -> &PackedSeq {
+        &self.sequence
+    }
+
+    /// Returns (contig_index, contig_start)
+    pub fn unflatten(&self, start: usize) -> (usize, ContigPosition) {
+        self.starts.unflatten(start)
+    }
+
+    pub fn decode(&self, start: usize, end: usize) -> Vec<u8> {
+        self.sequence.decode(start, end)
+    }
+
+    pub fn contig<'a>(&'a self, index: usize) -> PackedSeqSlice<'a> {
+        let start = self.starts.0[index];
+        let len = self.starts.0[index + 1] - start;
+
+        PackedSeqSlice::new(&self.sequence, start, len)
+    }
+
+    pub fn contig_start(&self, index: usize) -> usize {
+        self.starts.0[index]
+    }
+
+    pub fn max_contig_len(&self) -> Option<usize> {
+        (0..self.names.len()).map(|i| self.contig(i).len()).max()
+    }
+
+    pub fn total_length(&self) -> usize {
+        self.starts.total_length()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn testref() -> RefSequence {
+        let mut sequence = PackedSeq::new();
+        sequence.extend(b"AAAACCCGGT".to_vec());
+        let names = vec![
+            "n1".to_string(),
+            "n2".to_string(),
+            "n3".to_string(),
+            "n4".to_string(),
+        ];
+        let starts = vec![0, 4, 7, 9];
+        RefSequence::new(sequence, starts, names)
+    }
+
+    #[test]
+    fn new() {
+        let rs = testref();
+
+        assert_eq!(rs.total_length(), 10);
+        assert_eq!(rs.max_contig_len(), Some(4));
+
+        assert_eq!(rs.contig(0).len(), 4);
+        assert_eq!(rs.contig(1).len(), 3);
+        assert_eq!(rs.contig(2).len(), 2);
+        assert_eq!(rs.contig(3).len(), 1);
+        assert_eq!(rs.contig(0).len(), 4);
+    }
+
+    #[test]
+    fn decode() {
+        let rs = testref();
+
+        assert_eq!(rs.decode(0, 0), b"");
+        assert_eq!(rs.decode(0, 1), b"A");
+        assert_eq!(rs.decode(0, 2), b"AA");
+        assert_eq!(rs.decode(0, 3), b"AAA");
+        assert_eq!(rs.decode(4, 5), b"C");
+        assert_eq!(rs.decode(4, 6), b"CC");
+        assert_eq!(rs.decode(4, 7), b"CCC");
+        assert_eq!(rs.decode(9, 10), b"T");
+    }
+
+    #[test]
+    fn unflatten() {
+        let rs = testref();
+
+        assert_eq!(rs.unflatten(0), (0, ContigPosition(0)));
+        assert_eq!(rs.unflatten(1), (0, ContigPosition(1)));
+        assert_eq!(rs.unflatten(2), (0, ContigPosition(2)));
+        assert_eq!(rs.unflatten(3), (0, ContigPosition(3)));
+        assert_eq!(rs.unflatten(4), (1, ContigPosition(0)));
+        assert_eq!(rs.unflatten(5), (1, ContigPosition(1)));
+        assert_eq!(rs.unflatten(6), (1, ContigPosition(2)));
+        assert_eq!(rs.unflatten(7), (2, ContigPosition(0)));
+        assert_eq!(rs.unflatten(8), (2, ContigPosition(1)));
+        assert_eq!(rs.unflatten(9), (3, ContigPosition(0)));
     }
 }

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -179,10 +179,10 @@ impl<SI: Iterator<Item = Syncmer>> Iterator for RandstrobeIterator<SI> {
 #[cfg(test)]
 mod test {
     use super::*;
+
     use crate::io::fasta::read_ref;
     use crate::packed_seq::PackedSeq;
-    use crate::seeding::SeedingParameters;
-    use crate::seeding::SyncmerIterator;
+    use crate::seeding::{SeedingParameters, SyncmerIterator};
 
     fn read_phix() -> PackedSeq {
         read_ref("tests/phix.fasta").unwrap().contig(0).to_owned()

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 
 use super::InvalidSeedingParameter;
 use super::hash::xxh64;
-use crate::packed_seq::PackedSeq;
+use crate::packed_seq::{PackedSeq, PackedSeqSlice};
 
 /// Trait for types that can serve as a sequence source for `SyncmerIterator`.
 ///
@@ -27,10 +27,20 @@ impl SeqAccess for &[u8] {
     }
 }
 
-impl SeqAccess for &PackedSeq {
+impl<'a> SeqAccess for &'a PackedSeqSlice<'a> {
     /// Direct 2-bit extract - no table lookups, never returns 4.
     /// `**self` reaches `PackedSeq` so Rust resolves the inherent method,
     /// not this trait method (no recursion).
+    fn nucleotide_bits(&self, i: usize) -> u8 {
+        (**self).nucleotide_bits(i)
+    }
+
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+}
+
+impl SeqAccess for &PackedSeq {
     fn nucleotide_bits(&self, i: usize) -> u8 {
         (**self).nucleotide_bits(i)
     }


### PR DESCRIPTION
Instead of addressing a position on the genome with a (reference_id, reference_start) tuple, this uses a single 64-bit `ref_start` integer.

Advantages:
- Slightly simpler code in some places
- It appears to be slightly faster
- No more separate limit on the number of contigs and the length of each contig. Instead, the limit is on the total genome length (currently 64 bit).
- This should allow us to later reduce the number of bits needed for the reference coordinate.

Recovering the chromosome a position is on requires a binary search, but
this does not need to be done that often.

~~However, there are a couple of places in the code (currently marked with a `TODO` comment) where we iterate over anchors or chains from left to right and where we would previously do something when transitioning from one contig to another. Now, we can theoretically 1) chain from one contig to another and 2) pair one read with one on another contig. We’ll have to think a bit more about how much we need to prevent this.~~

The randstrobes generated in N regions change slightly because the pseudorandom nucleotide that the N wildcards are replaced with depends on the position, which is now relative to the start of the genome and not the start of the contig.

Closes #227
See #597