### PR TITLE
Pin the Rust toolchain and fix new clippy 1.97 lints

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]

--- a/src/io/reads.rs
+++ b/src/io/reads.rs
@@ -85,15 +85,13 @@ impl Iterator for InterleavedIterator {
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         let record1 = if let Some(record) = self.next_record.take() {
             record
-        } else if let Some(record) = self.reader.next() {
-            match record {
+        } else {
+            match self.reader.next()? {
                 Ok(record) => record,
                 Err(e) => {
                     return Some(Err(e));
                 }
             }
-        } else {
-            return None;
         };
 
         match self.reader.next() {

--- a/src/io/sam.rs
+++ b/src/io/sam.rs
@@ -189,7 +189,7 @@ impl Display for SamHeader<'_> {
         if let Some(read_group) = &self.read_group {
             write!(f, "@RG\tID:{}", read_group.id)?;
             for field in &read_group.fields {
-                write!(f, "\t{}", &field)?;
+                write!(f, "\t{}", field)?;
             }
             f.write_str("\n")?;
         }
@@ -197,7 +197,7 @@ impl Display for SamHeader<'_> {
             writeln!(
                 f,
                 "@PG\tID:strobealign\tPN:strobealign\tVN:{}\tCL:{}",
-                &self.version, &cmd_line
+                self.version, cmd_line
             )?;
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,7 +486,7 @@ fn run() -> Result<(), CliError> {
             "Total time indexing: {:.2} s",
             timer.elapsed().as_secs_f64()
         );
-        debug!("{}", &index_stats);
+        debug!("{}", index_stats);
 
         index
     };
@@ -532,9 +532,9 @@ fn run() -> Result<(), CliError> {
         gap_extend: args.gap_extension_penalty,
         end_bonus: args.end_bonus,
     };
-    debug!("{:?}", &mapping_parameters);
-    debug!("{:?}", &chaining_parameters);
-    debug!("{:?}", &scores);
+    debug!("{:?}", mapping_parameters);
+    debug!("{:?}", chaining_parameters);
+    debug!("{:?}", scores);
 
     let chainer = Chainer::new(index.k(), chaining_parameters);
     let aligner = Aligner::new(scores, index.k(), args.xdrop);

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -45,7 +45,7 @@ const fn make_is_wildcard_table() -> [u8; 256] {
 
 static ENCODE: [u8; 256] = make_encode_table();
 static IS_WILDCARD: [u8; 256] = make_is_wildcard_table();
-static DECODE: [u8; 4] = [b'A', b'C', b'G', b'T'];
+static DECODE: [u8; 4] = *b"ACGT";
 
 /// Deterministic pseudo-random 2-bit value for position `pos`.
 ///

--- a/src/revcomp.rs
+++ b/src/revcomp.rs
@@ -2,6 +2,7 @@
 // c, C -> G
 // g, G -> C
 // t, T, u, U -> A
+#[allow(clippy::byte_char_slices)]
 const REVCOMP_TABLE: [u8; 256] = [
     b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N',
     b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N', b'N',


### PR DESCRIPTION
A fix to match our toolchain version and the CI's. It fixes the version in `rust-toolchain.toml`, and I set it to the latest 1.97 (currently in the CI).

I also went ahead and fixed main to match clippy 1.97 rules. Feel free to use an older version of the toolchain if you don't want the small changes in the code.

Since the clippy warnings are found in main, no commit will pass the CI until this is resolved.