### PR TITLE
Make RefSequence a container for all contigs

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -542,8 +542,9 @@ mod tests {
     use super::*;
 
     use crate::indexer::make_index;
-    use crate::io::fasta::{RefSequence, read_ref};
+    use crate::io::fasta::read_ref;
     use crate::packed_seq::PackedSeq;
+    use crate::refseq::RefSequence;
     use crate::revcomp::reverse_complement;
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -587,20 +587,18 @@ mod tests {
 
     #[test]
     fn partial_orientation() {
-        let references = read_ref("tests/phix.fasta").unwrap();
-        let seq_decoded = references[0].sequence.decode_all();
+        let refseq = read_ref("tests/phix.fasta").unwrap();
+        let seq_decoded = refseq.sequences[0].decode_all();
         let rc_seq = reverse_complement(&seq_decoded);
-        let rc_references = vec![RefSequence {
-            name: "phix_rc".to_string(),
-            sequence: PackedSeq::from_slice(&rc_seq),
-        }];
+        let mut rc_refseq = RefSequence::new();
+        rc_refseq.push("phix_rc".to_string(), PackedSeq::from_slice(&rc_seq));
 
         let parameters = SeedingParameters::new(300);
-        let bits = parameters.syncmer.pick_bits(&references);
+        let bits = parameters.syncmer.pick_bits(&refseq);
 
-        let (fwd_index, _stats) = make_index(&references, parameters.clone(), bits, 0.0000001, 1);
+        let (fwd_index, _stats) = make_index(&refseq, parameters.clone(), bits, 0.0000001, 1);
 
-        let (rc_index, _stats) = make_index(&rc_references, parameters.clone(), bits, 0.0000001, 1);
+        let (rc_index, _stats) = make_index(&rc_refseq, parameters.clone(), bits, 0.0000001, 1);
 
         assert_eq!(fwd_index.randstrobes.len(), rc_index.randstrobes.len());
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -589,7 +589,7 @@ mod tests {
     #[test]
     fn partial_orientation() {
         let refseq = read_ref("tests/phix.fasta").unwrap();
-        let seq_decoded = refseq.sequences[0].decode_all();
+        let seq_decoded = refseq.contig(0).decode_all();
         let rc_seq = reverse_complement(&seq_decoded);
         let mut rc_refseq = RefSequence::new();
         rc_refseq.push("phix_rc".to_string(), PackedSeq::from_slice(&rc_seq));

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -16,14 +16,14 @@ use rayon::slice::ParallelSliceMut;
 
 /// Create a StrobemerIndex
 pub fn make_index(
-    references: &[RefSequence],
+    refseq: &RefSequence,
     parameters: SeedingParameters,
     bits: u8,
     filter_fraction: f64,
     n_threads: usize,
 ) -> (StrobemerIndex, IndexCreationStatistics) {
     let timer = Instant::now();
-    let randstrobe_counts = count_all_randstrobes(references, &parameters, n_threads);
+    let randstrobe_counts = count_all_randstrobes(refseq, &parameters, n_threads);
     debug!("  Counting hashes: {:.2} s", timer.elapsed().as_secs_f64());
     // stats.elapsed_counting_hashes = count_hash.duration();
     let mut stats = IndexCreationStatistics::default();
@@ -32,7 +32,7 @@ pub fn make_index(
     stats.tot_strobemer_count = total_randstrobes as u64;
 
     debug!("  Total number of randstrobes: {}", total_randstrobes);
-    let total_length: usize = references.iter().map(|refseq| refseq.sequence.len()).sum();
+    let total_length: usize = refseq.sequences.iter().map(|seq| seq.len()).sum();
     let memory_bytes: usize = total_length
         + size_of::<RefRandstrobe>() * total_randstrobes
         + size_of::<BucketIndex>() * (1usize << bits);
@@ -47,7 +47,7 @@ pub fn make_index(
     let timer = Instant::now();
     debug!("  Generating randstrobes ...");
     let mut randstrobes =
-        make_randstrobes_parallel(references, &parameters, &randstrobe_counts, n_threads);
+        make_randstrobes_parallel(refseq, &parameters, &randstrobe_counts, n_threads);
     debug!("  Generating seeds: {:.2} s", timer.elapsed().as_secs_f64());
     // stats.elapsed_generating_seeds = randstrobes_timer.duration();
 
@@ -169,22 +169,8 @@ pub fn make_index(
     )
 }
 
-/*
-    fn make_randstrobes(&self, randstrobe_counts: &[usize]) -> Vec<RefRandstrobe> {
-        let mut randstrobes = vec![RefRandstrobe::default(); randstrobe_counts.iter().sum()];
-
-        // Fill randstrobes vector
-        let mut offset = 0;
-        for ref_index in 0..self.references.len() {
-            self.assign_randstrobes(ref_index, &mut randstrobes[offset..offset+randstrobe_counts[ref_index]]);
-            offset += randstrobe_counts[ref_index];
-        }
-        randstrobes
-    }
-*/
-
 fn make_randstrobes_parallel(
-    references: &[RefSequence],
+    refseq: &RefSequence,
     parameters: &SeedingParameters,
     randstrobe_counts: &[usize],
     n_threads: usize,
@@ -193,7 +179,7 @@ fn make_randstrobes_parallel(
     let mut slices = vec![];
     {
         let mut slice = &mut randstrobes[..];
-        for &mid in randstrobe_counts.iter().take(references.len() - 1) {
+        for &mid in randstrobe_counts.iter().take(refseq.sequences.len() - 1) {
             let (left, right) = slice.split_at_mut(mid);
             slices.push(Arc::new(Mutex::new(left)));
             slice = right;
@@ -206,10 +192,10 @@ fn make_randstrobes_parallel(
             s.spawn(|| {
                 loop {
                     let j = ref_index.fetch_add(1, Ordering::SeqCst);
-                    if j >= references.len() {
+                    if j >= refseq.sequences.len() {
                         break;
                     }
-                    assign_randstrobes(references, parameters, j, *slices[j].lock().unwrap());
+                    assign_randstrobes(refseq, parameters, j, *slices[j].lock().unwrap());
                 }
             });
         }
@@ -220,12 +206,12 @@ fn make_randstrobes_parallel(
 
 /// Compute randstrobes of one reference contig and assign them to the provided slice
 fn assign_randstrobes(
-    references: &[RefSequence],
+    refseq: &RefSequence,
     parameters: &SeedingParameters,
     ref_index: usize,
     randstrobes: &mut [RefRandstrobe],
 ) {
-    let seq: &PackedSeq = &references[ref_index].sequence;
+    let seq: &PackedSeq = &refseq.sequences[ref_index];
     if seq.len() < parameters.randstrobe.w_max {
         return;
     }
@@ -253,11 +239,11 @@ fn assign_randstrobes(
 }
 
 fn count_all_randstrobes(
-    references: &[RefSequence],
+    refseq: &RefSequence,
     parameters: &SeedingParameters,
     n_threads: usize,
 ) -> Vec<usize> {
-    let counts = vec![0; references.len()];
+    let counts = vec![0; refseq.sequences.len()];
     let mutex = Mutex::new(counts);
     let ref_index = AtomicUsize::new(0);
     thread::scope(|s| {
@@ -265,10 +251,10 @@ fn count_all_randstrobes(
             s.spawn(|| {
                 loop {
                     let j = ref_index.fetch_add(1, Ordering::SeqCst);
-                    if j >= references.len() {
+                    if j >= refseq.sequences.len() {
                         break;
                     }
-                    let count = count_randstrobes(&references[j].sequence, parameters);
+                    let count = count_randstrobes(&refseq.sequences[j], parameters);
                     mutex.lock().unwrap()[j] = count;
                 }
             });
@@ -291,8 +277,8 @@ fn count_randstrobes(seq: &PackedSeq, parameters: &SeedingParameters) -> usize {
 
 impl SyncmerParameters {
     /// Pick a suitable number of bits for indexing randstrobe start indices
-    pub fn pick_bits(&self, references: &[RefSequence]) -> u8 {
-        let total_length: usize = references.iter().map(|r| r.sequence.len()).sum();
+    pub fn pick_bits(&self, refseq: &RefSequence) -> u8 {
+        let total_length: usize = refseq.sequences.iter().map(|seq| seq.len()).sum();
         let estimated_number_of_randstrobes = total_length / (self.k - self.s + 1) + 1;
         // Two randstrobes per bucket on average
         // TOOD checked_ilog2 or ilog2
@@ -367,28 +353,26 @@ mod test {
     #[test]
     fn pick_bits() {
         let parameters = SyncmerParameters::try_new(20, 16).unwrap();
-        let references = read_ref("tests/phix.fasta").unwrap();
-        assert_eq!(parameters.pick_bits(&references), 9);
+        let refseq = read_ref("tests/phix.fasta").unwrap();
+        assert_eq!(parameters.pick_bits(&refseq), 9);
     }
 
     #[test]
     fn index_phix() {
-        let references = read_ref("tests/phix.fasta").unwrap();
+        let refseq = read_ref("tests/phix.fasta").unwrap();
         let parameters = SeedingParameters::new(150);
-        let bits = parameters.syncmer.pick_bits(&references);
-        let (_index, stats) = make_index(&references, parameters, bits, 0.1, 1);
+        let bits = parameters.syncmer.pick_bits(&refseq);
+        let (_index, stats) = make_index(&refseq, parameters, bits, 0.1, 1);
         assert!(stats.distinct_strobemers > 0);
     }
 
     #[test]
     fn index_empty_reference() {
-        let references = vec![RefSequence {
-            name: "name".to_string(),
-            sequence: PackedSeq::new(),
-        }];
+        let mut refseq = RefSequence::new();
+        refseq.push("name".to_string(), PackedSeq::new());
         let parameters = SeedingParameters::new(150);
-        let bits = parameters.syncmer.pick_bits(&references);
-        let (_index2, stats) = make_index(&references, parameters, bits, 0.1, 1);
+        let bits = parameters.syncmer.pick_bits(&refseq);
+        let (_index2, stats) = make_index(&refseq, parameters, bits, 0.1, 1);
         assert_eq!(stats.distinct_strobemers, 0);
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,6 +1,6 @@
 use crate::index::{BucketIndex, RandstrobeHash, RefRandstrobe, StrobemerIndex};
-use crate::io::fasta::RefSequence;
 use crate::packed_seq::PackedSeq;
+use crate::refseq::RefSequence;
 use crate::seeding::{RandstrobeIterator, SeedingParameters, SyncmerIterator, SyncmerParameters};
 
 use std::cmp::Reverse;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -32,7 +32,7 @@ pub fn make_index(
     stats.tot_strobemer_count = total_randstrobes as u64;
 
     debug!("  Total number of randstrobes: {}", total_randstrobes);
-    let total_length: usize = refseq.sequences.iter().map(|seq| seq.len()).sum();
+    let total_length: usize = refseq.total_length();
     let memory_bytes: usize = total_length
         + size_of::<RefRandstrobe>() * total_randstrobes
         + size_of::<BucketIndex>() * (1usize << bits);
@@ -179,7 +179,7 @@ fn make_randstrobes_parallel(
     let mut slices = vec![];
     {
         let mut slice = &mut randstrobes[..];
-        for &mid in randstrobe_counts.iter().take(refseq.sequences.len() - 1) {
+        for &mid in randstrobe_counts.iter().take(refseq.names.len() - 1) {
             let (left, right) = slice.split_at_mut(mid);
             slices.push(Arc::new(Mutex::new(left)));
             slice = right;
@@ -192,7 +192,7 @@ fn make_randstrobes_parallel(
             s.spawn(|| {
                 loop {
                     let j = ref_index.fetch_add(1, Ordering::SeqCst);
-                    if j >= refseq.sequences.len() {
+                    if j >= refseq.names.len() {
                         break;
                     }
                     assign_randstrobes(refseq, parameters, j, *slices[j].lock().unwrap());
@@ -211,7 +211,7 @@ fn assign_randstrobes(
     ref_index: usize,
     randstrobes: &mut [RefRandstrobe],
 ) {
-    let seq: &PackedSeq = &refseq.sequences[ref_index];
+    let seq = refseq.contig(ref_index);
     if seq.len() < parameters.randstrobe.w_max {
         return;
     }
@@ -243,7 +243,7 @@ fn count_all_randstrobes(
     parameters: &SeedingParameters,
     n_threads: usize,
 ) -> Vec<usize> {
-    let counts = vec![0; refseq.sequences.len()];
+    let counts = vec![0; refseq.names.len()];
     let mutex = Mutex::new(counts);
     let ref_index = AtomicUsize::new(0);
     thread::scope(|s| {
@@ -251,10 +251,10 @@ fn count_all_randstrobes(
             s.spawn(|| {
                 loop {
                     let j = ref_index.fetch_add(1, Ordering::SeqCst);
-                    if j >= refseq.sequences.len() {
+                    if j >= refseq.names.len() {
                         break;
                     }
-                    let count = count_randstrobes(&refseq.sequences[j], parameters);
+                    let count = count_randstrobes(refseq.contig(j), parameters);
                     mutex.lock().unwrap()[j] = count;
                 }
             });
@@ -278,7 +278,7 @@ fn count_randstrobes(seq: &PackedSeq, parameters: &SeedingParameters) -> usize {
 impl SyncmerParameters {
     /// Pick a suitable number of bits for indexing randstrobe start indices
     pub fn pick_bits(&self, refseq: &RefSequence) -> u8 {
-        let total_length: usize = refseq.sequences.iter().map(|seq| seq.len()).sum();
+        let total_length: usize = refseq.total_length();
         let estimated_number_of_randstrobes = total_length / (self.k - self.s + 1) + 1;
         // Two randstrobes per bucket on average
         // TOOD checked_ilog2 or ilog2

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -375,4 +375,12 @@ mod test {
         let (_index2, stats) = make_index(&refseq, parameters, bits, 0.1, 1);
         assert_eq!(stats.distinct_strobemers, 0);
     }
+
+    #[test]
+    fn count_randstrobes_phix() {
+        let refseq = read_ref("tests/phix.fasta").unwrap();
+        let parameters = SeedingParameters::new(150);
+
+        assert_eq!(count_randstrobes(refseq.contig(0), &parameters), 1090);
+    }
 }

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -5,26 +5,7 @@ use std::path::Path;
 use crate::io::record::{End, SequenceRecord};
 use crate::io::{SequenceIOError, split_header};
 use crate::packed_seq::PackedSeq;
-
-#[derive(Default, Debug, Clone)]
-pub struct RefSequence {
-    pub names: Vec<String>,
-    pub sequences: Vec<PackedSeq>,
-}
-
-impl RefSequence {
-    pub fn new() -> Self {
-        RefSequence {
-            names: vec![],
-            sequences: vec![],
-        }
-    }
-
-    pub fn push(&mut self, name: String, seq: PackedSeq) {
-        self.names.push(name);
-        self.sequences.push(seq);
-    }
-}
+use crate::refseq::RefSequence;
 
 /// Check whether a name is fine to use in SAM output.
 /// The SAM specification is quite strict and forbids these

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -171,8 +171,8 @@ mod tests {
         let refseq = read_ref("tests/phix.fasta").unwrap();
         assert_eq!(refseq.names.len(), 1);
         assert_eq!(refseq.names[0], "NC_001422.1");
-        assert_eq!(refseq.sequences[0].len(), 5386);
-        assert_eq!(refseq.sequences[0].decode(0, 5), b"GAGTT");
+        assert_eq!(refseq.contig_len(0), 5386);
+        assert_eq!(refseq.contig(0).decode(0, 5), b"GAGTT");
     }
 
     #[test]
@@ -240,13 +240,13 @@ mod tests {
         let refseq = read_ref(tmp.path()).unwrap();
         assert_eq!(refseq.names.len(), 4);
         assert_eq!(refseq.names[0], "ref1");
-        assert_eq!(refseq.sequences[0].decode_all(), b"ACGT");
+        assert_eq!(refseq.contig(0).decode_all(), b"ACGT");
         assert_eq!(refseq.names[1], "ref2");
-        assert_eq!(refseq.sequences[1].decode_all(), b"AACCGGTT");
+        assert_eq!(refseq.contig(1).decode_all(), b"AACCGGTT");
         assert_eq!(refseq.names[2], "empty");
-        assert_eq!(refseq.sequences[2].decode_all(), b"");
+        assert_eq!(refseq.contig(2).decode_all(), b"");
         assert_eq!(refseq.names[3], "empty_at_end_of_file");
-        assert_eq!(refseq.sequences[3].decode_all(), b"");
+        assert_eq!(refseq.contig(3).decode_all(), b"");
     }
 
     #[test]

--- a/src/io/fasta.rs
+++ b/src/io/fasta.rs
@@ -6,10 +6,24 @@ use crate::io::record::{End, SequenceRecord};
 use crate::io::{SequenceIOError, split_header};
 use crate::packed_seq::PackedSeq;
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct RefSequence {
-    pub name: String,
-    pub sequence: PackedSeq,
+    pub names: Vec<String>,
+    pub sequences: Vec<PackedSeq>,
+}
+
+impl RefSequence {
+    pub fn new() -> Self {
+        RefSequence {
+            names: vec![],
+            sequences: vec![],
+        }
+    }
+
+    pub fn push(&mut self, name: String, seq: PackedSeq) {
+        self.names.push(name);
+        self.sequences.push(seq);
+    }
 }
 
 /// Check whether a name is fine to use in SAM output.
@@ -31,8 +45,8 @@ fn is_valid_name(name: &[u8]) -> bool {
     true
 }
 
-fn check_duplicate_names(records: &[RefSequence]) -> Result<(), SequenceIOError> {
-    let mut names: Vec<_> = records.iter().map(|r| &r.name).collect();
+fn check_duplicate_names(refseq: &RefSequence) -> Result<(), SequenceIOError> {
+    let mut names = refseq.names.clone();
     names.sort();
     for window in names.windows(2) {
         if window[0] == window[1] {
@@ -113,8 +127,8 @@ impl<B: BufRead> Iterator for FastaReader<B> {
     }
 }
 
-pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<Vec<RefSequence>, SequenceIOError> {
-    let mut records: Vec<RefSequence> = Vec::new();
+pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<RefSequence, SequenceIOError> {
+    let mut refseq = RefSequence::new();
     let mut current_name: Option<String> = None;
     let mut current_seq = PackedSeq::new();
     let mut line = String::new();
@@ -126,10 +140,7 @@ pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<Vec<RefSequence>, Sequen
             Ok(_) => {
                 if let Some(header) = line.strip_prefix('>') {
                     if let Some(name) = current_name.take() {
-                        records.push(RefSequence {
-                            name,
-                            sequence: current_seq,
-                        });
+                        refseq.push(name, current_seq);
                         current_seq = PackedSeq::new();
                     }
                     let (name, _comment) = split_header(header);
@@ -148,23 +159,20 @@ pub fn read_fasta<R: BufRead>(reader: &mut R) -> Result<Vec<RefSequence>, Sequen
         }
     }
     if let Some(name) = current_name {
-        records.push(RefSequence {
-            name,
-            sequence: current_seq,
-        });
+        refseq.push(name, current_seq);
     }
 
-    for record in &records {
-        if !is_valid_name(record.name.as_bytes()) {
+    for name in &refseq.names {
+        if !is_valid_name(name.as_bytes()) {
             return Err(SequenceIOError::Name);
         }
     }
-    check_duplicate_names(&records)?;
+    check_duplicate_names(&refseq)?;
 
-    Ok(records)
+    Ok(refseq)
 }
 
-pub fn read_ref<P: AsRef<Path>>(path: P) -> Result<Vec<RefSequence>, SequenceIOError> {
+pub fn read_ref<P: AsRef<Path>>(path: P) -> Result<RefSequence, SequenceIOError> {
     let f = File::open(path).unwrap();
     let mut reader = BufReader::new(f);
 
@@ -179,11 +187,11 @@ mod tests {
 
     #[test]
     fn read_ref_works() {
-        let records = read_ref("tests/phix.fasta").unwrap();
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0].name, "NC_001422.1");
-        assert_eq!(records[0].sequence.len(), 5386);
-        assert_eq!(records[0].sequence.decode(0, 5), b"GAGTT");
+        let refseq = read_ref("tests/phix.fasta").unwrap();
+        assert_eq!(refseq.names.len(), 1);
+        assert_eq!(refseq.names[0], "NC_001422.1");
+        assert_eq!(refseq.sequences[0].len(), 5386);
+        assert_eq!(refseq.sequences[0].decode(0, 5), b"GAGTT");
     }
 
     #[test]
@@ -248,34 +256,34 @@ mod tests {
         let tmp = temp_file::with_contents(
             b">ref1 a comment\nacgt\n\n>ref2\naacc\ngg\n\ntt\n>empty\n>empty_at_end_of_file",
         );
-        let records = read_ref(tmp.path()).unwrap();
-        assert_eq!(records.len(), 4);
-        assert_eq!(records[0].name, "ref1");
-        assert_eq!(records[0].sequence.decode_all(), b"ACGT");
-        assert_eq!(records[1].name, "ref2");
-        assert_eq!(records[1].sequence.decode_all(), b"AACCGGTT");
-        assert_eq!(records[2].name, "empty");
-        assert_eq!(records[2].sequence.decode_all(), b"");
-        assert_eq!(records[3].name, "empty_at_end_of_file");
-        assert_eq!(records[3].sequence.decode_all(), b"");
+        let refseq = read_ref(tmp.path()).unwrap();
+        assert_eq!(refseq.names.len(), 4);
+        assert_eq!(refseq.names[0], "ref1");
+        assert_eq!(refseq.sequences[0].decode_all(), b"ACGT");
+        assert_eq!(refseq.names[1], "ref2");
+        assert_eq!(refseq.sequences[1].decode_all(), b"AACCGGTT");
+        assert_eq!(refseq.names[2], "empty");
+        assert_eq!(refseq.sequences[2].decode_all(), b"");
+        assert_eq!(refseq.names[3], "empty_at_end_of_file");
+        assert_eq!(refseq.sequences[3].decode_all(), b"");
     }
 
     #[test]
     fn some_special_characters() {
         let mut reader = BufReader::new(b"><>;abc\nAAAA\n>abc\nCCCC\n".as_slice());
-        let records = read_fasta(&mut reader).unwrap();
-        assert_eq!(records.len(), 2);
-        assert_eq!(records[0].name, "<>;abc");
-        assert_eq!(records[1].name, "abc");
+        let refseq = read_fasta(&mut reader).unwrap();
+        assert_eq!(refseq.names.len(), 2);
+        assert_eq!(refseq.names[0], "<>;abc");
+        assert_eq!(refseq.names[1], "abc");
     }
 
     #[test]
     fn whitespace_in_header() {
         let mut reader = BufReader::new(b">ab c\nACGT\n>de\tf\nACGT\n".as_slice());
-        let records = read_fasta(&mut reader).unwrap();
-        assert_eq!(records.len(), 2);
-        assert_eq!(records[0].name, "ab");
-        assert_eq!(records[1].name, "de");
+        let refseq = read_fasta(&mut reader).unwrap();
+        assert_eq!(refseq.names.len(), 2);
+        assert_eq!(refseq.names[0], "ab");
+        assert_eq!(refseq.names[1], "de");
     }
 
     #[test]

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use crate::cigar::Cigar;
 use crate::details::Details;
-use crate::io::fasta::RefSequence;
+use crate::refseq::RefSequence;
 
 pub const PAIRED: u16 = 1;
 pub const PROPER_PAIR: u16 = 2;

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -178,12 +178,12 @@ impl Display for SamHeader<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "@HD\tVN:1.6\tSO:unsorted")?;
 
-        for i in 0..self.refseq.sequences.len() {
+        for i in 0..self.refseq.names.len() {
             writeln!(
                 f,
                 "@SQ\tSN:{}\tLN:{}",
                 self.refseq.names[i],
-                self.refseq.sequences[i].len()
+                self.refseq.contig_len(i)
             )?;
         }
         if let Some(read_group) = &self.read_group {

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -152,7 +152,7 @@ impl ReadGroup {
 }
 
 pub struct SamHeader<'a> {
-    references: &'a [RefSequence],
+    refseq: &'a RefSequence,
     cmd_line: Option<&'a str>,
     version: &'a str,
     read_group: Option<ReadGroup>,
@@ -160,13 +160,13 @@ pub struct SamHeader<'a> {
 
 impl<'a> SamHeader<'a> {
     pub fn new(
-        references: &'a [RefSequence],
+        refseq: &'a RefSequence,
         cmd_line: Option<&'a str>,
         version: &'a str,
         read_group: Option<ReadGroup>,
     ) -> Self {
         SamHeader {
-            references,
+            refseq,
             cmd_line,
             version,
             read_group,
@@ -178,8 +178,13 @@ impl Display for SamHeader<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "@HD\tVN:1.6\tSO:unsorted")?;
 
-        for refseq in self.references {
-            writeln!(f, "@SQ\tSN:{}\tLN:{}", refseq.name, refseq.sequence.len())?;
+        for i in 0..self.refseq.sequences.len() {
+            writeln!(
+                f,
+                "@SQ\tSN:{}\tLN:{}",
+                self.refseq.names[i],
+                self.refseq.sequences[i].len()
+            )?;
         }
         if let Some(read_group) = &self.read_group {
             write!(f, "@RG\tID:{}", read_group.id)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod packed_seq;
 pub mod partition;
 pub mod piecewisealigner;
 pub mod read;
+pub mod refseq;
 pub mod revcomp;
 pub mod seeding;
 pub mod shuffle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,25 +423,26 @@ fn run() -> Result<(), CliError> {
         e,
         path: args.ref_path.clone(),
     })?;
-    let references = fasta::read_fasta(&mut BufReader::new(ref_file))?;
+    let refseq = fasta::read_fasta(&mut BufReader::new(ref_file))?;
     info!(
         "Time reading reference: {:.2} s",
         timer.elapsed().as_secs_f64()
     );
-    let total_ref_size = references.iter().map(|r| r.sequence.len()).sum::<usize>();
-    let max_contig_size = references
+    let total_ref_size = refseq.sequences.iter().map(|seq| seq.len()).sum::<usize>();
+    let max_contig_size = refseq
+        .sequences
         .iter()
-        .map(|r| r.sequence.len())
+        .map(|seq| seq.len())
         .max()
         .ok_or(CliError::NoReference)?;
     info!(
         "Reference size: {:.2} Mbp ({} contig{}; largest: {:.2} Mbp)",
         total_ref_size as f64 / 1E6,
-        references.len(),
-        if references.len() != 1 { "s" } else { "" },
+        refseq.sequences.len(),
+        if refseq.sequences.len() != 1 { "s" } else { "" },
         max_contig_size as f64 / 1E6
     );
-    if references.len() > REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES {
+    if refseq.sequences.len() > REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES {
         error!(
             "Too many reference sequences. Current maximum is {}.",
             REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES
@@ -454,7 +455,7 @@ fn run() -> Result<(), CliError> {
     info!("Multi-context seed strategy: {}", args.mcs_strategy);
     let bits = args
         .bits
-        .unwrap_or_else(|| parameters.syncmer.pick_bits(&references));
+        .unwrap_or_else(|| parameters.syncmer.pick_bits(&refseq));
     info!("Bits used to index buckets: {}", bits);
 
     let index = if args.use_index {
@@ -480,7 +481,7 @@ fn run() -> Result<(), CliError> {
             if indexing_threads == 1 { "" } else { "s" }
         );
         let (index, index_stats) = make_index(
-            &references,
+            &refseq,
             parameters.clone(),
             bits,
             args.filter_fraction,
@@ -553,7 +554,7 @@ fn run() -> Result<(), CliError> {
     let read_group = rg_id.map(|s| ReadGroup::new(&s, args.rg));
 
     let header = SamHeader::new(
-        &references,
+        &refseq,
         if args.no_pg { None } else { Some(&cmd_line) },
         VERSION,
         read_group,
@@ -605,7 +606,7 @@ fn run() -> Result<(), CliError> {
 
     let mapper = Mapper {
         index: &index,
-        references: &references,
+        refseq: &refseq,
         mapping_parameters: &mapping_parameters,
         seeding_parameters: &parameters,
         chainer: &chainer,
@@ -613,7 +614,7 @@ fn run() -> Result<(), CliError> {
         aligner,
         include_unmapped: !args.only_mapped,
         mode,
-        abundances: vec![0f64; references.len()],
+        abundances: vec![0f64; refseq.sequences.len()],
     };
 
     let mode_message = match mode {
@@ -738,14 +739,14 @@ fn run() -> Result<(), CliError> {
     let mut out = Arc::into_inner(out).unwrap().into_inner().unwrap();
 
     if mode == Mode::Abundances {
-        let mut abundances = vec![0f64; references.len()];
+        let mut abundances = vec![0f64; refseq.sequences.len()];
         for _ in 0..n_threads {
             let worker_abundances = abundances_rx.recv().unwrap();
             for i in 0..abundances.len() {
                 abundances[i] += worker_abundances[i];
             }
         }
-        output_abundances(&abundances, &references, &mut out)?;
+        output_abundances(&abundances, &refseq, &mut out)?;
     }
 
     debug!("");
@@ -858,7 +859,7 @@ enum Mode {
 #[derive(Clone)]
 struct Mapper<'a> {
     index: &'a StrobemerIndex,
-    references: &'a [RefSequence],
+    refseq: &'a RefSequence,
     mapping_parameters: &'a MappingParameters,
     seeding_parameters: &'a SeedingParameters,
     sam_output: &'a SamOutput,
@@ -888,7 +889,7 @@ impl Mapper<'_> {
                             &r1,
                             &r2,
                             self.index,
-                            self.references,
+                            self.refseq,
                             self.mapping_parameters,
                             self.sam_output,
                             self.seeding_parameters,
@@ -909,7 +910,7 @@ impl Mapper<'_> {
                         let (mut records, details) = align_single_end_read(
                             &r1,
                             self.index,
-                            self.references,
+                            self.refseq,
                             self.mapping_parameters,
                             self.sam_output,
                             self.chainer,
@@ -934,7 +935,7 @@ impl Mapper<'_> {
                             &r1,
                             &r2,
                             self.index,
-                            self.references,
+                            self.refseq,
                             self.mapping_parameters.rescue_distance,
                             &mut isizedist,
                             self.mapping_parameters.mcs_strategy,
@@ -945,7 +946,7 @@ impl Mapper<'_> {
                         map_single_end_read(
                             &r1,
                             self.index,
-                            self.references,
+                            self.refseq,
                             self.mapping_parameters.rescue_distance,
                             self.mapping_parameters.mcs_strategy,
                             self.chainer,
@@ -990,12 +991,13 @@ impl Mapper<'_> {
 
 pub fn output_abundances<T: Write>(
     abundances: &[f64],
-    references: &[RefSequence],
+    refseq: &RefSequence,
     out: &mut T,
 ) -> io::Result<()> {
-    for i in 0..references.len() {
-        let normalized = abundances[i] / references[i].sequence.len() as f64;
-        writeln!(out, "{}\t{:.6}", references[i].name, normalized)?;
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..refseq.sequences.len() {
+        let normalized = abundances[i] / refseq.sequences[i].len() as f64;
+        writeln!(out, "{}\t{:.6}", refseq.names[i], normalized)?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,21 +428,16 @@ fn run() -> Result<(), CliError> {
         "Time reading reference: {:.2} s",
         timer.elapsed().as_secs_f64()
     );
-    let total_ref_size = refseq.sequences.iter().map(|seq| seq.len()).sum::<usize>();
-    let max_contig_size = refseq
-        .sequences
-        .iter()
-        .map(|seq| seq.len())
-        .max()
-        .ok_or(CliError::NoReference)?;
+    let total_ref_size = refseq.total_length();
+    let max_contig_size = refseq.max_contig_len().ok_or(CliError::NoReference)?;
     info!(
         "Reference size: {:.2} Mbp ({} contig{}; largest: {:.2} Mbp)",
         total_ref_size as f64 / 1E6,
-        refseq.sequences.len(),
-        if refseq.sequences.len() != 1 { "s" } else { "" },
+        refseq.names.len(),
+        if refseq.names.len() != 1 { "s" } else { "" },
         max_contig_size as f64 / 1E6
     );
-    if refseq.sequences.len() > REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES {
+    if refseq.names.len() > REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES {
         error!(
             "Too many reference sequences. Current maximum is {}.",
             REF_RANDSTROBE_MAX_NUMBER_OF_REFERENCES
@@ -614,7 +609,7 @@ fn run() -> Result<(), CliError> {
         aligner,
         include_unmapped: !args.only_mapped,
         mode,
-        abundances: vec![0f64; refseq.sequences.len()],
+        abundances: vec![0f64; refseq.names.len()],
     };
 
     let mode_message = match mode {
@@ -739,7 +734,7 @@ fn run() -> Result<(), CliError> {
     let mut out = Arc::into_inner(out).unwrap().into_inner().unwrap();
 
     if mode == Mode::Abundances {
-        let mut abundances = vec![0f64; refseq.sequences.len()];
+        let mut abundances = vec![0f64; refseq.names.len()];
         for _ in 0..n_threads {
             let worker_abundances = abundances_rx.recv().unwrap();
             for i in 0..abundances.len() {
@@ -995,8 +990,8 @@ pub fn output_abundances<T: Write>(
     out: &mut T,
 ) -> io::Result<()> {
     #[allow(clippy::needless_range_loop)]
-    for i in 0..refseq.sequences.len() {
-        let normalized = abundances[i] / refseq.sequences[i].len() as f64;
+    for i in 0..refseq.names.len() {
+        let normalized = abundances[i] / refseq.contig_len(i) as f64;
         writeln!(out, "{}\t{:.6}", refseq.names[i], normalized)?;
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use fastrand::Rng;
 use log::{debug, error, info, trace, warn};
 use mimalloc::MiMalloc;
 use strobealign::indexer::make_index;
+use strobealign::refseq::RefSequence;
 use thiserror::Error;
 
 use strobealign::aligner::{Aligner, Scores};
@@ -26,7 +27,6 @@ use strobealign::index::{
 use strobealign::insertsize::InsertSizeDistribution;
 use strobealign::io::SequenceIOError;
 use strobealign::io::fasta;
-use strobealign::io::fasta::RefSequence;
 use strobealign::io::reads::{
     PeekableSequenceReader, interleaved_record_iterator, open_reads, record_iterator,
 };

--- a/src/maponly.rs
+++ b/src/maponly.rs
@@ -99,7 +99,7 @@ fn paf_record_from_nam(
         query_end: nam.query_end as u64,
         is_revcomp: nam.is_revcomp,
         target_name: refseq.names[nam.ref_id].clone(),
-        target_length: refseq.sequences[nam.ref_id].len() as u64,
+        target_length: refseq.contig_len(nam.ref_id) as u64,
         target_start: nam.ref_start as u64,
         target_end: nam.ref_end as u64,
         matching_bases: nam.matching_bases as u64,

--- a/src/maponly.rs
+++ b/src/maponly.rs
@@ -4,13 +4,13 @@ use crate::chainer::Chainer;
 use crate::details::{Details, NamDetails};
 use crate::index::StrobemerIndex;
 use crate::insertsize::InsertSizeDistribution;
-use crate::io::fasta::RefSequence;
 use crate::io::paf::PafRecord;
 use crate::io::record::{End, SequenceRecord};
 use crate::mapper::mapping_quality;
 use crate::math::normal_pdf;
 use crate::mcsstrategy::McsStrategy;
 use crate::nam::{Nam, get_nams_by_chaining, sort_nams};
+use crate::refseq::RefSequence;
 
 /// Map a single-end read to the reference and return PAF records
 ///

--- a/src/maponly.rs
+++ b/src/maponly.rs
@@ -18,7 +18,7 @@ use crate::nam::{Nam, get_nams_by_chaining, sort_nams};
 pub fn map_single_end_read(
     record: &SequenceRecord,
     index: &StrobemerIndex,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     rescue_distance: usize,
     mcs_strategy: McsStrategy,
     chainer: &Chainer,
@@ -41,7 +41,7 @@ pub fn map_single_end_read(
             vec![paf_record_from_nam(
                 &nams[0],
                 &record.name,
-                references,
+                refseq,
                 record.sequence.len(),
                 Some(mapq),
                 End::None,
@@ -86,7 +86,7 @@ pub fn abundances_single_end_read(
 fn paf_record_from_nam(
     nam: &Nam,
     name: &str,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     query_length: usize,
     mapq: Option<u8>,
     end: End,
@@ -98,8 +98,8 @@ fn paf_record_from_nam(
         query_start: nam.query_start as u64,
         query_end: nam.query_end as u64,
         is_revcomp: nam.is_revcomp,
-        target_name: references[nam.ref_id].name.clone(),
-        target_length: references[nam.ref_id].sequence.len() as u64,
+        target_name: refseq.names[nam.ref_id].clone(),
+        target_length: refseq.sequences[nam.ref_id].len() as u64,
         target_start: nam.ref_start as u64,
         target_end: nam.ref_end as u64,
         matching_bases: nam.matching_bases as u64,
@@ -115,7 +115,7 @@ pub fn map_paired_end_read(
     r1: &SequenceRecord,
     r2: &SequenceRecord,
     index: &StrobemerIndex,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     rescue_distance: usize,
     insert_size_distribution: &mut InsertSizeDistribution,
     mcs_strategy: McsStrategy,
@@ -151,7 +151,7 @@ pub fn map_paired_end_read(
                 records.push(paf_record_from_nam(
                     nam1,
                     &r1.name,
-                    references,
+                    refseq,
                     r1.sequence.len(),
                     None,
                     End::One,
@@ -161,7 +161,7 @@ pub fn map_paired_end_read(
                 records.push(paf_record_from_nam(
                     nam2,
                     &r2.name,
-                    references,
+                    refseq,
                     r2.sequence.len(),
                     None,
                     End::Two,
@@ -172,7 +172,7 @@ pub fn map_paired_end_read(
             records.push(paf_record_from_nam(
                 nam1,
                 &r1.name,
-                references,
+                refseq,
                 r1.sequence.len(),
                 None,
                 End::One,
@@ -180,7 +180,7 @@ pub fn map_paired_end_read(
             records.push(paf_record_from_nam(
                 nam2,
                 &r2.name,
-                references,
+                refseq,
                 r2.sequence.len(),
                 None,
                 End::Two,

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -115,7 +115,7 @@ impl SamOutput {
     fn make_record(
         &self,
         alignment: Option<&Alignment>,
-        references: &[RefSequence],
+        refseq: &RefSequence,
         record: &SequenceRecord,
         mapq: u8,
         alignment_status: AlignmentStatus,
@@ -124,7 +124,7 @@ impl SamOutput {
         match alignment {
             Some(alignment) => self.make_mapped_record(
                 alignment,
-                references,
+                refseq,
                 record,
                 mapq,
                 alignment_status,
@@ -138,7 +138,7 @@ impl SamOutput {
     fn make_mapped_record(
         &self,
         alignment: &Alignment,
-        references: &[RefSequence],
+        refseq: &RefSequence,
         record: &SequenceRecord,
         mut mapq: u8,
         alignment_status: AlignmentStatus,
@@ -173,7 +173,7 @@ impl SamOutput {
         cigar.push(CigarOperation::Softclip, alignment.soft_clip_left);
         cigar.extend(&alignment.cigar);
         cigar.push(CigarOperation::Softclip, alignment.soft_clip_right);
-        let reference_name = Some(references[alignment.reference_id].name.clone());
+        let reference_name = Some(refseq.names[alignment.reference_id].clone());
         let details = if self.details { Some(details) } else { None };
         let cigar = if self.cigar_eqx {
             Some(cigar)
@@ -245,7 +245,7 @@ impl SamOutput {
     fn make_paired_records(
         &self,
         alignments: [Option<&Alignment>; 2],
-        references: &[RefSequence],
+        refseq: &RefSequence,
         records: [&SequenceRecord; 2],
         mapq: [u8; 2],
         details: &[Details; 2],
@@ -257,7 +257,7 @@ impl SamOutput {
         let mut sam_records = vec![
             self.make_record(
                 alignments[0],
-                references,
+                refseq,
                 records[0],
                 mapq[0],
                 alignment_status,
@@ -265,7 +265,7 @@ impl SamOutput {
             ),
             self.make_record(
                 alignments[1],
-                references,
+                refseq,
                 records[1],
                 mapq[1],
                 alignment_status,
@@ -290,8 +290,7 @@ impl SamOutput {
                 sam_records[i].mate_pos = Some(mate.ref_start as u32);
 
                 // RNEXT (reference name of mate)
-                sam_records[i].mate_reference_name =
-                    Some(references[mate.reference_id].name.clone());
+                sam_records[i].mate_reference_name = Some(refseq.names[mate.reference_id].clone());
                 if let Some(this) = alignments[i] {
                     // both aligned
 
@@ -316,8 +315,7 @@ impl SamOutput {
                     // mate-pair read whose mate is mapped, the unmapped read should have
                     // RNAME and POS identical to its mate."
                     sam_records[i].mate_reference_name = Some("=".to_string());
-                    sam_records[i].reference_name =
-                        Some(references[mate.reference_id].name.clone());
+                    sam_records[i].reference_name = Some(refseq.names[mate.reference_id].clone());
                     sam_records[i].pos = Some(mate.ref_start as u32);
                 }
             } else {
@@ -349,7 +347,7 @@ impl SamOutput {
 pub fn align_single_end_read(
     record: &SequenceRecord,
     index: &StrobemerIndex,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     mapping_parameters: &MappingParameters,
     sam_output: &SamOutput,
     chainer: &Chainer,
@@ -398,7 +396,7 @@ pub fn align_single_end_read(
         {
             break;
         }
-        let consistent_nam = nam.is_consistent(&read, references, k);
+        let consistent_nam = nam.is_consistent(&read, refseq, k);
         if !consistent_nam {
             details.inconsistent_nams += 1;
             continue;
@@ -406,7 +404,7 @@ pub fn align_single_end_read(
         let Some(alignment) = extend_seed(
             aligner,
             nam,
-            references,
+            refseq,
             &read,
             consistent_nam,
             mapping_parameters.use_ssw,
@@ -488,7 +486,7 @@ pub fn align_single_end_read(
     let best_alignment = best_alignment.unwrap();
     sam_records.push(sam_output.make_mapped_record(
         &best_alignment,
-        references,
+        refseq,
         record,
         mapq,
         AlignmentStatus::Primary,
@@ -514,7 +512,7 @@ pub fn align_single_end_read(
             // TODO .clone()
             sam_records.push(sam_output.make_mapped_record(
                 alignment,
-                references,
+                refseq,
                 record,
                 mapq,
                 AlignmentStatus::Secondary,
@@ -532,7 +530,7 @@ pub fn align_single_end_read(
 fn extend_seed(
     aligner: &Aligner,
     nam: &mut Nam,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     read: &Read,
     consistent_nam: bool,
     use_ssw: bool,
@@ -542,7 +540,7 @@ fn extend_seed(
     } else {
         read.seq()
     };
-    let refseq = &references[nam.ref_id].sequence;
+    let refseq = &refseq.sequences[nam.ref_id];
 
     let projected_ref_start = nam.ref_start.saturating_sub(nam.query_start);
     let projected_ref_end = min(nam.ref_end + query.len() - nam.query_end, refseq.len());
@@ -625,7 +623,7 @@ pub fn align_paired_end_read(
     r1: &SequenceRecord,
     r2: &SequenceRecord,
     index: &StrobemerIndex,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     mapping_parameters: &MappingParameters,
     sam_output: &SamOutput,
     seeding_parameters: &SeedingParameters,
@@ -660,7 +658,7 @@ pub fn align_paired_end_read(
         &read1,
         &read2,
         seeding_parameters.syncmer.k,
-        references,
+        refseq,
         &mut details,
         mapping_parameters.dropoff_threshold,
         insert_size_distribution,
@@ -695,7 +693,7 @@ pub fn align_paired_end_read(
 
             sam_records.extend(sam_output.make_paired_records(
                 [Some(&alignment1), Some(&alignment2)],
-                references,
+                refseq,
                 [r1, r2],
                 [mapq1, mapq2],
                 &details,
@@ -747,7 +745,7 @@ pub fn align_paired_end_read(
             sam_records.extend(aligned_pairs_to_sam(
                 &alignment_pairs,
                 sam_output,
-                references,
+                refseq,
                 mapping_parameters.max_secondary,
                 secondary_dropoff as f64,
                 r1,
@@ -781,7 +779,7 @@ fn extend_paired_seeds(
     read1: &Read,
     read2: &Read,
     k: usize,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     details: &mut [Details; 2],
     dropoff: f32,
     insert_size_distribution: &InsertSizeDistribution,
@@ -801,7 +799,7 @@ fn extend_paired_seeds(
             read2,
             read1,
             aligner,
-            references,
+            refseq,
             &mut nams[0],
             max_tries,
             dropoff,
@@ -819,7 +817,7 @@ fn extend_paired_seeds(
             read1,
             read2,
             aligner,
-            references,
+            refseq,
             &mut nams[1],
             max_tries,
             dropoff,
@@ -847,15 +845,15 @@ fn extend_paired_seeds(
         let mut n_max1 = nams[0][0].clone();
         let mut n_max2 = nams[1][0].clone();
 
-        let consistent_nam1 = n_max1.is_consistent(read1, references, k);
+        let consistent_nam1 = n_max1.is_consistent(read1, refseq, k);
         details[0].inconsistent_nams += !consistent_nam1 as usize;
-        let consistent_nam2 = n_max2.is_consistent(read2, references, k);
+        let consistent_nam2 = n_max2.is_consistent(read2, refseq, k);
         details[1].inconsistent_nams += !consistent_nam2 as usize;
 
         let alignment1 = extend_seed(
             aligner,
             &mut n_max1,
-            references,
+            refseq,
             read1,
             consistent_nam1,
             true, // SSW
@@ -863,7 +861,7 @@ fn extend_paired_seeds(
         let alignment2 = extend_seed(
             aligner,
             &mut n_max2,
-            references,
+            refseq,
             read2,
             consistent_nam2,
             true, // SSW
@@ -893,12 +891,12 @@ fn extend_paired_seeds(
     // the paired-end read as two single-end reads.
     let mut a_indv_max = [None, None];
     for i in 0..2 {
-        let consistent_nam = reverse_nam_if_needed(&mut nams[i][0], reads[i], references, k);
+        let consistent_nam = reverse_nam_if_needed(&mut nams[i][0], reads[i], refseq, k);
         details[i].inconsistent_nams += !consistent_nam as usize;
         a_indv_max[i] = extend_seed(
             aligner,
             &mut nams[i][0],
-            references,
+            refseq,
             reads[i],
             consistent_nam,
             true, // SSW
@@ -930,13 +928,12 @@ fn extend_paired_seeds(
             let alignment;
             if let Some(mut this_nam) = namsp[i].clone() {
                 if let Entry::Vacant(e) = alignment_cache[i].entry(this_nam.nam_id) {
-                    let consistent_nam =
-                        reverse_nam_if_needed(&mut this_nam, reads[i], references, k);
+                    let consistent_nam = reverse_nam_if_needed(&mut this_nam, reads[i], refseq, k);
                     details[i].inconsistent_nams += !consistent_nam as usize;
                     alignment = extend_seed(
                         aligner,
                         &mut this_nam,
-                        references,
+                        refseq,
                         reads[i],
                         consistent_nam,
                         true, // SSW
@@ -950,8 +947,8 @@ fn extend_paired_seeds(
             } else {
                 let mut other_nam = namsp[1 - i].clone().unwrap();
                 details[1 - i].inconsistent_nams +=
-                    !reverse_nam_if_needed(&mut other_nam, reads[1 - i], references, k) as usize;
-                alignment = rescue_align(aligner, &other_nam, references, reads[i], mu, sigma, k);
+                    !reverse_nam_if_needed(&mut other_nam, reads[1 - i], refseq, k) as usize;
+                alignment = rescue_align(aligner, &other_nam, refseq, reads[i], mu, sigma, k);
                 if alignment.is_some() {
                     details[i].mate_rescue += 1;
                     details[i].tried_alignment += 1;
@@ -1019,7 +1016,7 @@ fn rescue_read(
     read2: &Read, // read to be rescued
     read1: &Read, // read that has NAMs
     aligner: &Aligner,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     nams1: &mut [Nam],
     max_tries: usize,
     dropoff: f32,
@@ -1039,15 +1036,14 @@ fn rescue_read(
         if score_dropoff1 < dropoff {
             break;
         }
-        let consistent_nam = reverse_nam_if_needed(nam, read1, references, k);
+        let consistent_nam = reverse_nam_if_needed(nam, read1, refseq, k);
         details[0].inconsistent_nams += !consistent_nam as usize;
-        if let Some(alignment) = extend_seed(aligner, nam, references, read1, consistent_nam, true)
-        {
+        if let Some(alignment) = extend_seed(aligner, nam, refseq, read1, consistent_nam, true) {
             details[0].gapped += alignment.gapped as usize;
             alignments1.push(alignment);
             details[0].tried_alignment += 1;
 
-            let a2 = rescue_align(aligner, nam, references, read2, mu, sigma, k);
+            let a2 = rescue_align(aligner, nam, refseq, read2, mu, sigma, k);
             if a2.is_some() {
                 details[1].mate_rescue += 1;
             }
@@ -1094,7 +1090,7 @@ fn rescue_read(
 fn rescue_align(
     aligner: &Aligner,
     mate_nam: &Nam,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     read: &Read,
     mu: f32,
     sigma: f32,
@@ -1118,7 +1114,7 @@ fn rescue_align(
         )
     };
 
-    let ref_len = references[mate_nam.ref_id].sequence.len();
+    let ref_len = refseq.sequences[mate_nam.ref_id].len();
     let ref_start = ref_start.min(ref_len);
     let ref_end = ref_end.min(ref_len);
 
@@ -1126,9 +1122,7 @@ fn rescue_align(
         //        std::cerr << "RESCUE: Caught Bug3! ref start: " << ref_start << " ref end: " << ref_end << " ref len:  " << ref_len << std::endl;
         return None;
     }
-    let ref_segm = references[mate_nam.ref_id]
-        .sequence
-        .decode(ref_start, ref_end);
+    let ref_segm = refseq.sequences[mate_nam.ref_id].decode(ref_start, ref_end);
 
     if !has_shared_substring(r_tmp, &ref_segm, k) {
         return None;
@@ -1371,7 +1365,7 @@ fn count_best_alignment_pairs(pairs: &[ScoredAlignmentPair]) -> usize {
 fn aligned_pairs_to_sam(
     high_scores: &[ScoredAlignmentPair],
     sam_output: &SamOutput,
-    references: &[RefSequence],
+    refseq: &RefSequence,
     max_secondary: usize,
     secondary_dropoff: f64,
     record1: &SequenceRecord,
@@ -1396,7 +1390,7 @@ fn aligned_pairs_to_sam(
         let pair_status = is_proper_pair_opt(alignment1.as_ref(), alignment2.as_ref(), mu, sigma);
         records.extend(sam_output.make_paired_records(
             [alignment1.as_ref(), alignment2.as_ref()],
-            references,
+            refseq,
             [record1, record2],
             mapqs,
             details,
@@ -1420,7 +1414,7 @@ fn aligned_pairs_to_sam(
                 };
                 records.extend(sam_output.make_paired_records(
                     [alignment1.as_ref(), alignment2.as_ref()],
-                    references,
+                    refseq,
                     [record1, record2],
                     effective_mapqs,
                     details,

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -606,7 +606,7 @@ fn extend_seed(
         }
     }
     Some(Alignment {
-        cigar: info.cigar.clone(),
+        cigar: mem::take(&mut info.cigar),
         edit_distance: info.edit_distance,
         soft_clip_left: info.query_start,
         soft_clip_right: query.len() - info.query_end,

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -540,10 +540,10 @@ fn extend_seed(
     } else {
         read.seq()
     };
-    let refseq = &refseq.sequences[nam.ref_id];
+    let seq = &refseq.contig(nam.ref_id);
 
     let projected_ref_start = nam.ref_start.saturating_sub(nam.query_start);
-    let projected_ref_end = min(nam.ref_end + query.len() - nam.query_end, refseq.len());
+    let projected_ref_end = min(nam.ref_end + query.len() - nam.query_end, seq.len());
 
     // TODO ugly
     let mut info = AlignmentInfo {
@@ -558,7 +558,7 @@ fn extend_seed(
     let mut result_ref_start = 0;
     let mut gapped = true;
     if projected_ref_start + query.len() == projected_ref_end && consistent_nam {
-        let ref_segm_ham = refseq.decode(projected_ref_start, projected_ref_end);
+        let ref_segm_ham = seq.decode(projected_ref_start, projected_ref_end);
         if let Some(hamming_dist) = hamming_distance(query, &ref_segm_ham)
             && (hamming_dist as f32 / query.len() as f32) < 0.05
         {
@@ -579,8 +579,8 @@ fn extend_seed(
         let padding = read.len() / 10;
         if use_ssw {
             let ref_start = projected_ref_start.saturating_sub(padding);
-            let ref_end = min(projected_ref_end + padding, refseq.len());
-            let segment = refseq.decode(ref_start, ref_end);
+            let ref_end = min(projected_ref_end + padding, seq.len());
+            let segment = seq.decode(ref_start, ref_end);
             info = aligner.align(query, &segment)?;
             result_ref_start = ref_start + info.ref_start;
         } else {
@@ -588,8 +588,8 @@ fn extend_seed(
             // Decode the reference region needed by the piecewise aligner.
             // Use a generous range so all anchor-relative slices stay in bounds.
             let decode_start = nam.ref_start.saturating_sub(query.len() + padding);
-            let decode_end = (nam.ref_end + query.len() + padding).min(refseq.len());
-            let decoded_ref = refseq.decode(decode_start, decode_end);
+            let decode_end = (nam.ref_end + query.len() + padding).min(seq.len());
+            let decoded_ref = seq.decode(decode_start, decode_end);
             let adjusted_anchors: Vec<Anchor> = nam
                 .anchors
                 .iter()
@@ -1114,7 +1114,7 @@ fn rescue_align(
         )
     };
 
-    let ref_len = refseq.sequences[mate_nam.ref_id].len();
+    let ref_len = refseq.contig_len(mate_nam.ref_id);
     let ref_start = ref_start.min(ref_len);
     let ref_end = ref_end.min(ref_len);
 
@@ -1122,7 +1122,7 @@ fn rescue_align(
         //        std::cerr << "RESCUE: Caught Bug3! ref start: " << ref_start << " ref end: " << ref_end << " ref len:  " << ref_len << std::endl;
         return None;
     }
-    let ref_segm = refseq.sequences[mate_nam.ref_id].decode(ref_start, ref_end);
+    let ref_segm = refseq.contig(mate_nam.ref_id).decode(ref_start, ref_end);
 
     if !has_shared_substring(r_tmp, &ref_segm, k) {
         return None;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -14,7 +14,6 @@ use crate::cigar::{Cigar, CigarOperation};
 use crate::details::Details;
 use crate::index::StrobemerIndex;
 use crate::insertsize::InsertSizeDistribution;
-use crate::io::fasta::RefSequence;
 use crate::io::record::SequenceRecord;
 use crate::io::sam::{
     MREVERSE, MUNMAP, PAIRED, PROPER_PAIR, READ1, READ2, REVERSE, SECONDARY, SamRecord, UNMAP,
@@ -24,6 +23,7 @@ use crate::mcsstrategy::McsStrategy;
 use crate::nam::{Nam, get_nams_by_chaining, reverse_nam_if_needed, sort_nams};
 use crate::piecewisealigner::remove_spurious_anchors;
 use crate::read::Read;
+use crate::refseq::RefSequence;
 use crate::revcomp::reverse_complement;
 use crate::seeding::SeedingParameters;
 

--- a/src/nam.rs
+++ b/src/nam.rs
@@ -9,9 +9,9 @@ use crate::chainer::Anchor;
 use crate::chainer::Chainer;
 use crate::details::NamDetails;
 use crate::index::StrobemerIndex;
-use crate::io::fasta::RefSequence;
 use crate::mcsstrategy::McsStrategy;
 use crate::read::Read;
+use crate::refseq::RefSequence;
 use crate::seeding::randstrobes_query;
 use crate::shuffle::shuffle_best;
 

--- a/src/nam.rs
+++ b/src/nam.rs
@@ -46,13 +46,10 @@ impl Nam {
     /// Returns whether a NAM represents a consistent match between read and
     /// reference by comparing the nucleotide sequences of the first and last
     /// strobe (taking orientation into account).
-    pub fn is_consistent(&self, read: &Read, references: &[RefSequence], k: usize) -> bool {
-        let ref_start_kmer = references[self.ref_id]
-            .sequence
-            .decode(self.ref_start, self.ref_start + k);
-        let ref_end_kmer = references[self.ref_id]
-            .sequence
-            .decode(self.ref_end - k, self.ref_end);
+    pub fn is_consistent(&self, read: &Read, refseq: &RefSequence, k: usize) -> bool {
+        let ref_start_kmer =
+            refseq.sequences[self.ref_id].decode(self.ref_start, self.ref_start + k);
+        let ref_end_kmer = refseq.sequences[self.ref_id].decode(self.ref_end - k, self.ref_end);
 
         let seq = if self.is_revcomp {
             read.rc()
@@ -91,18 +88,9 @@ impl Display for Nam {
 /// - If first and last strobe match in reverse orientation, update the NAM
 ///   in place and return true.
 /// - If first and last strobe do not match consistently, return false.
-pub fn reverse_nam_if_needed(
-    nam: &mut Nam,
-    read: &Read,
-    references: &[RefSequence],
-    k: usize,
-) -> bool {
-    let ref_start_kmer = references[nam.ref_id]
-        .sequence
-        .decode(nam.ref_start, nam.ref_start + k);
-    let ref_end_kmer = references[nam.ref_id]
-        .sequence
-        .decode(nam.ref_end - k, nam.ref_end);
+pub fn reverse_nam_if_needed(nam: &mut Nam, read: &Read, refseq: &RefSequence, k: usize) -> bool {
+    let ref_start_kmer = refseq.sequences[nam.ref_id].decode(nam.ref_start, nam.ref_start + k);
+    let ref_end_kmer = refseq.sequences[nam.ref_id].decode(nam.ref_end - k, nam.ref_end);
 
     let (seq, seq_rc) = if nam.is_revcomp {
         (read.rc(), read.seq())

--- a/src/nam.rs
+++ b/src/nam.rs
@@ -47,9 +47,12 @@ impl Nam {
     /// reference by comparing the nucleotide sequences of the first and last
     /// strobe (taking orientation into account).
     pub fn is_consistent(&self, read: &Read, refseq: &RefSequence, k: usize) -> bool {
-        let ref_start_kmer =
-            refseq.sequences[self.ref_id].decode(self.ref_start, self.ref_start + k);
-        let ref_end_kmer = refseq.sequences[self.ref_id].decode(self.ref_end - k, self.ref_end);
+        let ref_start_kmer = refseq
+            .contig(self.ref_id)
+            .decode(self.ref_start, self.ref_start + k);
+        let ref_end_kmer = refseq
+            .contig(self.ref_id)
+            .decode(self.ref_end - k, self.ref_end);
 
         let seq = if self.is_revcomp {
             read.rc()
@@ -89,8 +92,12 @@ impl Display for Nam {
 ///   in place and return true.
 /// - If first and last strobe do not match consistently, return false.
 pub fn reverse_nam_if_needed(nam: &mut Nam, read: &Read, refseq: &RefSequence, k: usize) -> bool {
-    let ref_start_kmer = refseq.sequences[nam.ref_id].decode(nam.ref_start, nam.ref_start + k);
-    let ref_end_kmer = refseq.sequences[nam.ref_id].decode(nam.ref_end - k, nam.ref_end);
+    let ref_start_kmer = refseq
+        .contig(nam.ref_id)
+        .decode(nam.ref_start, nam.ref_start + k);
+    let ref_end_kmer = refseq
+        .contig(nam.ref_id)
+        .decode(nam.ref_end - k, nam.ref_end);
 
     let (seq, seq_rc) = if nam.is_revcomp {
         (read.rc(), read.seq())

--- a/src/refseq.rs
+++ b/src/refseq.rs
@@ -3,7 +3,7 @@ use crate::packed_seq::PackedSeq;
 #[derive(Default, Debug, Clone)]
 pub struct RefSequence {
     pub names: Vec<String>,
-    pub sequences: Vec<PackedSeq>,
+    sequences: Vec<PackedSeq>,
 }
 
 impl RefSequence {
@@ -17,5 +17,21 @@ impl RefSequence {
     pub fn push(&mut self, name: String, seq: PackedSeq) {
         self.names.push(name);
         self.sequences.push(seq);
+    }
+
+    pub fn contig(&self, index: usize) -> &PackedSeq {
+        &self.sequences[index]
+    }
+
+    pub fn contig_len(&self, index: usize) -> usize {
+        self.sequences[index].len()
+    }
+
+    pub fn max_contig_len(&self) -> Option<usize> {
+        self.sequences.iter().map(|seq| seq.len()).max()
+    }
+
+    pub fn total_length(&self) -> usize {
+        self.sequences.iter().map(|seq| seq.len()).sum()
     }
 }

--- a/src/refseq.rs
+++ b/src/refseq.rs
@@ -1,0 +1,21 @@
+use crate::packed_seq::PackedSeq;
+
+#[derive(Default, Debug, Clone)]
+pub struct RefSequence {
+    pub names: Vec<String>,
+    pub sequences: Vec<PackedSeq>,
+}
+
+impl RefSequence {
+    pub fn new() -> Self {
+        RefSequence {
+            names: vec![],
+            sequences: vec![],
+        }
+    }
+
+    pub fn push(&mut self, name: String, seq: PackedSeq) {
+        self.names.push(name);
+        self.sequences.push(seq);
+    }
+}

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -179,24 +179,26 @@ impl<SI: Iterator<Item = Syncmer>> Iterator for RandstrobeIterator<SI> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::io::fasta::{RefSequence, read_ref};
+    use crate::io::fasta::read_ref;
+    use crate::packed_seq::PackedSeq;
     use crate::seeding::SeedingParameters;
     use crate::seeding::SyncmerIterator;
 
-    fn read_phix() -> RefSequence {
+    fn read_phix() -> PackedSeq {
         read_ref("tests/phix.fasta")
             .unwrap()
+            .sequences
             .first()
             .unwrap()
-            .clone()
+            .to_owned()
     }
 
     #[test]
     fn randstrobe_iterator() {
-        let refseq = read_phix().sequence;
+        let seq = read_phix();
         let parameters = SeedingParameters::new(300);
         let syncmer_iter = SyncmerIterator::new(
-            &refseq,
+            &seq,
             parameters.syncmer.k,
             parameters.syncmer.s,
             parameters.syncmer.t,
@@ -206,8 +208,8 @@ mod test {
         for randstrobe in randstrobe_iter {
             assert!(randstrobe.hash > 0);
             assert!(randstrobe.strobe2_pos >= randstrobe.strobe2_pos);
-            assert!(randstrobe.strobe1_pos < refseq.len());
-            assert!(randstrobe.strobe2_pos < refseq.len());
+            assert!(randstrobe.strobe1_pos < seq.len());
+            assert!(randstrobe.strobe2_pos < seq.len());
         }
     }
 
@@ -215,10 +217,10 @@ mod test {
     // items. We need this to hold for `count_randstrobes()`.
     #[test]
     fn syncmer_and_randstrobe_iterator_same_count() {
-        let refseq = read_phix().sequence;
+        let seq = read_phix();
         let parameters = SeedingParameters::new(100);
         let syncmer_iter = SyncmerIterator::new(
-            &refseq,
+            &seq,
             parameters.syncmer.k,
             parameters.syncmer.s,
             parameters.syncmer.t,
@@ -226,7 +228,7 @@ mod test {
         let syncmer_count = syncmer_iter.count();
 
         let syncmer_iter = SyncmerIterator::new(
-            &refseq,
+            &seq,
             parameters.syncmer.k,
             parameters.syncmer.s,
             parameters.syncmer.t,

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -185,12 +185,7 @@ mod test {
     use crate::seeding::SyncmerIterator;
 
     fn read_phix() -> PackedSeq {
-        read_ref("tests/phix.fasta")
-            .unwrap()
-            .sequences
-            .first()
-            .unwrap()
-            .to_owned()
+        read_ref("tests/phix.fasta").unwrap().contig(0).to_owned()
     }
 
     #[test]

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -275,12 +275,7 @@ mod test {
     #[test]
     fn canonical_syncmers() {
         let parameters = SyncmerParameters::try_new(20, 16).unwrap();
-        let seq: Vec<u8> = read_ref("tests/phix.fasta")
-            .unwrap()
-            .sequences
-            .first()
-            .unwrap()
-            .decode_all();
+        let seq: Vec<u8> = read_ref("tests/phix.fasta").unwrap().contig(0).decode_all();
         let sequences: [Vec<u8>; 2] = [b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_vec(), seq];
         for s in sequences {
             let seq_revcomp = reverse_complement(&s);

--- a/src/seeding/syncmers.rs
+++ b/src/seeding/syncmers.rs
@@ -277,9 +277,9 @@ mod test {
         let parameters = SyncmerParameters::try_new(20, 16).unwrap();
         let seq: Vec<u8> = read_ref("tests/phix.fasta")
             .unwrap()
-            .pop()
+            .sequences
+            .first()
             .unwrap()
-            .sequence
             .decode_all();
         let sequences: [Vec<u8>; 2] = [b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_vec(), seq];
         for s in sequences {


### PR DESCRIPTION
This contains all of the purely refactoring commits of PR #607. That is, we can just merge this without having to wait for the other minor things that need to be done in that PR.

Instead of a single `PackedSeq`, the change is to store a `Vec<PackedSeq>` in `RefSequence`. So this means that what gets passed to a function that needs to know about the reference is no longer a `&[RefSequence]`, but a `&RefSequence`.

This lets us have a single data structure that stores the full genome sequence.

Also, this moves the `RefSequence` to a new `refseq` module (`refseq.rs`).