### PR TITLE
Run clippy in tests/run.sh

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -28,6 +28,9 @@ trap 'echo -e "\e[1;31mFailure\e[0m"' ERR
 # No --check on purpose, just do it
 cargo fmt
 
+cargo clippy -- -D warnings
+cargo clippy --tests -- -D warnings
+
 # Unit tests
 cargo test
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -25,7 +25,8 @@ function diff() {
 
 trap 'echo -e "\e[1;31mFailure\e[0m"' ERR
 
-cargo build
+# No --check on purpose, just do it
+cargo fmt
 
 # Unit tests
 cargo test


### PR DESCRIPTION
When doing local development, running `tests/run.sh` should run most of the various tests that are also run in CI. So we need to run clippy here as well.

Also, reformat the code with `cargo fmt` when runnig this.