### PR TITLE
Replace block-aligner with a custom SIMD aligner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@ In addition, the following functional changes have been made:
 * #624: Fix for secondary alignments: Secondary alignments are now output if
   their score is at least 0.95 times the score of the primary alignment.
   This "secondary threshold" can now be set with command-line option `--st`.
+* #614: The piecewise extension for single-end reads now uses an in-house SIMD
+  aligner, extension length is controlled by a bandwidth parameter (`--bw`, 
+  default 1024) in place of `--xdrop`.
 
 ## v0.17.0 (2025-12-18)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,12 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "block-aligner"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8986feb1596f749fdcf1046e1b8068dfe802fc45708e6e293b736e4c0bb3b3a5"
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,7 +548,6 @@ name = "strobealign"
 version = "0.18.0"
 dependencies = [
  "assert_cmd",
- "block-aligner",
  "cc",
  "clap",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,6 @@ flate2 = { version = "1.0", features = ["zlib-rs"]}
 thiserror = "2.0.11"
 rayon = "1.11.0"
 mimalloc = "0.1.48"
-[target.'cfg(target_arch = "wasm32-wasi")'.dependencies]
-block-aligner = { version = "0.5", features = ["simd_wasm"] }
-[target.'cfg(target_arch = "x86_64")'.dependencies]
-block-aligner = { version = "0.5", features = ["simd_avx2"] }
-[target.'cfg(target_arch = "aarch64")'.dependencies]
-block-aligner = { version = "0.5", features = ["simd_neon"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/src/aligner.rs
+++ b/src/aligner.rs
@@ -51,22 +51,33 @@ pub struct Aligner {
     pub scores: Scores, // TODO should not be pub?
     call_count: Cell<usize>,
     ssw_aligner: SswAligner,
-    piecewise_aligner: PiecewiseAligner,
+    /// `None` when built by [`Aligner::new_ssw_only`].
+    piecewise_aligner: Option<PiecewiseAligner>,
 }
 
 impl Aligner {
     pub fn new(scores: Scores, k: usize, bandwidth: usize) -> Self {
+        Aligner {
+            piecewise_aligner: Some(PiecewiseAligner::new(scores, k, bandwidth)),
+            ..Aligner::new_ssw_only(scores)
+        }
+    }
+
+    /// An aligner for SSW extension only.
+    ///
+    /// The piecewise aligner is not built, so a scoring scheme that only its kernel rules out is
+    /// accepted here.
+    pub fn new_ssw_only(scores: Scores) -> Self {
         let ssw_aligner = SswAligner::new(
             scores.match_,
             scores.mismatch,
             scores.gap_open,
             scores.gap_extend,
         );
-        let piecewise_aligner = PiecewiseAligner::new(scores, k, bandwidth);
         Aligner {
             scores,
             ssw_aligner,
-            piecewise_aligner,
+            piecewise_aligner: None,
             call_count: Cell::new(0usize),
         }
     }
@@ -159,6 +170,8 @@ impl Aligner {
     ) -> Option<AlignmentInfo> {
         self.call_count.set(self.call_count.get() + 1);
         self.piecewise_aligner
+            .as_ref()
+            .expect("this Aligner was built for SSW extension only")
             .extend_piecewise(query, refseq, chain, padding)
     }
 }

--- a/src/aligner.rs
+++ b/src/aligner.rs
@@ -55,14 +55,14 @@ pub struct Aligner {
 }
 
 impl Aligner {
-    pub fn new(scores: Scores, k: usize, xdrop: i32) -> Self {
+    pub fn new(scores: Scores, k: usize, bandwidth: usize) -> Self {
         let ssw_aligner = SswAligner::new(
             scores.match_,
             scores.mismatch,
             scores.gap_open,
             scores.gap_extend,
         );
-        let piecewise_aligner = PiecewiseAligner::new(scores, k, xdrop);
+        let piecewise_aligner = PiecewiseAligner::new(scores, k, bandwidth);
         Aligner {
             scores,
             ssw_aligner,

--- a/src/cigar.rs
+++ b/src/cigar.rs
@@ -84,6 +84,12 @@ impl Cigar {
         Cigar { ops: vec![] }
     }
 
+    pub fn with_capacity(hint: usize) -> Self {
+        Cigar {
+            ops: Vec::with_capacity(hint),
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.ops.is_empty()
     }
@@ -122,6 +128,10 @@ impl Cigar {
         Cigar {
             ops: self.ops.iter().copied().rev().collect(),
         }
+    }
+
+    pub fn reverse(&mut self) {
+        self.ops.reverse();
     }
 
     pub fn extend(&mut self, other: &Cigar) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,5 @@ pub mod refseq;
 pub mod revcomp;
 pub mod seeding;
 pub mod shuffle;
+pub mod simdaligner;
 pub mod ssw;

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,9 +281,9 @@ struct Args {
     #[arg(long = "ssw", help_heading = "Alignment")]
     use_ssw: bool,
 
-    /// X-drop threshold for piecewise extension
-    #[arg(long = "xdrop", default_value_t = 500, value_name = "N", help_heading = "Alignment")]
-    xdrop: i32,
+    /// Bandwidth of the piecewise start/end extensions, in diagonals
+    #[arg(long = "bw", default_value_t = 1024, value_name = "N", help_heading = "Alignment")]
+    bandwidth: usize,
 
 
     /// Path to input reference (in FASTA format)
@@ -559,7 +559,7 @@ fn run() -> Result<(), CliError> {
     debug!("{:?}", scores);
 
     let chainer = Chainer::new(index.k(), chaining_parameters);
-    let aligner = Aligner::new(scores, index.k(), args.xdrop);
+    let aligner = Aligner::new(scores, index.k(), args.bandwidth);
 
     let cmd_line = env::args().skip(1).collect::<Vec<_>>().join(" ");
     let rg_id = match args.rg_id {

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,7 +357,10 @@ fn run() -> Result<(), CliError> {
         gap_extend: args.gap_extension_penalty,
         end_bonus: args.end_bonus,
     };
-    check_scores(scores)?;
+    // Only the piecewise path has a bound on the scheme, and --ssw does not take it.
+    if !args.use_ssw {
+        check_scores(scores)?;
+    }
 
     if cfg!(target_os = "linux") {
         warn_clocksource();
@@ -566,7 +569,11 @@ fn run() -> Result<(), CliError> {
     debug!("{:?}", scores);
 
     let chainer = Chainer::new(index.k(), chaining_parameters);
-    let aligner = Aligner::new(scores, index.k(), args.bandwidth);
+    let aligner = if args.use_ssw {
+        Aligner::new_ssw_only(scores)
+    } else {
+        Aligner::new(scores, index.k(), args.bandwidth)
+    };
 
     let cmd_line = env::args().skip(1).collect::<Vec<_>>().join(" ");
     let rg_id = match args.rg_id {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ use strobealign::mapper::{
 };
 use strobealign::mcsstrategy::McsStrategy;
 use strobealign::seeding::{DEFAULT_AUX_LEN, InvalidSeedingParameter, SeedingParameters};
+use strobealign::simdaligner::{InvalidScores, check_scores};
 
 mod logger;
 
@@ -318,6 +319,9 @@ enum CliError {
     #[error("No sequences found in the reference FASTA")]
     NoReference,
 
+    #[error("Invalid scoring scheme: {0}")]
+    InvalidScores(#[from] InvalidScores),
+
     #[error("When opening '{0}': {1}", .path, .e)]
     IoWithPath { e: io::Error, path: String },
 }
@@ -345,6 +349,16 @@ fn run() -> Result<(), CliError> {
     };
     logger::init(level).unwrap();
     info!("This is {} {}", NAME, VERSION);
+
+    let scores = Scores {
+        match_: args.match_score,
+        mismatch: args.mismatch_score,
+        gap_open: args.gap_open_penalty,
+        gap_extend: args.gap_extension_penalty,
+        end_bonus: args.end_bonus,
+    };
+    check_scores(scores)?;
+
     if cfg!(target_os = "linux") {
         warn_clocksource();
     }
@@ -546,13 +560,6 @@ fn run() -> Result<(), CliError> {
         max_ref_gap: args.max_ref_gap,
         matches_weight: args.matches_weight,
         max_diagonal_ratio: args.max_diagonal_ratio,
-    };
-    let scores = Scores {
-        match_: args.match_score,
-        mismatch: args.mismatch_score,
-        gap_open: args.gap_open_penalty,
-        gap_extend: args.gap_extension_penalty,
-        end_bonus: args.end_bonus,
     };
     debug!("{:?}", mapping_parameters);
     debug!("{:?}", chaining_parameters);

--- a/src/piecewisealigner.rs
+++ b/src/piecewisealigner.rs
@@ -1,230 +1,31 @@
 use crate::{
     aligner::{AlignmentInfo, Scores, hamming_align_global},
     chainer::Anchor,
-    cigar::{Cigar, CigarOperation},
+    cigar::CigarOperation,
+    simdaligner::{AlignmentResult, SimdAligner},
 };
-use block_aligner::{
-    cigar::{Cigar as BlockCigar, Operation},
-    scan_block::{Block, PaddedBytes},
-    scores::{AAMatrix, AAProfile, Gaps, NucMatrix, Profile},
-};
+use std::cell::RefCell;
 
-// Maximum value for blockaligner's block sizes, higher values might cause a crash
-const MAXIMUM_BLOCK_SIZE: usize = 8192;
-
-#[derive(Clone, Copy)]
-enum XdropMode {
-    GlobalStartLocalEnd,
-    LocalStartGlobalEnd,
-}
-
-#[derive(Clone)]
 pub struct PiecewiseAligner {
     scores: Scores,
     k: usize,
-    gaps: Gaps,
-    matrix: NucMatrix,
-    xdrop: i32,
+    bandwidth: usize,
+    simd_aligner: RefCell<SimdAligner>,
 }
 
-struct AlignmentResult {
-    pub score: i32,
-    pub query_start: usize,
-    pub query_end: usize,
-    pub ref_start: usize,
-    pub ref_end: usize,
-    pub cigar: Cigar,
-}
-
-impl Default for AlignmentResult {
-    fn default() -> Self {
-        AlignmentResult {
-            score: 0,
-            query_start: 0,
-            query_end: 0,
-            ref_start: 0,
-            ref_end: 0,
-            cigar: Cigar::new(),
-        }
+impl Clone for PiecewiseAligner {
+    fn clone(&self) -> Self {
+        PiecewiseAligner::new(self.scores, self.k, self.bandwidth)
     }
 }
 
 impl PiecewiseAligner {
-    pub fn new(scores: Scores, k: usize, xdrop: i32) -> Self {
-        let gaps = Gaps {
-            open: -(scores.gap_open as i8),
-            extend: -(scores.gap_extend as i8),
-        };
-        let matrix = NucMatrix::new_simple(scores.match_ as i8, -(scores.mismatch as i8));
+    pub fn new(scores: Scores, k: usize, bandwidth: usize) -> Self {
         PiecewiseAligner {
             scores,
             k,
-            gaps,
-            matrix,
-            xdrop,
-        }
-    }
-
-    /// Performs a global alignment between two sequences.
-    ///
-    /// The alignment uses the blockaligner crate with block sizes
-    /// determined based on the largest length of the 2 sequences.
-    ///
-    /// # Parameters
-    ///
-    /// * `query` - The query sequence as a byte slice
-    /// * `reference` - The reference sequence as a byte slice
-    ///
-    /// # Returns
-    ///
-    /// An [`AlignmentResult`] containing:
-    /// - The alignment score
-    /// - Start and end positions in both sequences
-    /// - A CIGAR string representing the alignment operations
-    fn global_alignment(&self, query: &[u8], reference: &[u8]) -> AlignmentResult {
-        if query.is_empty() || reference.is_empty() {
-            return AlignmentResult::default();
-        }
-
-        // Blockaligner block ranges, set to maximum values for full global alignment
-        // Must be powers of 2
-        let max_len = query.len().max(reference.len());
-        let block_size = max_len.next_power_of_two().clamp(32, MAXIMUM_BLOCK_SIZE);
-
-        // Create padded sequences
-        let mut q_padded = PaddedBytes::new::<NucMatrix>(query.len(), block_size);
-        q_padded.set_bytes::<NucMatrix>(query, block_size);
-        let mut r_padded = PaddedBytes::new::<NucMatrix>(reference.len(), block_size);
-        r_padded.set_bytes::<NucMatrix>(reference, block_size);
-
-        // Make a global alignment call with traceback
-        let mut block = Block::<true, false>::new(query.len(), reference.len(), block_size);
-        block.align(
-            &q_padded,
-            &r_padded,
-            &self.matrix,
-            self.gaps,
-            block_size..=block_size,
-            0, // 0 x-drop threshold for global alignment
-        );
-        let res = block.res();
-
-        // Retrieve CIGAR
-        let mut cigar = BlockCigar::new(res.query_idx, res.reference_idx);
-        block.trace().cigar_eq(
-            &q_padded,
-            &r_padded,
-            res.query_idx,
-            res.reference_idx,
-            &mut cigar,
-        );
-
-        AlignmentResult {
-            score: res.score,
-            query_start: 0,
-            query_end: res.query_idx,
-            ref_start: 0,
-            ref_end: res.reference_idx,
-            cigar: build_cigar(&cigar),
-        }
-    }
-
-    /// Performs an alignment with one end fixed and the other allowed to terminate
-    /// early based on the x-drop mode.
-    ///
-    /// This method computes a semi-global alignment where one end of the alignment is
-    /// anchored while the other end can terminate early if the alignment score drops
-    /// too far below the maximum observed score (determined by the x-drop value).
-    ///
-    /// The alignment uses the blockaligner crate with block sizes chosen dynamically
-    /// as 20% of the maximum length of the 2 sequences and 50% of the maximum length
-    /// of the 2 sequences.
-    ///
-    /// # Parameters
-    ///
-    /// * `query` - The query sequence as a byte slice
-    /// * `reference` - The reference sequence as a byte slice
-    /// * `mode` - Controls which end is fixed:
-    ///   - [`XdropMode::GlobalStartLocalEnd`]: Alignment must start at position 0 of
-    ///     both sequences but may end before the last position
-    ///   - [`XdropMode::LocalStartGlobalEnd`]: Alignment must end at the last position
-    ///     of both sequences but may start after position 0. This is implemented by
-    ///     reversing both sequences, aligning them, and transforming the result back
-    ///     to forward coordinates.
-    ///
-    /// # Returns
-    ///
-    /// An [`AlignmentResult`] containing:
-    /// - The alignment score
-    /// - Start and end positions in both sequences
-    /// - A CIGAR string representing the alignment operations
-    fn xdrop_alignment(&self, query: &[u8], reference: &[u8], mode: XdropMode) -> AlignmentResult {
-        if query.is_empty() || reference.is_empty() {
-            return AlignmentResult::default();
-        }
-
-        // Blockaligner block ranges, set to 20% and 50% of longest sequence
-        // Must be powers of 2
-        let max_len = query.len().max(reference.len());
-        let min_size = (max_len / 5)
-            .next_power_of_two()
-            .clamp(32, MAXIMUM_BLOCK_SIZE);
-        let max_size = (max_len / 2)
-            .next_power_of_two()
-            .clamp(128, MAXIMUM_BLOCK_SIZE);
-
-        // Create padded sequences
-        // blockaligner only has a AA profile, no nucleotide profile, so we have to use AA matrix
-        let mut q_padded = PaddedBytes::new::<AAMatrix>(query.len(), max_size);
-        let mut r_padded = PaddedBytes::new::<AAMatrix>(reference.len(), max_size);
-
-        match mode {
-            XdropMode::GlobalStartLocalEnd => {
-                q_padded.set_bytes::<AAMatrix>(query, max_size);
-                r_padded.set_bytes::<AAMatrix>(reference, max_size);
-            }
-            XdropMode::LocalStartGlobalEnd => {
-                q_padded.set_bytes_rev::<AAMatrix>(query, max_size);
-                r_padded.set_bytes_rev::<AAMatrix>(reference, max_size);
-            }
-        }
-
-        // Create profile to align the reference on the query with end bonus
-        // We need to build a position-specific scoring matrix
-        // blockaligner only has a AA profile, no nucleotide profile
-        let profile = make_aa_profile(query, &self.scores, max_size, mode);
-
-        // Make an x-drop alignment call with traceback
-        let mut block = Block::<true, true>::new(reference.len(), query.len(), max_size);
-        block.align_profile(&r_padded, &profile, min_size..=max_size, self.xdrop);
-        let res = block.res();
-
-        // Retrieve CIGAR
-        let mut cigar = BlockCigar::new(res.query_idx, res.reference_idx);
-        block.trace().cigar_eq(
-            &r_padded,
-            &q_padded,
-            res.query_idx,
-            res.reference_idx,
-            &mut cigar,
-        );
-        match mode {
-            XdropMode::GlobalStartLocalEnd => AlignmentResult {
-                score: res.score,
-                query_start: 0,
-                query_end: res.reference_idx,
-                ref_start: 0,
-                ref_end: res.query_idx,
-                cigar: build_cigar_swap_indel(&cigar),
-            },
-            XdropMode::LocalStartGlobalEnd => AlignmentResult {
-                score: res.score,
-                query_start: query.len() - res.reference_idx,
-                query_end: query.len(),
-                ref_start: reference.len() - res.query_idx,
-                ref_end: reference.len(),
-                cigar: build_cigar_reverse_swap_indel(&cigar),
-            },
+            bandwidth,
+            simd_aligner: RefCell::new(SimdAligner::new(scores)),
         }
     }
 
@@ -267,8 +68,11 @@ impl PiecewiseAligner {
                 .saturating_sub(query_part.len() + padding);
             let ref_part = &refseq[ref_start..first_anchor.ref_start];
 
-            let mut pre_align =
-                self.xdrop_alignment(query_part, ref_part, XdropMode::LocalStartGlobalEnd);
+            let mut pre_align = self.simd_aligner.borrow_mut().local_start_alignment(
+                query_part,
+                ref_part,
+                Some(self.bandwidth),
+            );
 
             if pre_align.score == 0 {
                 AlignmentResult {
@@ -335,8 +139,11 @@ impl PiecewiseAligner {
                 .min(last_anchor_ref_end + query_part.len() + padding);
             let ref_part = &refseq[last_anchor_ref_end..ref_end];
 
-            let mut post_align =
-                self.xdrop_alignment(query_part, ref_part, XdropMode::GlobalStartLocalEnd);
+            let mut post_align = self.simd_aligner.borrow_mut().local_end_alignment(
+                query_part,
+                ref_part,
+                Some(self.bandwidth),
+            );
 
             if post_align.score == 0 {
                 AlignmentResult {
@@ -446,7 +253,10 @@ impl PiecewiseAligner {
                     }
                 }
 
-                let aligned = self.global_alignment(query_part, ref_part);
+                let aligned = self
+                    .simd_aligner
+                    .borrow_mut()
+                    .global_alignment(query_part, ref_part, None);
 
                 score += aligned.score;
                 cigar.extend(&aligned.cigar);
@@ -508,119 +318,6 @@ impl PiecewiseAligner {
             None
         }
     }
-}
-
-/// Converts a blockaligner CIGAR string to our internal CIGAR format.
-fn build_cigar(block_cigar: &BlockCigar) -> Cigar {
-    let mut result = Cigar::new();
-
-    for i in 0..block_cigar.len() {
-        let oplen = block_cigar.get(i);
-        let op_code = match oplen.op {
-            Operation::M => CigarOperation::Match,
-            Operation::Eq => CigarOperation::Eq,
-            Operation::X => CigarOperation::X,
-            Operation::I => CigarOperation::Insertion,
-            Operation::D => CigarOperation::Deletion,
-            _ => continue,
-        };
-        result.push(op_code, oplen.len);
-    }
-
-    result
-}
-
-/// Converts a blockaligner CIGAR string to our internal CIGAR format with
-/// insertions and deletions swapped.
-fn build_cigar_swap_indel(block_cigar: &BlockCigar) -> Cigar {
-    let mut result = Cigar::new();
-
-    for i in 0..block_cigar.len() {
-        let oplen = block_cigar.get(i);
-        let op_code = match oplen.op {
-            Operation::M => CigarOperation::Match,
-            Operation::Eq => CigarOperation::Eq,
-            Operation::X => CigarOperation::X,
-            Operation::I => CigarOperation::Deletion, // Swapped
-            Operation::D => CigarOperation::Insertion, // Swapped
-            _ => continue,
-        };
-        result.push(op_code, oplen.len);
-    }
-
-    result
-}
-
-/// Converts a blockaligner CIGAR string to our internal CIGAR format in reverse
-/// order with insertions and deletions swapped.
-fn build_cigar_reverse_swap_indel(block_cigar: &BlockCigar) -> Cigar {
-    let mut result = Cigar::new();
-
-    for i in (0..block_cigar.len()).rev() {
-        let oplen = block_cigar.get(i);
-        let op_code = match oplen.op {
-            Operation::M => CigarOperation::Match,
-            Operation::Eq => CigarOperation::Eq,
-            Operation::X => CigarOperation::X,
-            Operation::I => CigarOperation::Deletion, // Swapped
-            Operation::D => CigarOperation::Insertion, // Swapped
-            _ => continue,
-        };
-        result.push(op_code, oplen.len);
-    }
-
-    result
-}
-
-/// Creates a position-specific scoring matrix (profile) for aligning the reference
-/// against the query with end bonuses.
-///
-/// # Parameters
-///
-/// * `query` - The query sequence to build the profile from
-/// * `scores` - Scoring parameters
-/// * `max_size` - Maximum block size for alignment
-/// * `mode` - Alignment mode determining sequence traversal direction
-///
-/// # Returns
-///
-/// An [`AAProfile`] configured with position-specific scores for each nucleotide
-/// pairing and appropriate end bonuses based on the alignment mode.
-fn make_aa_profile(query: &[u8], scores: &Scores, max_size: usize, mode: XdropMode) -> AAProfile {
-    let mut profile = AAProfile::new(query.len(), max_size, -(scores.gap_extend as i8));
-
-    // Set scores for each nucleotide combination
-    for i in 1..=query.len() {
-        // Select the query character at this position depending on the alignment mode.
-        // `GlobalStartLocalEnd`: traverse the query from start to end (forward).
-        // `LocalStartGlobalEnd`: traverse the query from end to start (reversed).
-        let query_char = match mode {
-            XdropMode::GlobalStartLocalEnd => query[i - 1],
-            XdropMode::LocalStartGlobalEnd => query[query.len() - i],
-        };
-
-        for &c in b"ACGTN" {
-            if c == query_char {
-                profile.set(i, c, scores.match_ as i8);
-            } else {
-                profile.set(i, c, -(scores.mismatch as i8));
-            };
-        }
-    }
-
-    // Set gap costs
-    profile.set_all_gap_open_C(-(scores.gap_open as i8) - -(scores.gap_extend as i8));
-    profile.set_all_gap_close_C(0);
-    profile.set_all_gap_open_R(-(scores.gap_open as i8) - -(scores.gap_extend as i8));
-
-    // Give a bonus score to the end
-    let bonus_pos = query.len();
-    for &c in b"ACGTN" {
-        let current_score = profile.get(bonus_pos, c);
-        profile.set(bonus_pos, c, current_score + scores.end_bonus as i8);
-    }
-
-    profile
 }
 
 /// Removes spurious anchors from a chain of anchor points.
@@ -686,7 +383,7 @@ pub fn remove_spurious_anchors(anchors: &mut Vec<Anchor>) {
 
     // Second pruning:
     // We remove anchors of the ends of the chain if they create any indel.
-    // If they were part of the best scoring path, they should be retireved by the x-drop alignment.
+    // If they were part of the best scoring path, they should be retrieved by the local end/start alignment.
     // the idea is that spurious anchors are much more difficult to detect on the ends of the chain,
     // so we look at a small ratio of anchors and remove any anchors creating deviations.
 
@@ -721,532 +418,6 @@ pub fn remove_spurious_anchors(anchors: &mut Vec<Anchor>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn global_perfect_match() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"AAATTT", b"AAATTT");
-        assert_eq!(result.score, 6 * 2);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 6);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 6);
-        assert_eq!(result.cigar.to_string(), "6=");
-    }
-
-    #[test]
-    fn global_complete_mismatch() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"AAA", b"TTT");
-        assert_eq!(result.score, 3 * -8);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 3);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 3);
-        assert_eq!(result.cigar.to_string(), "3X");
-    }
-
-    #[test]
-    fn global_single_mismatch() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"AAATAA", b"AAAAAA");
-        assert_eq!(result.score, 5 * 2 - 8);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 6);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 6);
-        assert_eq!(result.cigar.to_string(), "3=1X2=");
-    }
-
-    #[test]
-    fn global_gap_in_query() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"AAATTT", b"AAAATTTT");
-        assert_eq!(result.score, 6 * 2 - 12 - 1);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 6);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 8);
-        assert_eq!(result.cigar.to_string(), "3=2D3=");
-    }
-
-    #[test]
-    fn global_gap_in_reference() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"AAAATTTT", b"AAATTT");
-        assert_eq!(result.score, 6 * 2 - 12 - 1,);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 8);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 6);
-        assert_eq!(result.cigar.to_string(), "3=2I3=");
-    }
-
-    #[test]
-    fn global_gap_at_query_start() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"AAATTT", b"TTAAATTT");
-        assert_eq!(result.score, 6 * 2 - 12 - 1);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 6);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 8);
-        assert_eq!(result.cigar.to_string(), "2D6=");
-    }
-
-    #[test]
-    fn global_gap_at_query_end() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"AAATTT", b"AAATTTAA");
-
-        assert_eq!(result.score, 6 * 2 - 12 - 1);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 6);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 8);
-        assert_eq!(result.cigar.to_string(), "6=2D");
-    }
-
-    #[test]
-    fn global_gap_at_reference_start() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"TTAAATTT", b"AAATTT");
-
-        assert_eq!(result.score, 6 * 2 - 12 - 1);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 8);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 6);
-        assert_eq!(result.cigar.to_string(), "2I6=");
-    }
-
-    #[test]
-    fn global_gap_at_reference_end() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"AAATTTAA", b"AAATTT");
-
-        assert_eq!(result.score, 6 * 2 - 12 - 1);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 8);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 6);
-        assert_eq!(result.cigar.to_string(), "6=2I");
-    }
-
-    #[test]
-    fn global_multiple_mismatches() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"ATATATATAT", b"AAAAAAAAAA");
-
-        assert_eq!(result.score, 5 * 2 - 5 * 8);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 10);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 10);
-        assert_eq!(result.cigar.to_string(), "1=1X1=1X1=1X1=1X1=1X");
-    }
-
-    #[test]
-    fn global_complex_alignment() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            0,
-        );
-        let result = aligner.global_alignment(b"AAACTTAAACCTT", b"AAAATTGAAATT");
-        assert_eq!(result.score, 10 * 2 - 8 - 2 * 12 - 1);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 13);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 12);
-        assert_eq!(result.cigar.to_string(), "3=1X2=1D3=2I2=");
-    }
-
-    #[test]
-    fn xdrop_forward_perfect_match() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result = aligner.xdrop_alignment(b"AAATTT", b"AAATTT", XdropMode::GlobalStartLocalEnd);
-        assert_eq!(result.score, 6 * 2 + 10);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 6);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 6);
-        assert_eq!(result.cigar.to_string(), "6=");
-    }
-
-    #[test]
-    fn xdrop_forward_with_mismatch() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result = aligner.xdrop_alignment(b"AAATAA", b"AAAAAA", XdropMode::GlobalStartLocalEnd);
-        assert_eq!(result.score, 5 * 2 - 8 + 10);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 6);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 6);
-        assert_eq!(result.cigar.to_string(), "3=1X2=");
-    }
-
-    #[test]
-    fn xdrop_forward_early_termination() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result = aligner.xdrop_alignment(
-            b"AAAAAAATTTTTTT",
-            b"AAAAAAACCCCCCC",
-            XdropMode::GlobalStartLocalEnd,
-        );
-        assert_eq!(result.score, 7 * 2);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.query_end, 7);
-        assert_eq!(result.ref_end, 7);
-        assert_eq!(result.cigar.to_string(), "7=");
-    }
-
-    #[test]
-    #[allow(clippy::identity_op)]
-    fn xdrop_forward_end_bonus_extends_alignment() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 50,
-            },
-            0,
-            100,
-        );
-        let result =
-            aligner.xdrop_alignment(b"AAAAAAAATT", b"AAAAAAAAAA", XdropMode::GlobalStartLocalEnd);
-        assert_eq!(result.score, 8 * 2 - 8 * 2 + 50);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 10);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 10);
-        assert_eq!(result.cigar.to_string(), "8=2X");
-    }
-
-    #[test]
-    fn xdrop_forward_with_gap() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result =
-            aligner.xdrop_alignment(b"AAAAACCTTT", b"AAAAATTT", XdropMode::GlobalStartLocalEnd);
-        assert_eq!(result.score, 8 * 2 - 12 - 1 + 10);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 10);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 8);
-        assert_eq!(result.cigar.to_string(), "5=2I3=");
-    }
-
-    #[test]
-    fn xdrop_forward_gap_in_reference() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result =
-            aligner.xdrop_alignment(b"AAAAATTT", b"AAAAACCTTT", XdropMode::GlobalStartLocalEnd);
-        assert_eq!(result.score, 8 * 2 - 12 - 1 + 10);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 8);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 10);
-        assert_eq!(result.cigar.to_string(), "5=2D3=");
-    }
-
-    #[test]
-    fn xdrop_reverse_perfect_match() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result = aligner.xdrop_alignment(b"AAATTT", b"AAATTT", XdropMode::LocalStartGlobalEnd);
-        assert_eq!(result.score, 6 * 2 + 10);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 6);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 6);
-        assert_eq!(result.cigar.to_string(), "6=");
-    }
-
-    #[test]
-    fn xdrop_reverse_with_mismatch() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result = aligner.xdrop_alignment(b"AATAAA", b"AAAAAA", XdropMode::LocalStartGlobalEnd);
-        assert_eq!(result.score, 5 * 2 - 8 + 10);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 6);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 6);
-        assert_eq!(result.cigar.to_string(), "2=1X3=");
-    }
-
-    #[test]
-    fn xdrop_reverse_early_termination() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result = aligner.xdrop_alignment(
-            b"TTTTTTTAAAAAAA",
-            b"CCCCCCCAAAAAAA",
-            XdropMode::LocalStartGlobalEnd,
-        );
-        assert_eq!(result.score, 7 * 2);
-        assert_eq!(result.query_start, 7);
-        assert_eq!(result.query_end, 14);
-        assert_eq!(result.ref_start, 7);
-        assert_eq!(result.ref_end, 14);
-        assert_eq!(result.cigar.to_string(), "7=");
-    }
-
-    #[test]
-    #[allow(clippy::identity_op)]
-    fn xdrop_reverse_end_bonus_extends_alignment() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 50,
-            },
-            0,
-            100,
-        );
-        let result =
-            aligner.xdrop_alignment(b"TTAAAAAAAA", b"AAAAAAAAAA", XdropMode::LocalStartGlobalEnd);
-        assert_eq!(result.score, 8 * 2 - 8 * 2 + 50);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 10);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 10);
-        assert_eq!(result.cigar.to_string(), "2X8=");
-    }
-
-    #[test]
-    fn xdrop_reverse_with_gap() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result =
-            aligner.xdrop_alignment(b"TTTCCAAAAA", b"TTTAAAAA", XdropMode::LocalStartGlobalEnd);
-        assert_eq!(result.score, 8 * 2 - 12 - 1 + 10);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 10);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 8);
-        assert_eq!(result.cigar.to_string(), "3=2I5=");
-    }
-
-    #[test]
-    fn xdrop_reverse_gap_in_reference() {
-        let aligner = PiecewiseAligner::new(
-            Scores {
-                match_: 2,
-                mismatch: 8,
-                gap_open: 12,
-                gap_extend: 1,
-                end_bonus: 10,
-            },
-            0,
-            100,
-        );
-        let result =
-            aligner.xdrop_alignment(b"TTTAAAAA", b"TTTCCAAAAA", XdropMode::LocalStartGlobalEnd);
-        assert_eq!(result.score, 8 * 2 - 12 - 1 + 10);
-        assert_eq!(result.query_start, 0);
-        assert_eq!(result.query_end, 8);
-        assert_eq!(result.ref_start, 0);
-        assert_eq!(result.ref_end, 10);
-        assert_eq!(result.cigar.to_string(), "3=2D5=");
-    }
 
     #[test]
     fn remove_spurious_anchors_control() {
@@ -1476,7 +647,7 @@ mod tests {
                 end_bonus: 10,
             },
             5,
-            100,
+            1024,
         );
         let query = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let refseq = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
@@ -1521,7 +692,7 @@ mod tests {
                 end_bonus: 10,
             },
             5,
-            100,
+            1024,
         );
         let query = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let refseq = b"TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT";
@@ -1555,7 +726,7 @@ mod tests {
                 end_bonus: 10,
             },
             5,
-            100,
+            1024,
         );
         let query = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let refseq =
@@ -1613,7 +784,7 @@ mod tests {
                 end_bonus: 10,
             },
             5,
-            100,
+            1024,
         );
         let query = b"CTTTTAAAAATTTTAAAAATGGTTTCAAAAATTCCTAAAAATTTTTCCCCC";
         let refseq = b"TTTTTAAAAATTTTTAAAAATTTTTAAAAATTTTTAAAAATTTTTAAAAA";
@@ -1643,6 +814,6 @@ mod tests {
         assert_eq!(result.query_end, 46);
         assert_eq!(result.ref_start, 0);
         assert_eq!(result.ref_end, 45);
-        assert_eq!(result.cigar.to_string(), "1X13=1D6=2I3=1X7=2X11=");
+        assert_eq!(result.cigar.to_string(), "1X9=1D10=2I3=1X7=2X11=");
     }
 }

--- a/src/simdaligner/aligner.rs
+++ b/src/simdaligner/aligner.rs
@@ -1,0 +1,446 @@
+use super::Scores;
+
+use super::backend::{self, Backend};
+use super::kernel::{U8Probe, fits_u8_lanes};
+use super::{AlignmentResult, SplitReferenceAlignment};
+
+/// The selected kernel, one variant per instruction set this build can reach.
+///
+/// Which variants exist is decided by `cfg`; which one is built is decided at runtime only on
+/// x86_64, where AVX2 is not baseline.
+enum Workspace {
+    #[cfg(target_arch = "x86_64")]
+    Avx2(U8Probe<backend::Avx2>),
+    #[cfg(target_arch = "x86_64")]
+    Sse41(U8Probe<backend::Sse41>),
+    #[cfg(all(
+        target_arch = "aarch64",
+        target_feature = "neon",
+        target_endian = "little"
+    ))]
+    Neon(U8Probe<backend::Neon>),
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    Simd128(U8Probe<backend::Simd128>),
+    Scalar(U8Probe<backend::Scalar>),
+}
+
+/// Pick the fastest kernel this machine can run.
+///
+/// Ordered fastest-first per architecture, with [`backend::Scalar`] as the last resort.
+#[allow(unreachable_code)]
+fn select_backend() -> Workspace {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if backend::Avx2::is_available() {
+            return Workspace::Avx2(U8Probe::new());
+        }
+        if backend::Sse41::is_available() {
+            return Workspace::Sse41(U8Probe::new());
+        }
+    }
+    #[cfg(all(
+        target_arch = "aarch64",
+        target_feature = "neon",
+        target_endian = "little"
+    ))]
+    {
+        return Workspace::Neon(U8Probe::new());
+    }
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    {
+        return Workspace::Simd128(U8Probe::new());
+    }
+
+    Workspace::Scalar(U8Probe::new())
+}
+
+/// Say so, once per process, when the aligner drops to the portable kernel.
+///
+/// Worth logging at all because nothing else would reveal it: the portable kernel gives
+/// identical alignments, just several times slower, which is indistinguishable from a large
+/// workload.
+fn warn_scalar_fallback() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        log::warn!(
+            "no SIMD kernel is available for this CPU ({}); falling back to the portable \
+             scalar kernel, which gives identical alignments several times slower. On \
+             x86_64 this means the CPU lacks both AVX2 and SSE4.1; on wasm32 it means the \
+             build did not enable simd128 (`-C target-feature=+simd128`).",
+            std::env::consts::ARCH
+        );
+    });
+}
+
+/// The two preconditions the kernel cannot check for itself, asserted once per scheme so the
+/// alignment path carries no validation. Shared by every constructor.
+fn validate(scores: Scores) {
+    assert!(
+        scores.gap_open >= scores.gap_extend,
+        "gap_open ({}) must be >= gap_extend ({}): the kernel collapses the open-vs-extend \
+         recurrence on that assumption",
+        scores.gap_open,
+        scores.gap_extend
+    );
+    assert!(
+        fits_u8_lanes(scores.match_, scores.gap_open, scores.gap_extend),
+        "scores do not fit the u8 kernel: match ({}) + 3*gap_open ({}) - gap_extend ({}) \
+         must be <= 255, i.e. gap_open <= ~84 at match=2. Past this an intermediate wraps \
+         and the score comes back better than optimal, silently.",
+        scores.match_,
+        scores.gap_open,
+        scores.gap_extend
+    );
+}
+
+/// Call the same method on whichever kernel was selected.
+///
+/// The body is written once and monomorphized per backend by inference on `$ws`, so dispatch
+/// costs one well-predicted branch per alignment call, not per cell.
+macro_rules! dispatch {
+    ($self:ident, $ws:ident => $body:expr) => {
+        match &mut $self.workspace {
+            #[cfg(target_arch = "x86_64")]
+            Workspace::Avx2($ws) => $body,
+            #[cfg(target_arch = "x86_64")]
+            Workspace::Sse41($ws) => $body,
+            #[cfg(all(
+                target_arch = "aarch64",
+                target_feature = "neon",
+                target_endian = "little"
+            ))]
+            Workspace::Neon($ws) => $body,
+            #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+            Workspace::Simd128($ws) => $body,
+            Workspace::Scalar($ws) => $body,
+        }
+    };
+}
+
+/// A reusable aligner configured with a fixed [`Scores`] scheme.
+pub struct SimdAligner {
+    workspace: Workspace,
+    scores: Scores,
+}
+
+impl Default for SimdAligner {
+    fn default() -> Self {
+        SimdAligner::new(Scores::default())
+    }
+}
+
+impl SimdAligner {
+    /// Builds an aligner for the given scoring scheme.
+    ///
+    /// The scheme is validated and the backend selected here, once per scheme, so that the
+    /// alignment path carries no feature detection and no validation.
+    ///
+    /// # Panics
+    ///
+    /// - If `scores.gap_open < scores.gap_extend`. The kernel collapses the gap-open and
+    ///   gap-extend cases into a single recurrence on that assumption.
+    /// - If `match_ + 3 * gap_open - gap_extend > 255`, i.e. roughly `gap_open > 84` at
+    ///   `match_ = 2`. Beyond that bound an intermediate value exceeds the kernel's 8-bit
+    ///   lanes.
+    pub fn new(scores: Scores) -> Self {
+        validate(scores);
+        let workspace = select_backend();
+        if matches!(workspace, Workspace::Scalar(_)) {
+            warn_scalar_fallback();
+        }
+        SimdAligner { workspace, scores }
+    }
+
+    /// An aligner pinned to the portable kernel, bypassing backend selection. **Tests only.**
+    #[cfg(test)]
+    pub(crate) fn with_scalar_kernel(scores: Scores) -> Self {
+        validate(scores);
+        SimdAligner {
+            workspace: Workspace::Scalar(U8Probe::new()),
+            scores,
+        }
+    }
+
+    /// Whether this build has a **vectorized** kernel for this machine.
+    ///
+    /// A performance question, not an availability one: `false` means [`SimdAligner::new`] falls
+    /// back to the portable kernel, which is correct and slow. It never panics for want of an
+    /// instruction set.
+    pub fn is_supported() -> bool {
+        !matches!(select_backend(), Workspace::Scalar(_))
+    }
+
+    /// The name of the kernel this aligner is using, for diagnostics: `"AVX2"`, `"SSE4.1"`,
+    /// `"NEON"`, `"simd128"` or `"scalar"`.
+    pub fn backend_name(&self) -> &'static str {
+        match &self.workspace {
+            #[cfg(target_arch = "x86_64")]
+            Workspace::Avx2(_) => backend::Avx2::NAME,
+            #[cfg(target_arch = "x86_64")]
+            Workspace::Sse41(_) => backend::Sse41::NAME,
+            #[cfg(all(
+                target_arch = "aarch64",
+                target_feature = "neon",
+                target_endian = "little"
+            ))]
+            Workspace::Neon(_) => backend::Neon::NAME,
+            #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+            Workspace::Simd128(_) => backend::Simd128::NAME,
+            Workspace::Scalar(_) => backend::Scalar::NAME,
+        }
+    }
+
+    /// The scoring scheme this aligner was built with.
+    pub fn scores(&self) -> Scores {
+        self.scores
+    }
+
+    /// Global (end-to-end) alignment: both sequences are aligned in full, and terminal gaps are
+    /// penalised.
+    ///
+    /// `query_start`/`query_end` and `ref_start`/`ref_end` always span the entire inputs.
+    ///
+    /// Empty inputs follow affine-gap semantics: aligning a length-`n` sequence against an empty
+    /// one yields a single length-`n` gap scoring `-(gap_open + (n - 1) * gap_extend)`, and two
+    /// empty inputs yield an empty alignment scoring 0.
+    ///
+    /// # `bandwidth`
+    ///
+    /// Global is the one mode pinned at **both** corners, and `(qlen, rlen)` sits `|qlen - rlen|`
+    /// off the diagonal a band is centred on, so a narrower band contains no path at all and `w`
+    /// is widened to reach it.
+    pub fn global_alignment(
+        &mut self,
+        query: &[u8],
+        reference: &[u8],
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        dispatch!(self, ws => ws.global_alignment(
+            query,
+            reference,
+            self.scores.match_,
+            self.scores.mismatch,
+            self.scores.gap_open,
+            self.scores.gap_extend,
+            bandwidth,
+        ))
+    }
+
+    /// Alignment with a **local reference end**: the query is spanned in full, but the reference
+    /// may end anywhere, and the unaligned reference tail costs nothing.
+    ///
+    /// Formally, the optimum over every end cell `(query.len(), j)` for `j` in
+    /// `0..=reference.len()`. `query_start`/`query_end` span the whole query, `ref_start` is 0,
+    /// and `ref_end` is where the alignment chose to stop: the CIGAR covers exactly
+    /// `reference[..ref_end]` and says nothing about the rest. `j = 0` is a legal end cell, in
+    /// which case the whole reference is the free end gap. Among equally-scoring end cells the
+    /// *smallest* `ref_end` wins.
+    ///
+    /// # `bandwidth`
+    ///
+    /// Anchored at `(0, 0)`, like [`local_end_alignment`](SimdAligner::local_end_alignment), so
+    /// `Some(w)` bounds `ref_end` to `[qlen - w, qlen + w]`. Spanning the query needs
+    /// `w >= qlen - rlen`, and `w` is widened to that where necessary.
+    pub fn local_reference_end_alignment(
+        &mut self,
+        query: &[u8],
+        reference: &[u8],
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        dispatch!(self, ws => ws.local_reference_end_alignment(
+            query,
+            reference,
+            self.scores.match_,
+            self.scores.mismatch,
+            self.scores.gap_open,
+            self.scores.gap_extend,
+            bandwidth,
+        ))
+    }
+
+    /// Alignment with a **local reference start**: the mirror of
+    /// [`local_reference_end_alignment`](SimdAligner::local_reference_end_alignment). The query
+    /// is spanned in full, but the reference may *begin* anywhere, and the unaligned reference
+    /// prefix costs nothing.
+    ///
+    /// Formally, the optimum over every start cell `(0, s)` for `s` in `0..=reference.len()`,
+    /// ending at `(query.len(), reference.len())`. `query_start`/`query_end` span the whole
+    /// query, `ref_end` is always `reference.len()`, and `ref_start` is where the alignment
+    /// chose to begin: the CIGAR covers exactly `reference[ref_start..]`. Among equally-scoring
+    /// start cells the *largest* `ref_start` wins: the shortest reference span, mirroring the
+    /// `_end` variant's rule.
+    ///
+    /// # `bandwidth`
+    ///
+    /// As [`local_reference_end_alignment`](SimdAligner::local_reference_end_alignment),
+    /// **mirrored with the mode**: the band is anchored at the *ends* of the two inputs, where
+    /// this alignment is pinned, and bounds `ref_start` to within `w` of `rlen - qlen`.
+    pub fn local_reference_start_alignment(
+        &mut self,
+        query: &[u8],
+        reference: &[u8],
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        dispatch!(self, ws => ws.local_reference_start_alignment(
+            query,
+            reference,
+            self.scores.match_,
+            self.scores.mismatch,
+            self.scores.gap_open,
+            self.scores.gap_extend,
+            bandwidth,
+        ))
+    }
+
+    /// **Local-end alignment**: both sequences start at 0, and the alignment ends wherever it
+    /// scores best. Both trailing tails (query and reference) are free.
+    ///
+    /// Formally, the optimum over every end cell `(i, j)` of
+    /// `H[i][j] + (if i == query.len() { scores.end_bonus } else { 0 })`. `query_end` and
+    /// `ref_end` are wherever it stopped, and the CIGAR covers exactly `query[..query_end]`
+    /// against `reference[..ref_end]`. Ties go to the longest extension: the largest
+    /// `query_end` wins, then the largest `ref_end`.
+    ///
+    /// `end_bonus` is added only if the alignment covers the whole query, and never enters the
+    /// recurrence; it is applied once, at the end, to choose between the best cell anywhere and
+    /// the best cell that finishes the query. That nudge is the difference between this and
+    /// [`local_reference_end_alignment`](SimdAligner::local_reference_end_alignment).
+    ///
+    /// The CIGAR ends with an insertion only if `end_bonus >= gap_open`, and never with a
+    /// deletion when `gap_open > 0`: a local maximum cannot end in a gap. `ref_end` does not
+    /// advance with a trailing insertion.
+    ///
+    /// # The score is never negative
+    ///
+    /// Cell `(0, 0)` is a legal end cell, so a hopeless extension returns the empty alignment:
+    /// spans `0..0` on both sequences, score 0, empty CIGAR. That is a normal result.
+    ///
+    /// One exception: an **empty query** trivially covers itself, so `(0, 0)` earns `end_bonus`
+    /// and the empty alignment comes back scoring `end_bonus` rather than 0. Don't use
+    /// `score == 0` alone as a "gave up" sentinel unless the query is known non-empty.
+    ///
+    /// # `bandwidth`
+    ///
+    /// Anchored at `(0, 0)`, which is in every band, so `Some(w)` is exactly `w`: this and
+    /// [`local_start_alignment`](SimdAligner::local_start_alignment) are the only two modes
+    /// never widened.
+    pub fn local_end_alignment(
+        &mut self,
+        query: &[u8],
+        reference: &[u8],
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        dispatch!(self, ws => ws.local_end_alignment(
+            query,
+            reference,
+            self.scores.match_,
+            self.scores.mismatch,
+            self.scores.gap_open,
+            self.scores.gap_extend,
+            self.scores.end_bonus,
+            bandwidth,
+        ))
+    }
+
+    /// **Local-start alignment**: the mirror of
+    /// [`local_end_alignment`](SimdAligner::local_end_alignment). Both sequences end at their
+    /// ends, and the alignment *begins* wherever it scores best; both leading prefixes are free.
+    ///
+    /// Formally, the optimum over every start cell `(a, b)` of the best alignment of
+    /// `query[a..]` against `reference[b..]`, plus `end_bonus` if `a == 0`. `query_start` and
+    /// `ref_start` are wherever it began; `query_end` and `ref_end` are always the ends of the
+    /// inputs. Ties go to the longest extension, mirrored: the *smallest* `query_start` wins,
+    /// then the smallest `ref_start`. Likewise a *leading* insertion requires
+    /// `end_bonus >= gap_open`, and with `gap_open > 0` the CIGAR never begins with a deletion.
+    ///
+    /// The score is never negative here either (the start cell
+    /// `(query.len(), reference.len())` is legal and scores 0, at the *end* of both sequences
+    /// rather than the start), and the empty-query exception applies:
+    /// see [`local_end_alignment`](SimdAligner::local_end_alignment).
+    ///
+    /// # `bandwidth`
+    ///
+    /// As [`local_end_alignment`](SimdAligner::local_end_alignment), **mirrored with the mode**:
+    /// the band is anchored at the *ends* of the two inputs, where this alignment is pinned, so
+    /// it constrains start cells to `|(qlen - a) - (rlen - b)| <= w`.
+    pub fn local_start_alignment(
+        &mut self,
+        query: &[u8],
+        reference: &[u8],
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        dispatch!(self, ws => ws.local_start_alignment(
+            query,
+            reference,
+            self.scores.match_,
+            self.scores.mismatch,
+            self.scores.gap_open,
+            self.scores.gap_extend,
+            self.scores.end_bonus,
+            bandwidth,
+        ))
+    }
+
+    /// **Split-reference alignment**: one query aligned across two references, with a single
+    /// jump between them. Built for detecting a tandem duplication that a linear aligner reports
+    /// as an insertion.
+    ///
+    /// The alignment starts at `query[0]` against `right_reference[0]` and ends at the end of
+    /// `left_reference`, jumping once from the right reference to the left. It returns two
+    /// [`AlignmentResult`]s that **partition the query exactly**:
+    ///
+    /// - `right` covers `query[..k]` against a prefix of `right_reference`;
+    /// - `left` covers `query[k..]` against a suffix of `left_reference`;
+    ///
+    /// where `k`, the jump point, is chosen to maximise the total score:
+    ///
+    /// ```text
+    /// score = max over k in 0..=query.len() of  F[k] + G[k]
+    ///   F[k] = the best alignment of query[..k] against any prefix of right_reference
+    ///   G[k] = the best alignment of query[k..] against any suffix of left_reference
+    /// ```
+    ///
+    /// `end_bonus` is ignored: the query is spanned in full by construction.
+    ///
+    /// Total score decides between splits. Among equal totals the **most balanced** wins (the
+    /// smallest `|left.score - right.score|`, since `5 + 5` describes a real duplication and
+    /// `-20 + 30` does not), then the smallest `k`. Each arm's own reference endpoint breaks
+    /// ties the way its one-reference counterpart does.
+    ///
+    /// # The score can be negative, and an arm can be empty
+    ///
+    /// Unlike the local modes there is no "give up" option: the two arms must cover the query,
+    /// so a query that neither reference explains still gets covered, at a cost. `k = 0` and
+    /// `k = query.len()` are legal, leaving one arm spanning the whole query and the other the
+    /// empty alignment; and an arm may consume no reference at all, reporting its query segment
+    /// as one pure insertion with `ref_start == ref_end`.
+    ///
+    /// # `bandwidth`
+    ///
+    /// `Some(w)` is **one band, applied to both arms**, each measured from that arm's own anchor:
+    /// the right arm from `(query[0], right_reference[0])`, the left arm from the ends of `query`
+    /// and `left_reference`. **It does not constrain the jump point**: `k` is still chosen over
+    /// every value the two bands admit.
+    ///
+    /// Both arms must together cover the query, and an arm reaches at most `reflen + w` query
+    /// bases in band, so `w` is widened where necessary to
+    /// `(qlen - left_reference.len() - right_reference.len()) / 2`.
+    pub fn split_reference_alignment(
+        &mut self,
+        query: &[u8],
+        left_reference: &[u8],
+        right_reference: &[u8],
+        bandwidth: Option<usize>,
+    ) -> SplitReferenceAlignment {
+        dispatch!(self, ws => ws.split_reference_alignment(
+            query,
+            left_reference,
+            right_reference,
+            self.scores.match_,
+            self.scores.mismatch,
+            self.scores.gap_open,
+            self.scores.gap_extend,
+            bandwidth,
+        ))
+    }
+}

--- a/src/simdaligner/aligner.rs
+++ b/src/simdaligner/aligner.rs
@@ -72,25 +72,67 @@ fn warn_scalar_fallback() {
     });
 }
 
-/// The two preconditions the kernel cannot check for itself, asserted once per scheme so the
-/// alignment path carries no validation. Shared by every constructor.
+/// Why a scoring scheme cannot be used with the u8 kernel.
+///
+/// The preconditions the kernel cannot check for itself. Take a scheme from user input through
+/// [`check_scores`]; [`SimdAligner::new`] panics on the same conditions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum InvalidScores {
+    #[error(
+        "gap open penalty ({gap_open}) must be at least the gap extension penalty ({gap_extend})"
+    )]
+    GapOpenBelowExtend { gap_open: u8, gap_extend: u8 },
+
+    #[error(
+        "match score ({match_}) + 3 * gap open penalty ({gap_open}) - gap extension penalty \
+         ({gap_extend}) must be at most 255, but is {}; at match score {match_} the gap open \
+         penalty can be at most {}",
+        *match_ as u32 + 3 * *gap_open as u32 - *gap_extend as u32,
+        (255 + *gap_extend as u32 - *match_ as u32) / 3
+    )]
+    ExceedsLanes {
+        match_: u8,
+        gap_open: u8,
+        gap_extend: u8,
+    },
+
+    #[error("end bonus ({end_bonus}) must be at most {}", i32::MAX)]
+    EndBonusTooLarge { end_bonus: u32 },
+}
+
+/// Whether a scheme can be used, as a `Result` rather than a panic.
+///
+/// The rules live here, not at the call sites, so a front end validating user input and
+/// [`SimdAligner::new`] cannot drift apart.
+pub fn check_scores(scores: Scores) -> Result<(), InvalidScores> {
+    if scores.gap_open < scores.gap_extend {
+        return Err(InvalidScores::GapOpenBelowExtend {
+            gap_open: scores.gap_open,
+            gap_extend: scores.gap_extend,
+        });
+    }
+    if !fits_u8_lanes(scores.match_, scores.gap_open, scores.gap_extend) {
+        return Err(InvalidScores::ExceedsLanes {
+            match_: scores.match_,
+            gap_open: scores.gap_open,
+            gap_extend: scores.gap_extend,
+        });
+    }
+    // The kernel adds the bonus as `i32`; past that it wraps negative and silently suppresses
+    // the end extensions.
+    if scores.end_bonus > i32::MAX as u32 {
+        return Err(InvalidScores::EndBonusTooLarge {
+            end_bonus: scores.end_bonus,
+        });
+    }
+    Ok(())
+}
+
+/// Asserted once per scheme, by every constructor, so the alignment path carries no validation.
 fn validate(scores: Scores) {
-    assert!(
-        scores.gap_open >= scores.gap_extend,
-        "gap_open ({}) must be >= gap_extend ({}): the kernel collapses the open-vs-extend \
-         recurrence on that assumption",
-        scores.gap_open,
-        scores.gap_extend
-    );
-    assert!(
-        fits_u8_lanes(scores.match_, scores.gap_open, scores.gap_extend),
-        "scores do not fit the u8 kernel: match ({}) + 3*gap_open ({}) - gap_extend ({}) \
-         must be <= 255, i.e. gap_open <= ~84 at match=2. Past this an intermediate wraps \
-         and the score comes back better than optimal, silently.",
-        scores.match_,
-        scores.gap_open,
-        scores.gap_extend
-    );
+    if let Err(e) = check_scores(scores) {
+        panic!("invalid scoring scheme for the SIMD aligner: {e}");
+    }
 }
 
 /// Call the same method on whichever kernel was selected.
@@ -137,11 +179,8 @@ impl SimdAligner {
     ///
     /// # Panics
     ///
-    /// - If `scores.gap_open < scores.gap_extend`. The kernel collapses the gap-open and
-    ///   gap-extend cases into a single recurrence on that assumption.
-    /// - If `match_ + 3 * gap_open - gap_extend > 255`, i.e. roughly `gap_open > 84` at
-    ///   `match_ = 2`. Beyond that bound an intermediate value exceeds the kernel's 8-bit
-    ///   lanes.
+    /// On any [`InvalidScores`] condition. Use [`check_scores`] instead if the scheme comes from
+    /// user input and the failure should be reported rather than raised.
     pub fn new(scores: Scores) -> Self {
         validate(scores);
         let workspace = select_backend();

--- a/src/simdaligner/backend/mod.rs
+++ b/src/simdaligner/backend/mod.rs
@@ -1,0 +1,225 @@
+//! The SIMD operations the kernel needs, and one implementation per instruction set.
+//!
+//! The kernel in `kernel.rs` is written once, generic over [`Backend`]. A backend supplies two
+//! vector types and 21 operations; everything else (the difference recurrence, the band geometry,
+//! the traceback and the replay) is shared and arch-independent.
+//!
+//! # What a backend has to provide
+//!
+//! Two lane widths, because the kernel runs two things at once:
+//!
+//! - **`V8`, `LANES` lanes of `u8`**: the DP itself. This is the hot loop.
+//! - **`V32`, `LANES32` lanes of `i32`**: the absolute-score reconstruction that rides
+//!   alongside it for the modes that argmax over absolute `H[i][j]`. See `TRACK_ROW_MAX`.
+//!
+//! [`Backend::LANES`] must be exactly `4 * LANES32`, which every real instruction set satisfies
+//! (AVX2: 32 and 8; SSE4.1/NEON/simd128: 16 and 4). The kernel's `nm` packing writes four
+//! `LANES32`-lane groups into one `u32` per chunk and relies on it; [`AssertLaneRatio`] pins
+//! it at compile time.
+//!
+//! # The two contracts that are easy to get wrong
+//!
+//! **Comparisons return an all-ones/all-zeros lane mask** (`0xFF` per byte for [`Backend::eq8`],
+//! `0xFFFF_FFFF` per lane for [`Backend::eq32`]/[`Backend::gt32`]), not `1`. The kernel feeds
+//! these to [`Backend::and8`]/[`Backend::or8`] and to the movemasks, both of which assume a
+//! saturated mask.
+//!
+//! **The movemasks put lane `i` in bit `i`**, and take each lane's *most significant* bit.
+//! `arg_for_row` and `replay` decode these bits by lane index, so a backend that packed them in
+//! the other order would produce a silently wrong CIGAR under a right score.
+//!
+//! # `LANES` is not fixed at 32
+//!
+//! The traceback words stay `u32` on every backend: a 16-lane backend leaves the upper 16 bits of
+//! each word unused rather than repacking. That wastes half of `tb`/`nm` on 128-bit targets and is
+//! deliberate: it keeps one flag format across every arch, so `replay` and `arg_for_row` are
+//! genuinely shared code rather than four near-copies.
+
+use std::marker::PhantomData;
+
+use super::kernel::U8Probe;
+
+#[cfg(test)]
+mod tests;
+
+pub mod scalar;
+pub use scalar::Scalar;
+
+#[cfg(target_arch = "x86_64")]
+pub mod x86;
+#[cfg(target_arch = "x86_64")]
+pub use x86::{Avx2, Sse41};
+
+#[cfg(all(
+    target_arch = "aarch64",
+    target_feature = "neon",
+    target_endian = "little"
+))]
+pub mod neon;
+#[cfg(all(
+    target_arch = "aarch64",
+    target_feature = "neon",
+    target_endian = "little"
+))]
+pub use neon::Neon;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+pub mod wasm;
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+pub use wasm::Simd128;
+
+/// Compile-time check that a backend's two lane counts are in the ratio the kernel's `nm`
+/// packing assumes. Instantiate it once per backend.
+///
+/// Being a post-monomorphization const error, it surfaces at codegen: `cargo build` and
+/// `cargo test` report it, `cargo check` does not. The runtime assertions in `U8Probe::new` and
+/// in the backend conformance tests are the backstop.
+pub struct AssertLaneRatio<B: Backend>(PhantomData<B>);
+
+impl<B: Backend> AssertLaneRatio<B> {
+    pub const CHECK: () = assert!(
+        B::LANES == 4 * B::LANES32,
+        "the kernel packs four LANES32-lane groups into one u32 per chunk, so LANES must be \
+         exactly 4 * LANES32"
+    );
+}
+
+/// One SIMD instruction set, as the kernel uses it.
+///
+/// Every operation is `unsafe`: the loads and stores genuinely are, and the arithmetic is legal
+/// only once the CPU has been checked. The check is carried by [`Backend::fill`], which holds the
+/// `#[target_feature]`, not by the operations themselves.
+///
+/// # Safety
+///
+/// The contract is the same for all 21 operations, so it is stated once here rather than
+/// repeated on each: the CPU must support this backend's instruction set, and pointers must be
+/// valid for `LANES` (or `LANES32`) elements. `fill` states its own, which differs.
+///
+/// Implementations must also uphold the lane-mask and movemask contracts described in the
+/// [module docs](self). A backend that violates them compiles and runs, and produces wrong
+/// alignments.
+#[allow(clippy::missing_safety_doc)]
+pub unsafe trait Backend: Copy + 'static {
+    /// Human-readable name, for the dispatch log line.
+    const NAME: &'static str;
+    /// `u8` lanes per vector. Must equal `4 * LANES32`.
+    const LANES: usize;
+    /// `i32` lanes per vector.
+    const LANES32: usize;
+
+    /// Whether this CPU can actually execute this backend.
+    ///
+    /// Safe to call anywhere, and the single source of truth for selection. `U8Probe::new`
+    /// asserts it, so that naming a kernel for an instruction set the CPU lacks panics rather
+    /// than being undefined behaviour, which it otherwise would be, since the alignment methods
+    /// are safe fns and `U8Probe` is re-exported through `simdaligner::internal`.
+    fn is_available() -> bool;
+
+    /// `LANES` lanes of `u8`.
+    type V8: Copy;
+    /// `LANES32` lanes of `i32`.
+    type V32: Copy;
+
+    // --- u8 lanes: the DP itself ---
+
+    /// Unaligned load of `LANES` bytes. The kernel never aligns its buffers.
+    unsafe fn load8(p: *const u8) -> Self::V8;
+    /// Unaligned store of `LANES` bytes.
+    ///
+    /// Always writes all `LANES` lanes, including on the partial last chunk: the kernel's
+    /// write-ordering hazards are built on that. Never narrow this to a masked store.
+    unsafe fn store8(p: *mut u8, v: Self::V8);
+    /// Broadcast one byte to every lane.
+    unsafe fn splat8(x: u8) -> Self::V8;
+    /// Lanewise **unsigned** max. The whole u8 kernel rests on this being unsigned.
+    unsafe fn max8(a: Self::V8, b: Self::V8) -> Self::V8;
+    /// Lanewise wrapping add. The kernel's values are provably in range, so wrapping vs
+    /// saturating never differs; do not substitute a saturating add, which would change the
+    /// answer if the range invariant were ever broken, and hide it.
+    unsafe fn add8(a: Self::V8, b: Self::V8) -> Self::V8;
+    /// Lanewise wrapping subtract. Same note as [`Backend::add8`].
+    unsafe fn sub8(a: Self::V8, b: Self::V8) -> Self::V8;
+    /// Lanewise equality, returning `0xFF` per equal byte and `0x00` otherwise.
+    unsafe fn eq8(a: Self::V8, b: Self::V8) -> Self::V8;
+    /// Bitwise and.
+    unsafe fn and8(a: Self::V8, b: Self::V8) -> Self::V8;
+    /// Bitwise or.
+    unsafe fn or8(a: Self::V8, b: Self::V8) -> Self::V8;
+    /// Select per lane: `if_true` where `mask` is set, `if_false` where it is clear.
+    ///
+    /// `mask` is always a saturated comparison mask at every call site, so a bit-select and an
+    /// MSB-select are equivalent here.
+    unsafe fn blend8(if_false: Self::V8, if_true: Self::V8, mask: Self::V8) -> Self::V8;
+    /// The MSB of each lane, lane `i` in bit `i`. Bits above `LANES` are zero.
+    unsafe fn movemask8(v: Self::V8) -> u32;
+
+    // --- i32 lanes: the absolute-score reconstruction ---
+
+    /// Unaligned load of `LANES32` `i32`s.
+    unsafe fn load32(p: *const i32) -> Self::V32;
+    /// Unaligned store of `LANES32` `i32`s.
+    unsafe fn store32(p: *mut i32, v: Self::V32);
+    /// Broadcast one `i32` to every lane.
+    unsafe fn splat32(x: i32) -> Self::V32;
+    /// Load `LANES32` **bytes** and zero-extend each to an `i32` lane.
+    ///
+    /// Zero-extension, not sign-extension: the deltas are unsigned and the kernel un-offsets
+    /// them afterwards by subtracting `gap_open`.
+    ///
+    /// **Must not read more than `LANES32` bytes.** The kernel's last group sits flush against
+    /// the end of the delta buffers, so a wider load (`vld1_u8`'s 8 bytes where 4 were asked
+    /// for, say) reads out of bounds. The padding leaves no slack to spare.
+    unsafe fn widen8to32(p: *const u8) -> Self::V32;
+    /// Lanewise wrapping add.
+    unsafe fn add32(a: Self::V32, b: Self::V32) -> Self::V32;
+    /// Lanewise wrapping subtract.
+    unsafe fn sub32(a: Self::V32, b: Self::V32) -> Self::V32;
+    /// Lanewise **signed** max. These are absolute scores and are routinely negative.
+    unsafe fn max32(a: Self::V32, b: Self::V32) -> Self::V32;
+    /// Lanewise equality, returning all-ones per equal lane.
+    unsafe fn eq32(a: Self::V32, b: Self::V32) -> Self::V32;
+    /// Lanewise **signed** greater-than, returning all-ones per lane where `a > b`.
+    unsafe fn gt32(a: Self::V32, b: Self::V32) -> Self::V32;
+    /// The MSB of each lane, lane `i` in bit `i`. Bits above `LANES32` are zero.
+    unsafe fn movemask32(v: Self::V32) -> u32;
+
+    /// Run the kernel's fill with this backend's instruction set enabled.
+    ///
+    /// # Why this exists, and why it is not just a call to `U8Probe::fill_generic`
+    ///
+    /// On x86 the intrinsics need `#[target_feature(enable = "avx2")]`, and a
+    /// `#[target_feature]` function **cannot be inlined into a caller that lacks the feature**.
+    /// Putting the attribute on the 21 operations above would therefore leave 21 real function
+    /// calls per cell. (The obvious fix, `#[inline(always)]` alongside `#[target_feature]`, is
+    /// still unstable: see rust-lang/rust#145574. This crate builds on stable.)
+    ///
+    /// So the feature goes **here** instead, on a trampoline wrapping the entire fill. The
+    /// operations stay plain `#[inline(always)]` functions with no feature of their own, so they
+    /// inline freely into this one and end up inside a function that does have the feature. That
+    /// is one `call` per alignment and none per cell, and it also puts the surrounding scalar
+    /// work under the same target.
+    ///
+    /// # Safety
+    ///
+    /// The CPU must actually support this backend's instruction set. `select_backend` in
+    /// `aligner.rs` is the only caller's source of `Self`, and it detects before it selects.
+    unsafe fn fill<
+        const TRACE: bool,
+        const TRACK_LAST_ROW: bool,
+        const TRACK_ROW_MAX: bool,
+        const ARG_LARGEST: bool,
+        const BANDED: bool,
+    >(
+        probe: &mut U8Probe<Self>,
+        qlen: usize,
+        rlen: usize,
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+        w: usize,
+    ) -> (i32, usize)
+    where
+        Self: Sized;
+}

--- a/src/simdaligner/backend/neon.rs
+++ b/src/simdaligner/backend/neon.rs
@@ -1,0 +1,231 @@
+//! aarch64 NEON, 16 lanes.
+//!
+//! Most of the twenty-one operations are a one-to-one transcription of the AVX2 backend at half
+//! the width. Three are not, and they are the whole of the interesting content of this file: the
+//! two movemasks, which NEON does not have and which are synthesized below, and `widen8to32`,
+//! which must not over-read the delta buffers' padding. `blend8` is also a bit-select rather than
+//! an MSB-select, and agrees only because every mask the kernel passes it is saturated.
+//!
+//! # NEON has no movemask
+//!
+//! `_mm256_movemask_epi8` extracts one bit per lane in a single instruction. NEON has no
+//! equivalent, and the kernel needs it on the hot path: with `TRACE` on (which every alignment
+//! mode compiles), it is four extractions per chunk, plus four more per chunk under
+//! `TRACK_ROW_MAX`.
+//!
+//! [`Neon::movemask8`] synthesizes it in four instructions: an arithmetic shift right by 7 to
+//! turn each lane's MSB into a full `0x00`/`0xFF` mask, an `and` against per-lane bit weights
+//! `1, 2, 4 ... 128` repeated across both halves, and one `addv` per half to sum each half's
+//! weights into a byte. The two bytes are the low and high halves of the 16-bit result.
+//!
+//! The weights repeat every 8 lanes rather than running `1 << i` across all 16 because `addv`
+//! reduces 8 lanes into a `u8`, and `1 + 2 + ... + 128` is exactly 255, the widest sum that
+//! still fits. Splitting into halves is what keeps the reduction in 8-bit lanes; a 16-lane
+//! version would need 16-bit lanes and a wider reduction to hold the same 16 bits.
+//!
+//! The cheaper `shrn`-by-4 trick is not used: it produces a nibble mask, where `arg_for_row`,
+//! `flag_at` and `replay` all decode one bit per lane, so taking it would mean a per-arch flag
+//! layout threaded through all four decoders.
+//!
+//! # Little-endian only
+//!
+//! This backend is gated on `target_endian = "little"`, which excludes `aarch64_be`. Two things
+//! here depend on byte order and it is not obvious they cancel: `widen8to32` reads four bytes as
+//! a scalar `u32` and then reinterprets the vector back to bytes, and big-endian NEON bitcasts
+//! carry an implicit lane reversal. There is no big-endian machine here to test on, and both
+//! reference backends are little-endian, so `aarch64_be` takes the portable kernel instead.
+
+use std::arch::aarch64::*;
+
+use super::Backend;
+use crate::simdaligner::kernel::U8Probe;
+
+/// 16 `u8` lanes on NEON. Baseline on aarch64, so there is nothing to detect.
+#[derive(Clone, Copy)]
+pub struct Neon;
+
+/// Per-lane bit weights for [`Neon::movemask8`], repeating every 8 lanes so that each half sums
+/// to at most 255. See the module docs.
+const LANE_BITS: [u8; 16] = [1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128];
+
+/// Per-lane bit weights for [`Neon::movemask32`].
+const LANE_BITS32: [u32; 4] = [1, 2, 4, 8];
+
+unsafe impl Backend for Neon {
+    const NAME: &'static str = "NEON";
+
+    fn is_available() -> bool {
+        // The module cfg already required NEON; nothing is left to detect.
+        true
+    }
+    const LANES: usize = 16;
+    const LANES32: usize = 4;
+
+    type V8 = uint8x16_t;
+    type V32 = int32x4_t;
+
+    #[inline(always)]
+    unsafe fn load8(p: *const u8) -> Self::V8 {
+        unsafe { vld1q_u8(p) }
+    }
+
+    #[inline(always)]
+    unsafe fn store8(p: *mut u8, v: Self::V8) {
+        unsafe { vst1q_u8(p, v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat8(x: u8) -> Self::V8 {
+        unsafe { vdupq_n_u8(x) }
+    }
+
+    #[inline(always)]
+    unsafe fn max8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { vmaxq_u8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn add8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        // Wrapping, matching `_mm256_add_epi8`. NOT `vqaddq_u8`, which saturates.
+        unsafe { vaddq_u8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn sub8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        // Wrapping, matching `_mm256_sub_epi8`. NOT `vqsubq_u8`.
+        unsafe { vsubq_u8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn eq8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { vceqq_u8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn and8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { vandq_u8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn or8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { vorrq_u8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn blend8(if_false: Self::V8, if_true: Self::V8, mask: Self::V8) -> Self::V8 {
+        // `vbslq_u8` selects per *bit*, where `_mm256_blendv_epi8` selects per lane on the MSB.
+        // Every mask the kernel passes here is a saturated `0x00`/`0xFF` comparison result, so
+        // the two agree. A caller passing a partially-set mask would see them differ.
+        unsafe { vbslq_u8(mask, if_true, if_false) }
+    }
+
+    #[inline(always)]
+    unsafe fn movemask8(v: Self::V8) -> u32 {
+        unsafe {
+            // MSB of each lane -> 0x00 / 0xFF, by arithmetic shift right on signed lanes.
+            let mask = vreinterpretq_u8_s8(vshrq_n_s8(vreinterpretq_s8_u8(v), 7));
+            let bits = vandq_u8(mask, vld1q_u8(LANE_BITS.as_ptr()));
+            // One `addv` per half: each sums to at most 255, so each lands in one byte.
+            let lo = vaddv_u8(vget_low_u8(bits)) as u32;
+            let hi = vaddv_u8(vget_high_u8(bits)) as u32;
+            lo | (hi << 8)
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn load32(p: *const i32) -> Self::V32 {
+        unsafe { vld1q_s32(p) }
+    }
+
+    #[inline(always)]
+    unsafe fn store32(p: *mut i32, v: Self::V32) {
+        unsafe { vst1q_s32(p, v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat32(x: i32) -> Self::V32 {
+        unsafe { vdupq_n_s32(x) }
+    }
+
+    #[inline(always)]
+    unsafe fn widen8to32(p: *const u8) -> Self::V32 {
+        // Read exactly four bytes as a scalar `u32` rather than `vld1_u8`, which would read
+        // eight. The delta buffers are padded by `LANES` (16) past `qlen`, and the group loop's
+        // last group starts at `hi + 3 * LANES32`; an eight-byte read there would reach
+        // `hi + 20`, which is past the padding. Four keeps it inside.
+        let four = unsafe { std::ptr::read_unaligned(p as *const u32) };
+        unsafe {
+            // Broadcast puts the four bytes in both halves; only the low half is widened.
+            let bytes = vreinterpret_u8_u32(vdup_n_u32(four));
+            vreinterpretq_s32_u32(vmovl_u16(vget_low_u16(vmovl_u8(bytes))))
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn add32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { vaddq_s32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn sub32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { vsubq_s32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn max32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { vmaxq_s32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn eq32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { vreinterpretq_s32_u32(vceqq_s32(a, b)) }
+    }
+
+    #[inline(always)]
+    unsafe fn gt32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { vreinterpretq_s32_u32(vcgtq_s32(a, b)) }
+    }
+
+    #[inline(always)]
+    unsafe fn movemask32(v: Self::V32) -> u32 {
+        unsafe {
+            let mask = vreinterpretq_u32_s32(vshrq_n_s32(v, 31));
+            let bits = vandq_u32(mask, vld1q_u32(LANE_BITS32.as_ptr()));
+            // Four weights summing to at most 15: one reduction, no halving needed.
+            vaddvq_u32(bits)
+        }
+    }
+
+    // NEON is baseline on aarch64, so this attribute enables nothing that was not already on.
+    // It is here so the selection stays honest if this is ever built for an aarch64 target
+    // without it, in which case `select_backend`'s `cfg` excludes this backend entirely.
+    #[target_feature(enable = "neon")]
+    unsafe fn fill<
+        const TRACE: bool,
+        const TRACK_LAST_ROW: bool,
+        const TRACK_ROW_MAX: bool,
+        const ARG_LARGEST: bool,
+        const BANDED: bool,
+    >(
+        probe: &mut U8Probe<Self>,
+        qlen: usize,
+        rlen: usize,
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+        w: usize,
+    ) -> (i32, usize) {
+        unsafe {
+            probe.fill_generic::<TRACE, TRACK_LAST_ROW, TRACK_ROW_MAX, ARG_LARGEST, BANDED>(
+                qlen,
+                rlen,
+                match_score,
+                mismatch,
+                gap_open,
+                gap_extend,
+                w,
+            )
+        }
+    }
+}

--- a/src/simdaligner/backend/scalar.rs
+++ b/src/simdaligner/backend/scalar.rs
@@ -1,0 +1,187 @@
+//! The portable fallback: the same kernel, with arrays standing in for vector registers.
+//!
+//! This is **not** an independently-written reference implementation of the DP. It is the exact
+//! same kernel, with `[u8; 16]` where a real backend has a register. So it is a *portability*
+//! fallback, not a correctness oracle: if the shared kernel had a bug, this would reproduce it
+//! faithfully.
+//!
+//! 16 lanes rather than 1, matching the 128-bit backends: the width is what the kernel's chunk
+//! bookkeeping and `nm` packing are parameterized on, so reusing a real width keeps this path on
+//! the same code paths as SSE4.1 and NEON instead of on a degenerate one of its own. LLVM
+//! auto-vectorizes most of these loops anyway, so "scalar" describes the source, not necessarily
+//! the object code.
+
+use super::Backend;
+use crate::simdaligner::kernel::U8Probe;
+
+/// The portable fallback backend. See the [module docs](self).
+#[derive(Clone, Copy)]
+pub struct Scalar;
+
+unsafe impl Backend for Scalar {
+    const NAME: &'static str = "scalar";
+
+    fn is_available() -> bool {
+        // Always. That is what makes it the last resort.
+        true
+    }
+    const LANES: usize = 16;
+    const LANES32: usize = 4;
+
+    type V8 = [u8; 16];
+    type V32 = [i32; 4];
+
+    #[inline(always)]
+    unsafe fn load8(p: *const u8) -> Self::V8 {
+        unsafe { std::ptr::read_unaligned(p as *const [u8; 16]) }
+    }
+
+    #[inline(always)]
+    unsafe fn store8(p: *mut u8, v: Self::V8) {
+        unsafe { std::ptr::write_unaligned(p as *mut [u8; 16], v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat8(x: u8) -> Self::V8 {
+        [x; 16]
+    }
+
+    #[inline(always)]
+    unsafe fn max8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        std::array::from_fn(|i| a[i].max(b[i]))
+    }
+
+    #[inline(always)]
+    unsafe fn add8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        std::array::from_fn(|i| a[i].wrapping_add(b[i]))
+    }
+
+    #[inline(always)]
+    unsafe fn sub8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        std::array::from_fn(|i| a[i].wrapping_sub(b[i]))
+    }
+
+    #[inline(always)]
+    unsafe fn eq8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        std::array::from_fn(|i| if a[i] == b[i] { 0xFF } else { 0 })
+    }
+
+    #[inline(always)]
+    unsafe fn and8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        std::array::from_fn(|i| a[i] & b[i])
+    }
+
+    #[inline(always)]
+    unsafe fn or8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        std::array::from_fn(|i| a[i] | b[i])
+    }
+
+    #[inline(always)]
+    unsafe fn blend8(if_false: Self::V8, if_true: Self::V8, mask: Self::V8) -> Self::V8 {
+        // MSB-select, matching `_mm256_blendv_epi8`. Every call site passes a saturated mask, so
+        // this agrees with a bit-select too.
+        std::array::from_fn(|i| {
+            if mask[i] & 0x80 != 0 {
+                if_true[i]
+            } else {
+                if_false[i]
+            }
+        })
+    }
+
+    #[inline(always)]
+    unsafe fn movemask8(v: Self::V8) -> u32 {
+        let mut m = 0u32;
+        for (i, lane) in v.iter().enumerate() {
+            m |= ((lane >> 7) as u32) << i;
+        }
+        m
+    }
+
+    #[inline(always)]
+    unsafe fn load32(p: *const i32) -> Self::V32 {
+        unsafe { std::ptr::read_unaligned(p as *const [i32; 4]) }
+    }
+
+    #[inline(always)]
+    unsafe fn store32(p: *mut i32, v: Self::V32) {
+        unsafe { std::ptr::write_unaligned(p as *mut [i32; 4], v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat32(x: i32) -> Self::V32 {
+        [x; 4]
+    }
+
+    #[inline(always)]
+    unsafe fn widen8to32(p: *const u8) -> Self::V32 {
+        let b = unsafe { std::ptr::read_unaligned(p as *const [u8; 4]) };
+        std::array::from_fn(|i| b[i] as i32)
+    }
+
+    #[inline(always)]
+    unsafe fn add32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        std::array::from_fn(|i| a[i].wrapping_add(b[i]))
+    }
+
+    #[inline(always)]
+    unsafe fn sub32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        std::array::from_fn(|i| a[i].wrapping_sub(b[i]))
+    }
+
+    #[inline(always)]
+    unsafe fn max32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        std::array::from_fn(|i| a[i].max(b[i]))
+    }
+
+    #[inline(always)]
+    unsafe fn eq32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        std::array::from_fn(|i| if a[i] == b[i] { -1 } else { 0 })
+    }
+
+    #[inline(always)]
+    unsafe fn gt32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        std::array::from_fn(|i| if a[i] > b[i] { -1 } else { 0 })
+    }
+
+    #[inline(always)]
+    unsafe fn movemask32(v: Self::V32) -> u32 {
+        let mut m = 0u32;
+        for (i, lane) in v.iter().enumerate() {
+            m |= (((*lane as u32) >> 31) & 1) << i;
+        }
+        m
+    }
+
+    // No `#[target_feature]`: this backend uses no instruction the base target lacks, which is
+    // the entire point of it. The trampoline is still here because the trait requires it, and
+    // it costs nothing: it is one inlinable call per alignment.
+    unsafe fn fill<
+        const TRACE: bool,
+        const TRACK_LAST_ROW: bool,
+        const TRACK_ROW_MAX: bool,
+        const ARG_LARGEST: bool,
+        const BANDED: bool,
+    >(
+        probe: &mut U8Probe<Self>,
+        qlen: usize,
+        rlen: usize,
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+        w: usize,
+    ) -> (i32, usize) {
+        unsafe {
+            probe.fill_generic::<TRACE, TRACK_LAST_ROW, TRACK_ROW_MAX, ARG_LARGEST, BANDED>(
+                qlen,
+                rlen,
+                match_score,
+                mismatch,
+                gap_open,
+                gap_extend,
+                w,
+            )
+        }
+    }
+}

--- a/src/simdaligner/backend/tests.rs
+++ b/src/simdaligner/backend/tests.rs
@@ -1,0 +1,477 @@
+//! Conformance tests for the backends.
+//!
+//! Two layers, and the split is deliberate because of what can and cannot be run where.
+//!
+//! [`ops`] checks each backend's **21 operations** against a plain-Rust definition of what each
+//! one means, on whatever machine the tests run on. This is the layer that validates a port: run
+//! the suite on an aarch64 box and it checks the NEON transcription instruction by instruction,
+//! including the synthesized movemask, which is the one operation with real logic in it.
+//!
+//! [`differential`] checks that two backends produce **byte-identical alignments** end to end.
+//! On x86_64 that compares AVX2 against SSE4.1 and the portable kernel (32 lanes against 16),
+//! which is what exercises the lane-width bookkeeping: chunk counts, the `nm` packing, and the
+//! band's edge cases. NEON and simd128 are the same 16-lane shape, so a green run here says the
+//! shared half is right for them too, and leaves only their intrinsics to [`ops`].
+//!
+//! Neither layer can substitute for the other, and neither runs NEON on x86. Together they mean
+//! a NEON port is wrong only if a NEON intrinsic does not do what its name says.
+
+use super::*;
+
+/// A deterministic xorshift, so a failure reproduces exactly.
+///
+/// Deliberately not `fastrand`: a test that fails once every few hundred seeds and cannot be
+/// replayed is worse than no test.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+
+    fn byte(&mut self) -> u8 {
+        (self.next() >> 24) as u8
+    }
+
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() >> 16) as usize % n
+    }
+
+    fn dna(&mut self, len: usize) -> Vec<u8> {
+        // Includes bytes outside ACGT on purpose: the unknown-base path is part of the kernel
+        // and has its own scoring rule.
+        const ALPHABET: &[u8] = b"ACGTACGTACGTNU";
+        (0..len)
+            .map(|_| ALPHABET[self.below(ALPHABET.len())])
+            .collect()
+    }
+}
+
+mod ops {
+    use super::*;
+
+    /// Read a `V8` back out as bytes.
+    unsafe fn bytes<B: Backend>(v: B::V8) -> Vec<u8> {
+        let mut out = vec![0u8; B::LANES];
+        unsafe { B::store8(out.as_mut_ptr(), v) };
+        out
+    }
+
+    /// Read a `V32` back out as `i32`s.
+    unsafe fn words<B: Backend>(v: B::V32) -> Vec<i32> {
+        let mut out = vec![0i32; B::LANES32];
+        unsafe { B::store32(out.as_mut_ptr(), v) };
+        out
+    }
+
+    /// Every `u8` operation, against its plain-Rust definition.
+    fn check_u8<B: Backend>() {
+        let mut rng = Rng(0x2545F491_4F6CDD1D);
+        for round in 0..64 {
+            // Round 0 pins the boundary values the random rounds would only hit by luck: 0x00
+            // and 0xFF matter because they are what comparisons produce, and 0x80 matters
+            // because it is the MSB that `movemask8` and `blend8` read.
+            let (a, b): (Vec<u8>, Vec<u8>) = if round == 0 {
+                let pattern = [0u8, 0xFF, 0x80, 0x7F, 1, 254, 128, 127];
+                (
+                    (0..B::LANES).map(|i| pattern[i % pattern.len()]).collect(),
+                    (0..B::LANES)
+                        .map(|i| pattern[(i + 3) % pattern.len()])
+                        .collect(),
+                )
+            } else {
+                // Full-range bytes, with `b` copying every third lane from `a` so that `eq8`
+                // still sees both outcomes in every vector.
+                //
+                // The collisions used to come from masking both to `& 0x0F` instead. That also
+                // forced every MSB to zero, which made `movemask8` return 0 on every random
+                // round and left the bit-order contract (the one thing NEON has to synthesize)
+                // tested only by round 0, whose pattern happens to be a palindrome and so
+                // survives a reversed movemask. Caught by mutating `<< i` to `<< (15 - i)`.
+                let a: Vec<u8> = (0..B::LANES).map(|_| rng.byte()).collect();
+                let b: Vec<u8> = (0..B::LANES)
+                    .enumerate()
+                    .map(|(i, _)| if i % 3 == 0 { a[i] } else { rng.byte() })
+                    .collect();
+                (a, b)
+            };
+
+            unsafe {
+                let va = B::load8(a.as_ptr());
+                let vb = B::load8(b.as_ptr());
+
+                assert_eq!(bytes::<B>(va), a, "{}: load8/store8 round trip", B::NAME);
+
+                let splat = bytes::<B>(B::splat8(0xAB));
+                assert_eq!(splat, vec![0xAB; B::LANES], "{}: splat8", B::NAME);
+
+                let expect: Vec<u8> = (0..B::LANES).map(|i| a[i].max(b[i])).collect();
+                assert_eq!(
+                    bytes::<B>(B::max8(va, vb)),
+                    expect,
+                    "{}: max8 (unsigned)",
+                    B::NAME
+                );
+
+                let expect: Vec<u8> = (0..B::LANES).map(|i| a[i].wrapping_add(b[i])).collect();
+                assert_eq!(
+                    bytes::<B>(B::add8(va, vb)),
+                    expect,
+                    "{}: add8 wraps",
+                    B::NAME
+                );
+
+                let expect: Vec<u8> = (0..B::LANES).map(|i| a[i].wrapping_sub(b[i])).collect();
+                assert_eq!(
+                    bytes::<B>(B::sub8(va, vb)),
+                    expect,
+                    "{}: sub8 wraps",
+                    B::NAME
+                );
+
+                let expect: Vec<u8> = (0..B::LANES)
+                    .map(|i| if a[i] == b[i] { 0xFF } else { 0x00 })
+                    .collect();
+                let eq = B::eq8(va, vb);
+                assert_eq!(
+                    bytes::<B>(eq),
+                    expect,
+                    "{}: eq8 saturates the mask",
+                    B::NAME
+                );
+
+                let expect: Vec<u8> = (0..B::LANES).map(|i| a[i] & b[i]).collect();
+                assert_eq!(bytes::<B>(B::and8(va, vb)), expect, "{}: and8", B::NAME);
+
+                let expect: Vec<u8> = (0..B::LANES).map(|i| a[i] | b[i]).collect();
+                assert_eq!(bytes::<B>(B::or8(va, vb)), expect, "{}: or8", B::NAME);
+
+                // Selection under a saturated mask, which is the only kind the kernel passes.
+                let expect: Vec<u8> = (0..B::LANES)
+                    .map(|i| if a[i] == b[i] { a[i] } else { b[i] })
+                    .collect();
+                assert_eq!(
+                    bytes::<B>(B::blend8(vb, va, eq)),
+                    expect,
+                    "{}: blend8 picks if_true where the mask is set",
+                    B::NAME
+                );
+
+                // The operation with actual logic on NEON. Lane i must land in bit i.
+                let mut expect_mask = 0u32;
+                for (i, lane) in a.iter().enumerate() {
+                    expect_mask |= ((lane >> 7) as u32) << i;
+                }
+                assert_eq!(
+                    B::movemask8(va),
+                    expect_mask,
+                    "{}: movemask8 must take each lane's MSB into bit i (round {round})",
+                    B::NAME
+                );
+            }
+        }
+    }
+
+    /// Every `i32` operation, against its plain-Rust definition.
+    fn check_i32<B: Backend>() {
+        let mut rng = Rng(0x9E3779B9_7F4A7C15);
+        for round in 0..64 {
+            let (a, b): (Vec<i32>, Vec<i32>) = if round == 0 {
+                // Negatives matter: these are absolute scores, and `max32`/`gt32` are signed.
+                let pattern = [0i32, -1, i32::MIN, i32::MAX, -5, 5, -100000, 100000];
+                (
+                    (0..B::LANES32)
+                        .map(|i| pattern[i % pattern.len()])
+                        .collect(),
+                    (0..B::LANES32)
+                        .map(|i| pattern[(i + 2) % pattern.len()])
+                        .collect(),
+                )
+            } else {
+                let a: Vec<i32> = (0..B::LANES32)
+                    .map(|_| (rng.next() as i32) % 1000 - 500)
+                    .collect();
+                let b: Vec<i32> = (0..B::LANES32)
+                    .enumerate()
+                    .map(|(i, _)| {
+                        if i % 3 == 0 {
+                            a[i]
+                        } else {
+                            (rng.next() as i32) % 1000 - 500
+                        }
+                    })
+                    .collect();
+                (a, b)
+            };
+
+            unsafe {
+                let va = B::load32(a.as_ptr());
+                let vb = B::load32(b.as_ptr());
+
+                assert_eq!(words::<B>(va), a, "{}: load32/store32 round trip", B::NAME);
+                assert_eq!(
+                    words::<B>(B::splat32(-77)),
+                    vec![-77; B::LANES32],
+                    "{}: splat32",
+                    B::NAME
+                );
+
+                let expect: Vec<i32> = (0..B::LANES32).map(|i| a[i].wrapping_add(b[i])).collect();
+                assert_eq!(words::<B>(B::add32(va, vb)), expect, "{}: add32", B::NAME);
+
+                let expect: Vec<i32> = (0..B::LANES32).map(|i| a[i].wrapping_sub(b[i])).collect();
+                assert_eq!(words::<B>(B::sub32(va, vb)), expect, "{}: sub32", B::NAME);
+
+                let expect: Vec<i32> = (0..B::LANES32).map(|i| a[i].max(b[i])).collect();
+                assert_eq!(
+                    words::<B>(B::max32(va, vb)),
+                    expect,
+                    "{}: max32 must be SIGNED",
+                    B::NAME
+                );
+
+                let expect: Vec<i32> = (0..B::LANES32)
+                    .map(|i| if a[i] == b[i] { -1 } else { 0 })
+                    .collect();
+                assert_eq!(words::<B>(B::eq32(va, vb)), expect, "{}: eq32", B::NAME);
+
+                let expect: Vec<i32> = (0..B::LANES32)
+                    .map(|i| if a[i] > b[i] { -1 } else { 0 })
+                    .collect();
+                assert_eq!(
+                    words::<B>(B::gt32(va, vb)),
+                    expect,
+                    "{}: gt32 must be SIGNED",
+                    B::NAME
+                );
+
+                let mut expect_mask = 0u32;
+                for (i, lane) in a.iter().enumerate() {
+                    expect_mask |= (((*lane as u32) >> 31) & 1) << i;
+                }
+                assert_eq!(
+                    B::movemask32(va),
+                    expect_mask,
+                    "{}: movemask32 must take each lane's sign bit into bit i (round {round})",
+                    B::NAME
+                );
+
+                // Widening load: `LANES32` bytes, zero-extended.
+                let src: Vec<u8> = (0..B::LANES32 + 8).map(|_| rng.byte()).collect();
+                let expect: Vec<i32> = (0..B::LANES32).map(|i| src[i] as i32).collect();
+                assert_eq!(
+                    words::<B>(B::widen8to32(src.as_ptr())),
+                    expect,
+                    "{}: widen8to32 must ZERO-extend",
+                    B::NAME
+                );
+            }
+        }
+    }
+
+    fn check<B: Backend>() {
+        assert_eq!(
+            B::LANES,
+            4 * B::LANES32,
+            "{}: the nm packing needs LANES == 4 * LANES32",
+            B::NAME
+        );
+        assert!(B::LANES <= 32, "{}: a lane per bit of a u32", B::NAME);
+        check_u8::<B>();
+        check_i32::<B>();
+    }
+
+    #[test]
+    fn scalar_backend_matches_its_definition() {
+        check::<Scalar>();
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_backend_matches_its_definition() {
+        if is_x86_feature_detected!("avx2") {
+            check::<Avx2>();
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn sse41_backend_matches_its_definition() {
+        if is_x86_feature_detected!("sse4.1") {
+            check::<Sse41>();
+        }
+    }
+
+    #[cfg(all(
+        target_arch = "aarch64",
+        target_feature = "neon",
+        target_endian = "little"
+    ))]
+    #[test]
+    fn neon_backend_matches_its_definition() {
+        check::<Neon>();
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    #[test]
+    fn simd128_backend_matches_its_definition() {
+        check::<Simd128>();
+    }
+}
+
+mod differential {
+    use super::*;
+    use crate::simdaligner::kernel::U8Probe;
+
+    /// Run every alignment mode on both backends and require identical results.
+    ///
+    /// Identical, not merely equally-scoring: the tie-break rules are part of the contract, so
+    /// two backends that pick different equally-optimal CIGARs are a bug, not a wash.
+    fn compare<A: Backend, B: Backend>() {
+        let mut rng = Rng(0xDEADBEEF_CAFEF00D);
+        let mut pa = U8Probe::<A>::new();
+        let mut pb = U8Probe::<B>::new();
+
+        // Lengths that straddle a chunk boundary at both widths (16 and 32), so the partial
+        // last chunk, which is where the write-ordering hazards live, is exercised at every
+        // offset rather than only at the ones a round number happens to hit.
+        let lengths = [
+            1usize, 2, 3, 15, 16, 17, 31, 32, 33, 47, 63, 64, 65, 100, 129, 200,
+        ];
+
+        for &qlen in &lengths {
+            for &rlen in &lengths {
+                let q = rng.dna(qlen);
+                let r = rng.dna(rlen);
+                for bandwidth in [None, Some(0), Some(1), Some(8), Some(33)] {
+                    let (m, mm, go, ge, eb) = (2u8, 8u8, 12u8, 1u8, 10u32);
+
+                    macro_rules! same {
+                        ($mode:ident $(, $extra:expr)*) => {
+                            assert_eq!(
+                                pa.$mode(&q, &r, m, mm, go, ge $(, $extra)*, bandwidth),
+                                pb.$mode(&q, &r, m, mm, go, ge $(, $extra)*, bandwidth),
+                                "{} vs {} disagree on {} (qlen={qlen}, rlen={rlen}, band={bandwidth:?})\n\
+                                 query={:?}\nref={:?}",
+                                A::NAME, B::NAME, stringify!($mode),
+                                String::from_utf8_lossy(&q), String::from_utf8_lossy(&r),
+                            );
+                        };
+                    }
+
+                    same!(global_alignment);
+                    same!(local_reference_end_alignment);
+                    same!(local_reference_start_alignment);
+                    same!(local_end_alignment, eb);
+                    same!(local_start_alignment, eb);
+                }
+
+                // Split-reference takes two references, so it gets its own call.
+                let r2 = rng.dna(rlen);
+                for bandwidth in [None, Some(8)] {
+                    assert_eq!(
+                        pa.split_reference_alignment(&q, &r, &r2, 2, 8, 12, 1, bandwidth),
+                        pb.split_reference_alignment(&q, &r, &r2, 2, 8, 12, 1, bandwidth),
+                        "{} vs {} disagree on split_reference_alignment \
+                         (qlen={qlen}, rlen={rlen}, band={bandwidth:?})",
+                        A::NAME,
+                        B::NAME
+                    );
+                }
+            }
+        }
+    }
+
+    /// The load-bearing one on x86: 32 lanes against 16, which is what says the lane-width
+    /// bookkeeping is right before NEON or simd128 depend on it.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_and_sse41_agree() {
+        if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("sse4.1") {
+            compare::<Avx2, Sse41>();
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn avx2_and_the_portable_kernel_agree() {
+        if is_x86_feature_detected!("avx2") {
+            compare::<Avx2, Scalar>();
+        }
+    }
+
+    #[cfg(all(
+        target_arch = "aarch64",
+        target_feature = "neon",
+        target_endian = "little"
+    ))]
+    #[test]
+    fn neon_and_the_portable_kernel_agree() {
+        compare::<Neon, Scalar>();
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    #[test]
+    fn simd128_and_the_portable_kernel_agree() {
+        compare::<Simd128, Scalar>();
+    }
+}
+
+/// The dispatch itself: that a backend is picked, reported honestly, and aligns correctly
+/// whichever one it turned out to be.
+mod selection {
+    use crate::simdaligner::{Scores, SimdAligner};
+
+    #[test]
+    fn the_chosen_backend_is_reported_and_works() {
+        let mut aligner = SimdAligner::new(Scores::default());
+        let name = aligner.backend_name();
+
+        // `is_supported` means "the pick was vectorized", so it must agree with the name.
+        assert_eq!(
+            SimdAligner::is_supported(),
+            name != "scalar",
+            "is_supported disagrees with the backend actually selected ({name})"
+        );
+
+        // Whichever kernel was picked, it still has to align. This is the fallback's contract:
+        // identical answers, not merely a graceful degradation.
+        let r = aligner.global_alignment(b"ACGTACGT", b"ACGTTACGT", None);
+        assert_eq!(
+            r.cigar.to_string(),
+            "3=1D5=",
+            "backend {name} produced a wrong CIGAR"
+        );
+    }
+
+    /// The portable kernel is reachable by name on every machine, whatever was auto-selected,
+    /// and agrees with the selected one through the public API rather than at the `U8Probe`
+    /// level the `differential` suite works at.
+    #[test]
+    fn the_portable_kernel_is_reachable_and_agrees() {
+        let mut scalar = SimdAligner::with_scalar_kernel(Scores::default());
+        assert_eq!(scalar.backend_name(), "scalar");
+
+        let mut selected = SimdAligner::new(Scores::default());
+        for (query, reference) in [
+            (&b"ACGTACGT"[..], &b"ACGTTACGT"[..]),
+            (&b"ACGTACGT"[..], &b"ACGTACGT"[..]),
+            (&b"AACCGGTT"[..], &b"AACCTTGGTT"[..]),
+            (&b""[..], &b"ACGT"[..]),
+        ] {
+            let a = scalar.global_alignment(query, reference, None);
+            let b = selected.global_alignment(query, reference, None);
+            assert_eq!(
+                a,
+                b,
+                "scalar and {} disagree on {:?} vs {:?}",
+                selected.backend_name(),
+                String::from_utf8_lossy(query),
+                String::from_utf8_lossy(reference)
+            );
+        }
+    }
+}

--- a/src/simdaligner/backend/wasm.rs
+++ b/src/simdaligner/backend/wasm.rs
@@ -1,0 +1,186 @@
+//! wasm32 simd128, 16 lanes.
+//!
+//! The easiest of the three ports: simd128 was specified with the x86 and NEON backends of real
+//! codebases in view, and it has a native bitmask (`i8x16_bitmask` and `i32x4_bitmask`, lane
+//! `i` in bit `i`), so unlike NEON there is nothing to synthesize. Every operation is one
+//! intrinsic.
+//!
+//! # This backend is compile-time only
+//!
+//! wasm has no runtime feature detection, so there is no equivalent of the `is_x86_feature_detected!`
+//! that picks between AVX2 and SSE4.1. Either the module is built with simd128 enabled and this
+//! backend exists, or it is not and the aligner falls back to the portable kernel with a
+//! warning. Enable it with:
+//!
+//! ```text
+//! RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-unknown-unknown --release
+//! ```
+//!
+//! The `cfg` on this module *is* the check: see `select_backend` in `aligner.rs`.
+
+use std::arch::wasm32::*;
+
+use super::Backend;
+use crate::simdaligner::kernel::U8Probe;
+
+/// 16 `u8` lanes on wasm simd128.
+#[derive(Clone, Copy)]
+pub struct Simd128;
+
+unsafe impl Backend for Simd128 {
+    const NAME: &'static str = "simd128";
+
+    fn is_available() -> bool {
+        // wasm has no runtime detection; the module cfg IS the check.
+        true
+    }
+    const LANES: usize = 16;
+    const LANES32: usize = 4;
+
+    type V8 = v128;
+    type V32 = v128;
+
+    #[inline(always)]
+    unsafe fn load8(p: *const u8) -> Self::V8 {
+        unsafe { v128_load(p as *const v128) }
+    }
+
+    #[inline(always)]
+    unsafe fn store8(p: *mut u8, v: Self::V8) {
+        unsafe { v128_store(p as *mut v128, v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat8(x: u8) -> Self::V8 {
+        u8x16_splat(x)
+    }
+
+    #[inline(always)]
+    unsafe fn max8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        u8x16_max(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn add8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        // Wrapping. NOT `u8x16_add_sat`.
+        u8x16_add(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn sub8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        // Wrapping. NOT `u8x16_sub_sat`.
+        u8x16_sub(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn eq8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        u8x16_eq(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn and8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        v128_and(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn or8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        v128_or(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn blend8(if_false: Self::V8, if_true: Self::V8, mask: Self::V8) -> Self::V8 {
+        // Bit-select, like NEON's `vbslq_u8`; agrees with x86's MSB-select because every mask
+        // the kernel passes is a saturated comparison result.
+        v128_bitselect(if_true, if_false, mask)
+    }
+
+    #[inline(always)]
+    unsafe fn movemask8(v: Self::V8) -> u32 {
+        // Native, and already lane `i` -> bit `i`.
+        i8x16_bitmask(v) as u32
+    }
+
+    #[inline(always)]
+    unsafe fn load32(p: *const i32) -> Self::V32 {
+        unsafe { v128_load(p as *const v128) }
+    }
+
+    #[inline(always)]
+    unsafe fn store32(p: *mut i32, v: Self::V32) {
+        unsafe { v128_store(p as *mut v128, v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat32(x: i32) -> Self::V32 {
+        i32x4_splat(x)
+    }
+
+    #[inline(always)]
+    unsafe fn widen8to32(p: *const u8) -> Self::V32 {
+        // Four bytes only: see the note in the NEON backend for why a wider load would run past
+        // the delta buffers' padding on the group loop's last group.
+        let four = unsafe { std::ptr::read_unaligned(p as *const u32) };
+        // The splat puts the four bytes in every lane; only the low four are extended.
+        u32x4_extend_low_u16x8(u16x8_extend_low_u8x16(u32x4_splat(four)))
+    }
+
+    #[inline(always)]
+    unsafe fn add32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        i32x4_add(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn sub32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        i32x4_sub(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn max32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        i32x4_max(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn eq32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        i32x4_eq(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn gt32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        i32x4_gt(a, b)
+    }
+
+    #[inline(always)]
+    unsafe fn movemask32(v: Self::V32) -> u32 {
+        i32x4_bitmask(v) as u32
+    }
+
+    #[target_feature(enable = "simd128")]
+    unsafe fn fill<
+        const TRACE: bool,
+        const TRACK_LAST_ROW: bool,
+        const TRACK_ROW_MAX: bool,
+        const ARG_LARGEST: bool,
+        const BANDED: bool,
+    >(
+        probe: &mut U8Probe<Self>,
+        qlen: usize,
+        rlen: usize,
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+        w: usize,
+    ) -> (i32, usize) {
+        unsafe {
+            probe.fill_generic::<TRACE, TRACK_LAST_ROW, TRACK_ROW_MAX, ARG_LARGEST, BANDED>(
+                qlen,
+                rlen,
+                match_score,
+                mismatch,
+                gap_open,
+                gap_extend,
+                w,
+            )
+        }
+    }
+}

--- a/src/simdaligner/backend/x86.rs
+++ b/src/simdaligner/backend/x86.rs
@@ -1,0 +1,333 @@
+//! x86_64 backends: [`Avx2`] at 32 lanes and [`Sse41`] at 16.
+//!
+//! Both are written out longhand rather than through a macro, so that a reviewer checking a port
+//! against the intrinsics reference reads the intrinsic itself.
+//!
+//! # Why SSE4.1 exists
+//!
+//! Not for pre-2013 hardware, but because it is **16 lanes on a machine that also has the
+//! 32-lane kernel**, which makes it the only way to differentially test the `LANES != 32`
+//! bookkeeping (the chunk counts, the `nm` packing, the band's edge cases) on hardware we can
+//! actually run. NEON and simd128 are the same 16-lane shape, so a disagreement there is much
+//! cheaper to diagnose once 16 lanes as such is ruled out. It also removes the hard panic on a
+//! CPU without AVX2.
+//!
+//! # Where `#[target_feature]` is, and is not
+//!
+//! On [`Backend::fill`] alone, and deliberately **not** on the 21 operations; see
+//! [`Backend::fill`] for why. The intrinsics are still `unsafe` to execute on a CPU without the
+//! feature, and `select_backend` in `aligner.rs`, the only thing that names one of these types,
+//! detects first.
+
+use std::arch::x86_64::*;
+
+use super::Backend;
+use crate::simdaligner::kernel::U8Probe;
+
+/// 32 `u8` lanes. The fastest path on any modern x86_64.
+#[derive(Clone, Copy)]
+pub struct Avx2;
+
+unsafe impl Backend for Avx2 {
+    const NAME: &'static str = "AVX2";
+
+    fn is_available() -> bool {
+        is_x86_feature_detected!("avx2")
+    }
+    const LANES: usize = 32;
+    const LANES32: usize = 8;
+
+    type V8 = __m256i;
+    type V32 = __m256i;
+
+    #[inline(always)]
+    unsafe fn load8(p: *const u8) -> Self::V8 {
+        unsafe { _mm256_loadu_si256(p as *const __m256i) }
+    }
+
+    #[inline(always)]
+    unsafe fn store8(p: *mut u8, v: Self::V8) {
+        unsafe { _mm256_storeu_si256(p as *mut __m256i, v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat8(x: u8) -> Self::V8 {
+        unsafe { _mm256_set1_epi8(x as i8) }
+    }
+
+    #[inline(always)]
+    unsafe fn max8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm256_max_epu8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn add8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm256_add_epi8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn sub8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm256_sub_epi8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn eq8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm256_cmpeq_epi8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn and8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm256_and_si256(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn or8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm256_or_si256(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn blend8(if_false: Self::V8, if_true: Self::V8, mask: Self::V8) -> Self::V8 {
+        unsafe { _mm256_blendv_epi8(if_false, if_true, mask) }
+    }
+
+    #[inline(always)]
+    unsafe fn movemask8(v: Self::V8) -> u32 {
+        unsafe { _mm256_movemask_epi8(v) as u32 }
+    }
+
+    #[inline(always)]
+    unsafe fn load32(p: *const i32) -> Self::V32 {
+        unsafe { _mm256_loadu_si256(p as *const __m256i) }
+    }
+
+    #[inline(always)]
+    unsafe fn store32(p: *mut i32, v: Self::V32) {
+        unsafe { _mm256_storeu_si256(p as *mut __m256i, v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat32(x: i32) -> Self::V32 {
+        unsafe { _mm256_set1_epi32(x) }
+    }
+
+    #[inline(always)]
+    unsafe fn widen8to32(p: *const u8) -> Self::V32 {
+        unsafe { _mm256_cvtepu8_epi32(_mm_loadl_epi64(p as *const __m128i)) }
+    }
+
+    #[inline(always)]
+    unsafe fn add32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm256_add_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn sub32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm256_sub_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn max32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm256_max_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn eq32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm256_cmpeq_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn gt32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm256_cmpgt_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn movemask32(v: Self::V32) -> u32 {
+        unsafe { _mm256_movemask_ps(_mm256_castsi256_ps(v)) as u32 }
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn fill<
+        const TRACE: bool,
+        const TRACK_LAST_ROW: bool,
+        const TRACK_ROW_MAX: bool,
+        const ARG_LARGEST: bool,
+        const BANDED: bool,
+    >(
+        probe: &mut U8Probe<Self>,
+        qlen: usize,
+        rlen: usize,
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+        w: usize,
+    ) -> (i32, usize) {
+        unsafe {
+            probe.fill_generic::<TRACE, TRACK_LAST_ROW, TRACK_ROW_MAX, ARG_LARGEST, BANDED>(
+                qlen,
+                rlen,
+                match_score,
+                mismatch,
+                gap_open,
+                gap_extend,
+                w,
+            )
+        }
+    }
+}
+
+/// 16 `u8` lanes. See the module docs for why this is here.
+#[derive(Clone, Copy)]
+pub struct Sse41;
+
+unsafe impl Backend for Sse41 {
+    const NAME: &'static str = "SSE4.1";
+
+    fn is_available() -> bool {
+        is_x86_feature_detected!("sse4.1")
+    }
+    const LANES: usize = 16;
+    const LANES32: usize = 4;
+
+    type V8 = __m128i;
+    type V32 = __m128i;
+
+    #[inline(always)]
+    unsafe fn load8(p: *const u8) -> Self::V8 {
+        unsafe { _mm_loadu_si128(p as *const __m128i) }
+    }
+
+    #[inline(always)]
+    unsafe fn store8(p: *mut u8, v: Self::V8) {
+        unsafe { _mm_storeu_si128(p as *mut __m128i, v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat8(x: u8) -> Self::V8 {
+        unsafe { _mm_set1_epi8(x as i8) }
+    }
+
+    #[inline(always)]
+    unsafe fn max8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm_max_epu8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn add8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm_add_epi8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn sub8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm_sub_epi8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn eq8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm_cmpeq_epi8(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn and8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm_and_si128(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn or8(a: Self::V8, b: Self::V8) -> Self::V8 {
+        unsafe { _mm_or_si128(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn blend8(if_false: Self::V8, if_true: Self::V8, mask: Self::V8) -> Self::V8 {
+        unsafe { _mm_blendv_epi8(if_false, if_true, mask) }
+    }
+
+    #[inline(always)]
+    unsafe fn movemask8(v: Self::V8) -> u32 {
+        unsafe { _mm_movemask_epi8(v) as u32 }
+    }
+
+    #[inline(always)]
+    unsafe fn load32(p: *const i32) -> Self::V32 {
+        unsafe { _mm_loadu_si128(p as *const __m128i) }
+    }
+
+    #[inline(always)]
+    unsafe fn store32(p: *mut i32, v: Self::V32) {
+        unsafe { _mm_storeu_si128(p as *mut __m128i, v) }
+    }
+
+    #[inline(always)]
+    unsafe fn splat32(x: i32) -> Self::V32 {
+        unsafe { _mm_set1_epi32(x) }
+    }
+
+    #[inline(always)]
+    unsafe fn widen8to32(p: *const u8) -> Self::V32 {
+        // Four bytes, not eight: `_mm_cvtepu8_epi32` widens the low four lanes. Read them as a
+        // `u32` so this is one unaligned scalar load rather than a 16-byte load that could run
+        // off the end of the buffer's LANES-byte padding.
+        let four = unsafe { std::ptr::read_unaligned(p as *const u32) };
+        unsafe { _mm_cvtepu8_epi32(_mm_cvtsi32_si128(four as i32)) }
+    }
+
+    #[inline(always)]
+    unsafe fn add32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm_add_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn sub32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm_sub_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn max32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm_max_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn eq32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm_cmpeq_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn gt32(a: Self::V32, b: Self::V32) -> Self::V32 {
+        unsafe { _mm_cmpgt_epi32(a, b) }
+    }
+
+    #[inline(always)]
+    unsafe fn movemask32(v: Self::V32) -> u32 {
+        unsafe { _mm_movemask_ps(_mm_castsi128_ps(v)) as u32 }
+    }
+
+    #[target_feature(enable = "sse4.1")]
+    unsafe fn fill<
+        const TRACE: bool,
+        const TRACK_LAST_ROW: bool,
+        const TRACK_ROW_MAX: bool,
+        const ARG_LARGEST: bool,
+        const BANDED: bool,
+    >(
+        probe: &mut U8Probe<Self>,
+        qlen: usize,
+        rlen: usize,
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+        w: usize,
+    ) -> (i32, usize) {
+        unsafe {
+            probe.fill_generic::<TRACE, TRACK_LAST_ROW, TRACK_ROW_MAX, ARG_LARGEST, BANDED>(
+                qlen,
+                rlen,
+                match_score,
+                mismatch,
+                gap_open,
+                gap_extend,
+                w,
+            )
+        }
+    }
+}

--- a/src/simdaligner/kernel.rs
+++ b/src/simdaligner/kernel.rs
@@ -1,0 +1,2290 @@
+//! The `u8` kernel: the difference recurrence on anti-diagonals, `B::LANES` lanes.
+//!
+//! Generic over [`Backend`], which supplies the vector type and 21 operations. Instantiated at
+//! 32 lanes on AVX2 and 16 on SSE4.1, NEON, wasm simd128 and the portable fallback.
+//!
+//! # Where things are
+//!
+//! A public mode on `U8Probe` picks a band strategy, then goes through one of three wrappers to
+//! the fill and the traceback:
+//!
+//! ```text
+//! pub fn <mode>  ->  align | local | row_pass | split_reference
+//!                        -> prepare     encode both sequences, size the delta buffers
+//!                        -> size_flags  size the tb/nm buffers
+//!                        -> fill_generic  the fill: deltas forward, flags out
+//!                        -> arg_for_row[_banded]   which column won a row (from the nm bits)
+//!                        -> replay      walk the flags back, emit the CIGAR
+//! ```
+//!
+//! See `fill_generic`'s "Which mode compiles which flags" table for what each mode switches on.
+//!
+//! # The difference recurrence
+//!
+//! Rather than storing the DP cells, this stores the **differences between adjacent cells**
+//! (Suzuki & Kasahara 2018, BMC Bioinformatics 19(Suppl 1):45), which are bounded by the
+//! **scoring scheme alone**, with no length term, so they fit `u8` lanes at any sequence length.
+//!
+//! The recurrence is the paper's Eq 3, the *offset* form, in this crate's gap convention
+//! (`go = gap_open - gap_extend`, `ge = gap_extend`, `C = 2*gap_open`, `s_G(x,y) = s(x,y) + C`).
+//! The offset variables fold the constants in so that `ΔE'_G` absorbs `ΔV` and `ΔF'_G` absorbs
+//! `ΔH`, which leaves nothing to add before the maxes and gives a critical path of 4:
+//!
+//! ```text
+//! A_G  [i,j] = max( s_G(a,b), ΔE'_G[i-1,j], ΔF'_G[i,j-1] )
+//! ΔH_G [i,j] = A_G[i,j] - ΔV_G[i-1,j]
+//! ΔV_G [i,j] = A_G[i,j] - ΔH_G[i,j-1]
+//! ΔE'_G[i,j] = max( A_G[i,j], ΔE'_G[i-1,j] + go ) - ΔH_G[i,j-1]
+//! ΔF'_G[i,j] = max( A_G[i,j], ΔF'_G[i,j-1] + go ) - ΔV_G[i-1,j]
+//! ```
+//!
+//! with the boundary `ΔV_G[0,j] = ΔE'_G[0,j] = ΔH_G[i,0] = ΔF'_G[i,0] = 0` at index 1 and `go`
+//! after. Two transcription traps, if comparing against the paper: its gap convention is
+//! `G(k) = G_o + k*G_e` against this crate's `gap_open + (k-1)*gap_extend`, so
+//! `G_o = gap_open - gap_extend`; and its supplement's Eq 19 is sign-flipped against its own Eq 7.
+//!
+//! Everything is unsigned: `0 <= ΔH_G, ΔV_G, ΔE'_G, ΔF'_G <= match + 2*gap_open`. The hard
+//! **zero** lower bound is what permits `u8` lanes with `max_epu8`, leaves the kernel needing no
+//! sentinel, and makes the plain wrapping `B::sub8` safe.
+//!
+//! # Why anti-diagonals, and why there are no shifts
+//!
+//! `ΔE'_G[i,j]` depends on `ΔE'_G[i-1,j]` (same column, previous row), so a column-vectorised
+//! layout has an intra-vector serial dependency. On an anti-diagonal `p = i + j`, `A_G`'s inputs
+//! are:
+//!
+//! ```text
+//! (i,j) needs  ΔV_G[i-1, j]  and ΔE'_G[i-1, j]     <- anti-diagonal p-1, row i-1
+//!              ΔH_G[i, j-1]  and ΔF'_G[i, j-1]     <- anti-diagonal p-1, row i
+//! ```
+//!
+//! **Everything comes from `p-1`, and there is no `p-2` term**: `A_G` *is* the diagonal step, so
+//! the diagonal predecessor is already folded in. Holding each anti-diagonal in a buffer indexed
+//! by **row** makes "row `i-1`" and "row `i`" two `loadu`s one byte apart, so the paper's shifts
+//! are not needed here: the addressing does it.
+//!
+//! Cell `(i, p-i)` reads `query[i-1]`, contiguous in `i`, and `refseq[p-i-1]`, which runs
+//! *backwards* in `i`, so the reference is stored **reversed** and becomes
+//! `ref_rev[rlen + i - p]`, contiguous too. (Group it `rlen + i - p`, never
+//! `rlen - p + i`: the latter underflows a `usize` once the anti-diagonal starts sliding right.)
+//!
+//! # Two hazards
+//!
+//! - **Boundary cells are written after the chunk loop, never before.** A full-width store is
+//!   unconditional, so the partial last chunk scribbles over the row just past the interior,
+//!   which for `p <= qlen` is the `(p, 0)` boundary cell.
+//! - **Garbage lanes need no mask.** Anti-diagonal cells have no cross-lane dependency, so
+//!   garbage stays in its own lane; and anti-diagonal `p` provably reads only rows
+//!   `[lo(p-1), hi(p-1)]`, which `p-1`'s interior and boundary writes cover exactly.
+
+use std::marker::PhantomData;
+
+use super::backend::{AssertLaneRatio, Backend};
+use super::{AlignmentResult, Cigar, CigarOperation, SplitReferenceAlignment};
+
+/// Traceback flag words per chunk: `from_diag`, `from_e`, `e_open`, `f_open`.
+///
+/// **The alignment state is already in the deltas.** `A_G = max(s_G, ΔE'_G[i-1,j], ΔF'_G[i,j-1])`,
+/// so *which operand achieved the max* is the traceback direction; likewise which operand won
+/// `ΔE'_G[i,j] = max(A_G, ΔE'_G[i-1,j] + go) - ΔH_G[i,j-1]` says whether the gap opened or
+/// extended. So every flag is a `B::eq8` against values already in registers, extracted with
+/// `B::movemask8`: **4 bits per cell**, 8 ops per `LANES` cells.
+///
+/// Every flag is an *equality* rather than a `>`, deliberately: AVX2 has no unsigned byte compare
+/// (its `cmpgt_epi8` is signed, and these values can exceed 127 with a large `gap_open`), and
+/// equality does not care about signedness.
+///
+/// # Only three of the four directions are stored
+///
+/// `A_G`'s max has three operands and at least one of them achieves it, so one direction can be
+/// left unstored and recovered as the fallthrough. **Which one is not free to choose: the
+/// inferred direction is the one the replay checks last, and therefore the one it can never
+/// prefer on a tie.** Since the replay prefers the diagonal (see `replay`), `from_diag` is
+/// stored and `from_f` is inferred. (`e_open`/`f_open` are a two-way max, so neither is
+/// inferable from the other; both stay.)
+///
+/// `from_diag` cannot be `cmpeq(A_G, s_G)` on its own; see [`TB_FROM_DIAG`].
+const TB_WORDS: usize = 4;
+
+/// One `u32` of "this cell took its row's max" per chunk: a bit per lane, in the same
+/// `(p, chunk)` coordinates as the traceback flags, so `tb_base[p]` indexes both. See
+/// `U8Probe::nm`.
+const NM_WORDS: usize = 1;
+
+const TB_FROM_E: usize = 0;
+const TB_E_OPEN: usize = 1;
+const TB_F_OPEN: usize = 2;
+/// Did the **diagonal** achieve `A_G`'s max?
+///
+/// `cmpeq(A_G, s_G)` is the obvious answer and it is **wrong for a clamped `s_G`**. Any scheme
+/// with `mismatch > 2*gap_open` makes `s_G(mismatch) = C - mismatch` negative, and a u8 lane
+/// cannot hold that, so the fill clamps it to zero. Clamping is lossless *for the value* (a
+/// negative diagonal loses every max it enters and zero loses just as thoroughly), but **not**
+/// for the flag: `A_G == s_G == 0` then holds while the true diagonal is strictly negative and
+/// the real max came from a gap. Believing that bit takes a path worth `mismatch` points less
+/// than the fill reported: a wrong CIGAR under a right score, which only a test that re-scores
+/// the CIGAR can catch.
+///
+/// The fix: on a clamped scheme the diagonal is masked off at **mismatch cells**, which is
+/// exactly where the clamp bites, using the `q == r` mask the blend already computed. Masking
+/// discards nothing: where `s_G` clamps, the true diagonal is negative while `ΔE'_G`/`ΔF'_G`
+/// are `>= 0`, so at a mismatch cell it provably never wins.
+const TB_FROM_DIAG: usize = 3;
+
+/// The interior row range of anti-diagonal `p`, band included.
+///
+/// A band is the constraint `|i - j| <= w`. On anti-diagonal `p` the cell in row `i` sits at
+/// column `j = p - i`, so `i - j = 2i - p` and the constraint reads
+///
+/// ```text
+/// |2i - p| <= w   <=>   ceil((p - w) / 2) <= i <= floor((p + w) / 2)
+/// ```
+///
+/// which is one more `max` and one more `min` on the range the matrix corners already force. The
+/// strip is `w + 1` rows wide when `p + w` is even and `w` when it is odd: the two bounds
+/// advance on alternating anti-diagonals, since each moves at half of `p`'s rate. So the fill
+/// costs `(qlen + rlen) * (w + 1)` cells instead of `qlen * rlen`.
+///
+/// Returns `(lo, hi)`, inclusive. `lo > hi` means the anti-diagonal has no interior. Unbanded
+/// that happens at `p = 1` and nowhere else for `w >= 1`; **under a band it happens whenever the
+/// strip has run off the end of the query**, which is any `p` past `2 * qlen + w` and is routine
+/// for a short query against a long reference: `band_rows::<true>(10, 3, 100, 1)` is `(5, 3)`.
+/// The fill's `live` flag exists for exactly this case; see its comment before assuming it is
+/// unreachable.
+///
+/// Requires `p >= 1`: `hi` computes `p - 1`.
+#[inline(always)]
+fn band_rows<const BANDED: bool>(p: usize, qlen: usize, rlen: usize, w: usize) -> (usize, usize) {
+    let lo = 1.max(p.saturating_sub(rlen));
+    let hi = qlen.min(p - 1);
+    if BANDED {
+        // `saturating_sub`: `p - w` goes negative for every anti-diagonal before the band's
+        // lower edge lifts off row 0.
+        (lo.max(p.saturating_sub(w).div_ceil(2)), hi.min((p + w) / 2))
+    } else {
+        (lo, hi)
+    }
+}
+
+/// Does a band of `w` reach every cell of a `qlen x rlen` matrix?
+///
+/// The furthest any cell sits from the main diagonal is `max(qlen, rlen)`: the corners
+/// `(qlen, 0)` and `(0, rlen)`. At or past that the band excludes nothing, so the banded optimum
+/// *is* the exact optimum: same candidate set, same tie-breaks, same CIGAR.
+///
+/// Callers then take the exact path, which is also the cheaper one: `global` and the
+/// `local_reference_*` modes read their score off the `anchor` walk instead of running
+/// `TRACK_ROW_MAX`, and the band's per-anti-diagonal bookkeeping is pure waste when the strip
+/// excludes nothing.
+#[inline]
+fn band_reaches_everything(qlen: usize, rlen: usize, w: usize) -> bool {
+    w >= qlen.max(rlen)
+}
+
+/// The query counterpart of [`ref_span`]. Only the `local_*` modes (the ones that let the
+/// query end early) ever pass `consumed != qlen`.
+#[inline]
+fn query_span<const REVERSED: bool>(qlen: usize, consumed: usize) -> (usize, usize) {
+    if REVERSED {
+        (qlen - consumed, qlen)
+    } else {
+        (0, consumed)
+    }
+}
+
+/// Map "how much reference the CIGAR consumed" onto a span of the caller's reference.
+///
+/// Under `REVERSED` the kernel ran on back-to-front codes, so a run of `consumed` bases
+/// starting at the reversed origin is a run *ending* at the forward end. One subtraction, the
+/// only coordinate work `REVERSED` costs.
+#[inline]
+fn ref_span<const REVERSED: bool>(rlen: usize, consumed: usize) -> (usize, usize) {
+    if REVERSED {
+        (rlen - consumed, rlen)
+    } else {
+        (0, consumed)
+    }
+}
+
+/// Does this scoring scheme survive `u8` lanes?
+///
+/// The bound is `M + 3*gap_open - gap_extend`, **not** the `M + 2*gap_open` that bounds the
+/// stored values. The looser rule is a trap: `ΔE'_G`'s recurrence forms `ΔE'_G[i-1,j] + go`
+/// **before** subtracting, and that intermediate is not a stored value, so it is not covered.
+/// It reaches `upper + go`.
+///
+/// Saturating instead of rejecting does not help: a saturating add clamping to 255 makes the
+/// following `max` pick the wrong operand, a wrong answer rather than a caught one.
+///
+/// Note this takes **no lengths**: the bound depends on the scoring scheme alone, so no sequence
+/// is ever too long for it. At default scores it is `2 + 36 - 1 = 37` against a ceiling of 255,
+/// and it holds out to `gap_open ~ 84`.
+pub fn fits_u8_lanes(match_score: u8, gap_open: u8, gap_extend: u8) -> bool {
+    let upper = match_score as i64 + 2 * gap_open as i64;
+    let go = gap_open as i64 - gap_extend as i64;
+    upper + go <= u8::MAX as i64
+}
+
+/// One anti-diagonal's four difference vectors, indexed by row `i`.
+///
+/// Grow-only, and padded by `B::LANES` so the partial last chunk can store all `B::LANES` lanes
+/// without a bounds check.
+#[derive(Default)]
+struct Deltas {
+    dh: Vec<u8>,
+    dv: Vec<u8>,
+    de: Vec<u8>,
+    df: Vec<u8>,
+}
+
+impl Deltas {
+    fn grow(&mut self, rows: usize) {
+        for b in [&mut self.dh, &mut self.dv, &mut self.de, &mut self.df] {
+            if b.len() < rows {
+                b.resize(rows, 0);
+            }
+        }
+    }
+}
+
+/// Reusable scratch, owned by the aligner and reused across calls.
+///
+/// Every buffer here is **grow-only**: sized up when a call needs more and never shrunk, so a
+/// steady stream of similar-sized alignments allocates once.
+pub struct U8Probe<B: Backend> {
+    q_codes: Vec<u8>,
+    r_rev: Vec<u8>,
+    prev: Deltas,
+    cur: Deltas,
+    /// Traceback flags, `TB_WORDS` `u32`s per chunk: **4 bits per cell**, laid out in
+    /// `(p, lane)` coordinates rather than `(i, j)`.
+    ///
+    /// Under a band this stores only the cells actually visited, not the full matrix.
+    tb: Vec<u32>,
+    /// Chunk index at which anti-diagonal `p` starts within `tb`. Anti-diagonals have unequal
+    /// lengths (the ramp at both matrix corners), so a fixed stride would waste ~50%.
+    tb_base: Vec<u32>,
+
+    /// The per-row running **absolute** score: `abs[i] == H[i][p - i]` for the anti-diagonal
+    /// being filled. A reconstruction carried alongside the u8 DP for the modes that argmax over
+    /// absolute scores, so `fits_u8_lanes` is untouched and still has no length term. See
+    /// `TRACK_ROW_MAX` on `fill_generic`.
+    abs: Vec<i32>,
+    /// `row_max[i] == max over j of H[i][j]`.
+    row_max: Vec<i32>,
+
+    /// **Where** each row's maximum was attained, as one bit per cell: set iff that cell took
+    /// its row's running max. One `u32` per chunk, in the same `(p, chunk)` coordinates
+    /// as `tb`, so `tb_base[p]` indexes both.
+    ///
+    /// The argmax is only ever asked about one row, so carrying a winning `j` per row would
+    /// compute one for every row on every anti-diagonal and throw all but one away. The bit is
+    /// enough: `arg_for_row` recovers the row that matters afterwards, scalar and exact. The bit
+    /// *is* the update condition, so the last cell whose bit is set is by construction the cell
+    /// a blend would have left.
+    nm: Vec<u32>,
+    /// Row 0's argmax, which the bit stream cannot carry: row 0 is never *interior* to an
+    /// anti-diagonal (`i_from >= 1` always), so it has no lane and no bit. Maintained scalar in
+    /// the boundary, and load-bearing: with `gap_open == gap_extend == 0` the whole of row 0
+    /// ties at 0 and the longest-extension tie-break has to take the furthest cell.
+    row0_arg: i32,
+
+    /// A second set of flags and row maxima, for `split_reference_alignment` and nothing else.
+    ///
+    /// That mode runs the kernel **twice** (once forward against the right reference, once
+    /// REVERSED against the left) and then replays **both** arms, so both tracebacks have to
+    /// be alive at the same time. Empty for every other mode.
+    tb_b: Vec<u32>,
+    tb_base_b: Vec<u32>,
+    row_max_b: Vec<i32>,
+    nm_b: Vec<u32>,
+    row0_arg_b: i32,
+
+    /// A parameter of `U8Probe` rather than of each method: the traceback's lane bookkeeping
+    /// (`B::LANES`) has to agree with the fill that wrote it, and one type parameter for both is
+    /// what makes that impossible to get wrong.
+    _backend: PhantomData<B>,
+}
+
+/// Hand-written rather than derived: `#[derive(Default)]` would require `B: Default`, and a
+/// backend is a marker type that is never instantiated.
+impl<B: Backend> Default for U8Probe<B> {
+    fn default() -> Self {
+        U8Probe {
+            q_codes: Vec::new(),
+            r_rev: Vec::new(),
+            prev: Deltas::default(),
+            cur: Deltas::default(),
+            tb: Vec::new(),
+            tb_base: Vec::new(),
+            abs: Vec::new(),
+            row_max: Vec::new(),
+            nm: Vec::new(),
+            row0_arg: 0,
+            tb_b: Vec::new(),
+            tb_base_b: Vec::new(),
+            row_max_b: Vec::new(),
+            nm_b: Vec::new(),
+            row0_arg_b: 0,
+            _backend: PhantomData,
+        }
+    }
+}
+
+/// Recover `argmax over j of H[row][j]` from the new-max bit stream.
+///
+/// Takes its buffers explicitly rather than reaching through `self`, because `split_reference`
+/// holds two passes' worth at once and has to say which.
+///
+/// The stream's bit is the fill's `take` mask, so the last cell with the bit set is the one still
+/// holding row `row`'s max when the fill ended. Walking backwards therefore needs no knowledge of
+/// the tie-break: `ARG_LARGEST` makes `take` non-strict, so later ties re-fire the bit and the
+/// last wins; otherwise `take` is strict and the first winner stays.
+///
+/// Row `row` is interior to anti-diagonal `p` exactly for `p` in `[row+1, row+rlen]`, so those
+/// are the only `p` scanned, which is also why the garbage the partial chunk tail writes above
+/// `i_to` is never read: it lands at `p <= row`, below where this starts.
+///
+/// Falling off the bottom means no interior cell ever took the max, so the row's max is still
+/// its column-0 seed: `j = 0`.
+///
+/// The scan is two phases because `lane = row - max(1, p - rlen)` is constant at `row - 1` while
+/// `p <= rlen + 1`, which is most of it.
+fn arg_for_row<B: Backend>(
+    nm: &[u32],
+    tb_base: &[u32],
+    row0_arg: i32,
+    row: usize,
+    rlen: usize,
+) -> usize {
+    // Row 0 has no lane and no bit (`i_from >= 1` always), so it is carried scalar.
+    if row == 0 {
+        return row0_arg as usize;
+    }
+    let word_at = |p: usize, lane: usize| -> bool {
+        // SAFETY: `p <= row + rlen <= qlen + rlen`, which is what `size_flags` sized `tb_base`
+        // to, and `tb_base[p] + lane/B::LANES` is a chunk the fill wrote: `row` is interior to
+        // every `p` this scans (see below), so its lane is one the group loop covered.
+        unsafe {
+            let w = *nm.get_unchecked(*tb_base.get_unchecked(p) as usize + lane / B::LANES);
+            w >> (lane % B::LANES) & 1 != 0
+        }
+    };
+
+    let mut p = row + rlen;
+    // Phase 2: `p > rlen + 1`, so `i_from = p - rlen` and the lane slides with `p`. At most
+    // `qlen` iterations, the ramp off the end of the reference.
+    while p > rlen + 1 && p > row {
+        if word_at(p, row + rlen - p) {
+            return p - row;
+        }
+        p -= 1;
+    }
+    // Phase 1: `i_from == 1`, so the lane is fixed and so is everything derived from it.
+    let lane = row - 1;
+    let off = lane / B::LANES;
+    let bit = 1u32 << (lane % B::LANES);
+    while p > row {
+        // SAFETY: as above.
+        if unsafe { *nm.get_unchecked(*tb_base.get_unchecked(p) as usize + off) } & bit != 0 {
+            return p - row;
+        }
+        p -= 1;
+    }
+    0
+}
+
+/// [`arg_for_row`] under a band: `argmax over j of H[row][j]`, from the same bit stream.
+///
+/// A separate scan rather than a clamp on the other one, because bounding the range here is a
+/// **correctness** requirement, not an optimisation. Row `row` is in band only for `p` in
+/// `[2*row - w, 2*row + w]`. Above that the row sits above the band, `row - lo(p)` goes negative
+/// and the unchecked read lands anywhere; below it the row sits inside the garbage the partial
+/// chunk's tail wrote, and `lane / B::LANES` can walk into the next anti-diagonal's chunks and read
+/// a bit that means something else.
+///
+/// Falling off the bottom returns the row's seed column, which under a band is `row - w`, not 0:
+/// row `row > w` has no column-0 cell and is seeded at its first in-band column by the fill's
+/// band-entry seed. `saturating_sub` covers both cases.
+///
+/// That also disposes of the one garbage bit in the stream. At `p = 2*row - w` the row's `take`
+/// came from a `ΔV` whose left neighbour is outside the band, so the bit means nothing, but the
+/// scan only reaches it after finding no set bit above, which is exactly the case where the
+/// answer is the seed column anyway. Set or clear, it returns `row - w`.
+fn arg_for_row_banded<B: Backend>(
+    nm: &[u32],
+    tb_base: &[u32],
+    row0_arg: i32,
+    row: usize,
+    qlen: usize,
+    rlen: usize,
+    w: usize,
+) -> usize {
+    if row == 0 {
+        return row0_arg as usize;
+    }
+    // Row `row` is interior to `p` for `j = p - row` in `[1, rlen]` and `|2*row - p| <= w`.
+    let p_hi = (row + rlen).min(2 * row + w);
+    let p_lo = (row + 1).max((2 * row).saturating_sub(w));
+
+    let mut p = p_hi;
+    while p >= p_lo {
+        let (lo, _) = band_rows::<true>(p, qlen, rlen, w);
+        let lane = row - lo;
+        // SAFETY: `p` is in `[p_lo, p_hi]`, so `row` is interior to it and `lane` is a lane the
+        // group loop covered; `p <= row + rlen <= qlen + rlen` is what `size_flags` sized
+        // `tb_base` to.
+        let set = unsafe {
+            let word = *nm.get_unchecked(*tb_base.get_unchecked(p) as usize + lane / B::LANES);
+            word >> (lane % B::LANES) & 1 != 0
+        };
+        if set {
+            return p - row;
+        }
+        p -= 1;
+    }
+    row.saturating_sub(w)
+}
+
+/// The alphabet: **A, C, G, T, U**, and one code for everything else.
+///
+/// Codes 0-3 are A/C/G/T, case-insensitive, with `U` folded onto `T`. Code 4 is *unknown*
+/// (every other byte), and it must never match anything, **not even another unknown byte**.
+///
+/// There is no substitution matrix: the scheme is `match` on the diagonal and `-mismatch`
+/// everywhere else, a binary *predicate*, so scoring a cell is one `cmpeq` against codes already
+/// in registers.
+///
+/// The one thing a plain compare cannot express is `unknown != unknown`, because `x == x` is
+/// unavoidably true. Hence the **asymmetry**: [`U8Probe::prepare`] re-encodes unknown to code 5
+/// on the *reference* side only, so the compare says "not equal" and the blend picks
+/// `-mismatch`. See `mod.rs`, "Alphabet".
+fn code(b: u8) -> u8 {
+    match b.to_ascii_uppercase() {
+        b'A' => 0,
+        b'C' => 1,
+        b'G' => 2,
+        b'T' | b'U' => 3,
+        _ => 4,
+    }
+}
+
+impl<B: Backend> U8Probe<B> {
+    pub fn new() -> Self {
+        assert!(
+            B::is_available(),
+            "this CPU cannot execute the {} kernel. `SimdAligner` never selects an unavailable \
+             backend, so reaching this means `U8Probe` was named directly - the alignment \
+             methods are safe fns, so without this check that would be undefined behaviour \
+             rather than a panic.",
+            B::NAME
+        );
+        // Referencing the associated const is what instantiates it; a violation fails the build.
+        let () = AssertLaneRatio::<B>::CHECK;
+        // The same condition again at runtime, because the const above is a
+        // post-monomorphization error and so does not fire under `cargo check`.
+        assert!(
+            B::LANES == 4 * B::LANES32,
+            "backend lane counts must satisfy LANES == 4 * LANES32; got {} and {}",
+            B::LANES,
+            B::LANES32
+        );
+        assert!(
+            B::LANES <= 32,
+            "the traceback packs one lane per bit of a u32 word, so a backend cannot exceed 32 \
+             lanes without widening `tb`/`nm`"
+        );
+        Self::default()
+    }
+
+    /// Check the preconditions, encode both sequences, and size the delta buffers.
+    ///
+    /// Assumes both sequences are non-empty: a zero-length side is one pure gap and never
+    /// reaches the kernel.
+    fn prepare<const REVERSED: bool>(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        match_score: u8,
+        gap_open: u8,
+        gap_extend: u8,
+    ) {
+        assert!(
+            fits_u8_lanes(match_score, gap_open, gap_extend),
+            "scores do not fit u8 lanes"
+        );
+        assert!(gap_open >= gap_extend, "gap_open must be >= gap_extend");
+        // No instruction-set check here: `U8Probe::new` asserted it at construction.
+
+        let (qlen, rlen) = (query.len(), refseq.len());
+
+        // Grow-then-overwrite, not `clear()` + `extend()`: the latter re-checks capacity per
+        // element.
+        //
+        // REVERSED is free, and this is where: the sequences have to be encoded every call
+        // anyway, so a `_start` mode just encodes them **back-to-front** and the kernel never
+        // learns the mode exists. Note the two axes compose: the kernel always wants the
+        // reference laid out backwards relative to the query (that is what makes `refseq[p-i-1]`
+        // a contiguous load), so under REVERSED it is reversed *twice* and comes out forward.
+        if self.q_codes.len() < qlen + B::LANES {
+            self.q_codes.resize(qlen + B::LANES, 4);
+        }
+        if REVERSED {
+            for (dst, &b) in self.q_codes[..qlen].iter_mut().zip(query.iter().rev()) {
+                *dst = code(b);
+            }
+        } else {
+            for (dst, &b) in self.q_codes[..qlen].iter_mut().zip(query) {
+                *dst = code(b);
+            }
+        }
+        self.q_codes[qlen..qlen + B::LANES].fill(4);
+
+        // Code 5 is N on the reference side, the asymmetry that makes `N != N` fall out of
+        // the compare.
+        if self.r_rev.len() < rlen + B::LANES {
+            self.r_rev.resize(rlen + B::LANES, 5);
+        }
+        let enc_r = |b: u8| -> u8 {
+            let c = code(b);
+            if c == 4 { 5 } else { c }
+        };
+        if REVERSED {
+            for (dst, &b) in self.r_rev[..rlen].iter_mut().zip(refseq.iter()) {
+                *dst = enc_r(b);
+            }
+        } else {
+            for (dst, &b) in self.r_rev[..rlen].iter_mut().zip(refseq.iter().rev()) {
+                *dst = enc_r(b);
+            }
+        }
+        self.r_rev[rlen..rlen + B::LANES].fill(5);
+
+        let rows = qlen + 1 + B::LANES;
+        self.prev.grow(rows);
+        self.cur.grow(rows);
+        // Each buffer gets its OWN check. Gating all three on `abs.len()` looks equivalent and
+        // is not: `split_reference` swaps `row_max` with its `_b` twin between its two passes,
+        // so `abs` can already be grown while the row buffers are the empty ones; the check
+        // would not fire and the kernel would write off the end.
+        if self.abs.len() < rows {
+            self.abs.resize(rows, 0);
+        }
+        if self.row_max.len() < rows {
+            self.row_max.resize(rows, 0);
+        }
+    }
+
+    /// Global alignment: both sequences spanned end to end.
+    #[allow(clippy::too_many_arguments)] // a kernel entry point: the scheme plus the bandwidth
+    pub fn global_alignment(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        m: u8,
+        mm: u8,
+        go: u8,
+        ge: u8,
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        match bandwidth {
+            // A band that reaches every cell is the exact mode, and the exact mode is cheaper;
+            // see `band_reaches_everything`.
+            Some(w) if !band_reaches_everything(query.len(), refseq.len(), w) => {
+                self.global_banded(query, refseq, m, mm, go, ge, w)
+            }
+            _ => self.align::<false, false>(query, refseq, m, mm, go, ge),
+        }
+    }
+
+    /// The banded `global` path: `S[qlen][rlen]`, confined to `|i - j| <= w`.
+    ///
+    /// # Widening: global is pinned at both corners
+    ///
+    /// Every other mode has one anchor and lets the far end float, so `|i-j| <= w` is a statement
+    /// about drift away from that anchor and any `w` is meaningful. Global must also *arrive* at
+    /// `(qlen, rlen)`, which sits `|qlen - rlen|` off the diagonal the band is centred on. A
+    /// narrower band does not contain a bad alignment, it contains **no path at all**:
+    /// `band_rows` returns `lo > hi` for the final anti-diagonal and the corner is never
+    /// computed. Hence the widening to `|qlen - rlen|`, the narrowest diagonal band that still
+    /// joins the two corners.
+    ///
+    /// # The score comes from `abs`, not `anchor`
+    ///
+    /// `align`'s `anchor` walk cannot survive a band; see [`U8Probe::local_reference`]. But
+    /// `TRACK_ROW_MAX` already maintains `abs[i]`, the running **absolute** score of row `i`'s
+    /// cell on the current anti-diagonal. Row `qlen` is live for `p` up to `qlen + rlen`, and the
+    /// widening guarantees it is still in band there, so when the fill returns `abs[qlen]` *is*
+    /// `S[qlen][rlen]`. The end cell is read, not recomputed.
+    #[allow(clippy::too_many_arguments)] // ditto, plus the bandwidth
+    fn global_banded(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        m: u8,
+        mm: u8,
+        go: u8,
+        ge: u8,
+        w: usize,
+    ) -> AlignmentResult {
+        let (qlen, rlen) = (query.len(), refseq.len());
+        // Band-independent given the widening below: with one side empty the only path is the
+        // single gap `degenerate` returns, and `w >= |qlen - rlen|` is exactly wide enough to
+        // hold it.
+        if qlen == 0 || rlen == 0 {
+            return self.degenerate::<false, false>(qlen, rlen, go, ge);
+        }
+        let w = w.max(1).max(qlen.abs_diff(rlen));
+
+        self.row_pass::<false, true>(query, refseq, m, mm, go, ge, w);
+
+        // `abs[qlen]` after the fill is `S[qlen][rlen]`; see this function's docs. The widening
+        // is what puts the corner in band, and so what makes this read meaningful.
+        debug_assert!(
+            qlen.abs_diff(rlen) <= w,
+            "the widening should have put the corner in band"
+        );
+        let score = self.abs[qlen];
+
+        let cigar = self.replay::<false, true>(query, refseq, qlen, rlen, w);
+        AlignmentResult {
+            score,
+            query_start: 0,
+            query_end: qlen,
+            ref_start: 0,
+            ref_end: rlen,
+            cigar,
+        }
+    }
+
+    /// The query is spanned in full; the **reference may stop anywhere**, and its trailing
+    /// tail is free and does not appear in the CIGAR.
+    ///
+    /// `j = 0` is a legal end cell and sometimes the winning one. Ties resolve to the
+    /// **smallest** `ref_end`.
+    #[allow(clippy::too_many_arguments)] // a kernel entry point: the scheme plus the bandwidth
+    pub fn local_reference_end_alignment(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        m: u8,
+        mm: u8,
+        go: u8,
+        ge: u8,
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        match bandwidth {
+            Some(w) if !band_reaches_everything(query.len(), refseq.len(), w) => {
+                self.local_reference::<false>(query, refseq, m, mm, go, ge, w)
+            }
+            _ => self.align::<true, false>(query, refseq, m, mm, go, ge),
+        }
+    }
+
+    /// The mirror: the reference may **begin** anywhere and its leading prefix is free.
+    ///
+    /// This is `local_reference_end_alignment` on reversed inputs, and that is exact rather than
+    /// an approximation: affine gap costs are symmetric under reversal, and so is literal byte
+    /// identity. Ties resolve to the **largest** `ref_start`.
+    #[allow(clippy::too_many_arguments)] // a kernel entry point: the scheme plus the bandwidth
+    pub fn local_reference_start_alignment(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        m: u8,
+        mm: u8,
+        go: u8,
+        ge: u8,
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        match bandwidth {
+            Some(w) if !band_reaches_everything(query.len(), refseq.len(), w) => {
+                self.local_reference::<true>(query, refseq, m, mm, go, ge, w)
+            }
+            _ => self.align::<true, true>(query, refseq, m, mm, go, ge),
+        }
+    }
+
+    /// The banded `local_reference_*` path: `max over j of H[qlen][j]`, confined to `|i-j| <= w`.
+    ///
+    /// # Why not `align` with `BANDED` switched on
+    ///
+    /// `align` does not read its score out of the fill. It walks `anchor`, a closed-form
+    /// recurrence along row `qlen` that reads `ΔV[qlen]` on **every** anti-diagonal past `qlen`,
+    /// and row `qlen` is a horizontal line while the band is a diagonal strip, so the two meet on
+    /// only `O(w)` of those; under a band the rest of that walk reads lanes the fill never
+    /// wrote. That is why `BANDED` and `TRACK_LAST_ROW` are never compiled together.
+    ///
+    /// `TRACK_ROW_MAX` is the way in: it carries **absolute** per-cell scores, it is already
+    /// banded, and `row_max[qlen]` *is* this mode's objective. It costs a `row_max` store and a
+    /// bit of the new-max stream per chunk, which is why `None` still takes `align`.
+    #[allow(clippy::too_many_arguments)] // ditto, plus the bandwidth
+    fn local_reference<const REVERSED: bool>(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        m: u8,
+        mm: u8,
+        go: u8,
+        ge: u8,
+        w: usize,
+    ) -> AlignmentResult {
+        let (qlen, rlen) = (query.len(), refseq.len());
+        // Band-independent: see the widening below, which always admits the whole of the one
+        // live row or column these cases consist of.
+        if qlen == 0 || rlen == 0 {
+            return self.degenerate::<true, REVERSED>(qlen, rlen, go, ge);
+        }
+
+        // The widening. This mode must span the query, so it must reach a cell `(qlen, j)` with
+        // `j <= rlen`; in band that needs `qlen - w <= rlen`. Below that the band contains no
+        // alignment at all (not a bad one, *none*), so `Some(w)` is honoured as "at least w",
+        // and widened to the narrowest band that has an answer.
+        let w = w.max(1).max(qlen.saturating_sub(rlen));
+
+        self.row_pass::<REVERSED, true>(query, refseq, m, mm, go, ge, w);
+
+        // `last_row == min(qlen, rlen + w) == qlen` after the widening, so row `qlen` is filled
+        // and this read is in bounds; that is what the widening is for.
+        debug_assert!(
+            qlen <= rlen + w,
+            "the widening should have made row qlen reachable"
+        );
+        let score = self.row_max[qlen];
+        // `ARG_LARGEST = false` in `row_pass`, so ties give the smallest `j` (this mode's rule).
+        let j =
+            arg_for_row_banded::<B>(&self.nm, &self.tb_base, self.row0_arg, qlen, qlen, rlen, w);
+        debug_assert!(
+            qlen.abs_diff(j) <= w,
+            "the reduce picked ({qlen}, {j}), which is outside the band of {w}"
+        );
+
+        let cigar = self.replay::<REVERSED, true>(query, refseq, qlen, j, w);
+        let (ref_start, ref_end) = ref_span::<REVERSED>(rlen, j);
+        AlignmentResult {
+            score,
+            query_start: 0,
+            query_end: qlen,
+            ref_start,
+            ref_end,
+            cigar,
+        }
+    }
+
+    /// Ends wherever it scores best: `max over (i, j) of H[i][j] + (end_bonus if i == qlen)`.
+    ///
+    /// Cell `(0,0)` is a legal end cell, so **the score is never negative**: a hopeless
+    /// extension returns the empty alignment (spans `0..0`, score 0, empty CIGAR).
+    ///
+    /// `end_bonus` never enters the DP. It is applied once, at the end, to choose between "the
+    /// best cell anywhere" and "the best cell that finishes the query". Ties resolve to the
+    /// **longest extension**: largest `query_end`, then largest `ref_end`.
+    #[allow(clippy::too_many_arguments)] // a kernel entry point: the scheme is five scalars
+    pub fn local_end_alignment(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        m: u8,
+        mm: u8,
+        go: u8,
+        ge: u8,
+        end_bonus: u32,
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        match bandwidth {
+            Some(w) if !band_reaches_everything(query.len(), refseq.len(), w.max(1)) => {
+                self.local::<false, true>(query, refseq, m, mm, go, ge, end_bonus, w.max(1))
+            }
+            _ => self.local::<false, false>(query, refseq, m, mm, go, ge, end_bonus, 0),
+        }
+    }
+
+    /// The mirror: begins wherever it scores best, both leading prefixes free.
+    ///
+    /// Its empty alignment sits at the *end* of both sequences (`qlen..qlen`, `rlen..rlen`),
+    /// the mirror of `local_end`'s, which sits at the start. Tie-break mirrored too: the
+    /// **smallest** `query_start`, then the smallest `ref_start`.
+    #[allow(clippy::too_many_arguments)] // a kernel entry point: the scheme is five scalars
+    pub fn local_start_alignment(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        m: u8,
+        mm: u8,
+        go: u8,
+        ge: u8,
+        end_bonus: u32,
+        bandwidth: Option<usize>,
+    ) -> AlignmentResult {
+        match bandwidth {
+            Some(w) if !band_reaches_everything(query.len(), refseq.len(), w.max(1)) => {
+                self.local::<true, true>(query, refseq, m, mm, go, ge, end_bonus, w.max(1))
+            }
+            _ => self.local::<true, false>(query, refseq, m, mm, go, ge, end_bonus, 0),
+        }
+    }
+
+    /// `w` is read only when `BANDED`, and is the caller's bandwidth already clamped to
+    /// `>= 1`: a zero-width band is not meaningful, so callers clamp rather than pass it on.
+    #[allow(clippy::too_many_arguments)] // ditto, plus the bandwidth
+    fn local<const REVERSED: bool, const BANDED: bool>(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+        end_bonus: u32,
+        w: usize,
+    ) -> AlignmentResult {
+        let (qlen, rlen) = (query.len(), refseq.len());
+        // A zero-length side skips the kernel, but it is NOT simply "the empty alignment":
+        //
+        //  * with `qlen == 0`, EVERY cell has `i == qlen`, so `end_bonus` applies to all of
+        //    them. The empty alignment scores `end_bonus`, not 0.
+        //  * with free gaps (`gap_open == gap_extend == 0`) the whole boundary row/column ties
+        //    at 0, and the longest-extension tie-break must then take the FURTHEST cell, not
+        //    the origin.
+        //
+        // So scan the one live row or column in closed form.
+        if qlen == 0 || rlen == 0 {
+            let gap = |k: usize| -> i32 {
+                if k == 0 {
+                    0
+                } else {
+                    -(gap_open as i32) - (k as i32 - 1) * gap_extend as i32
+                }
+            };
+            // The band reaches the live row/column too: `H[0][j]` sits `j` off the diagonal, so
+            // a band of `w` can only see the first `w` of it. Without this the free-gap case
+            // would report the furthest cell in the row rather than in the *band*.
+            let reach = |k: usize| if BANDED { k.min(w) } else { k };
+            let (mut best, mut bi, mut bj) = (i32::MIN, 0usize, 0usize);
+            if qlen == 0 {
+                // Row 0: H[0][j] is j deletions, and i == qlen == 0 throughout, so the bonus
+                // is on every candidate. `>=` takes the largest j on ties.
+                for j in 0..=reach(rlen) {
+                    let v = gap(j) + end_bonus as i32;
+                    if v >= best {
+                        best = v;
+                        bj = j;
+                    }
+                }
+            } else {
+                // Column 0: H[i][0] is i insertions; only i == qlen earns the bonus. `>=`
+                // takes the largest i on ties. Under a band that cell may not exist, in which
+                // case the loop never visits it and no bonus is added. That is right: the query
+                // cannot be spanned inside the band at all.
+                for i in 0..=reach(qlen) {
+                    let v = gap(i) + if i == qlen { end_bonus as i32 } else { 0 };
+                    if v >= best {
+                        best = v;
+                        bi = i;
+                    }
+                }
+            }
+            let mut cigar = Cigar::default();
+            if bi > 0 {
+                cigar.push(CigarOperation::Insertion, bi);
+            }
+            if bj > 0 {
+                cigar.push(CigarOperation::Deletion, bj);
+            }
+            let (query_start, query_end) = query_span::<REVERSED>(qlen, bi);
+            let (ref_start, ref_end) = ref_span::<REVERSED>(rlen, bj);
+            return AlignmentResult {
+                score: best,
+                query_start,
+                query_end,
+                ref_start,
+                ref_end,
+                cigar,
+            };
+        }
+
+        self.prepare::<REVERSED>(query, refseq, match_score, gap_open, gap_extend);
+        self.size_flags::<true, BANDED>(qlen, rlen, w);
+
+        unsafe {
+            B::fill::<true, false, true, true, BANDED>(
+                self,
+                qlen,
+                rlen,
+                match_score,
+                mismatch,
+                gap_open,
+                gap_extend,
+                w,
+            )
+        };
+
+        // How far down the query the band still has cells to offer.
+        //
+        // Row `i`'s in-band columns are `[i - w, i + w]` intersected with `[0, rlen]`, which is
+        // empty once `i > rlen + w`. Those rows are not merely bad candidates, they were never
+        // filled: `row_max[i]` there is whatever the previous call left, or the garbage the
+        // partial chunk's tail wrote. So the reduce must not look at them: a wrong-but-huge
+        // value would win, and would win *silently*.
+        let last_row = if BANDED { qlen.min(rlen + w) } else { qlen };
+
+        // Reduce the per-row maxima to a single cell. Ties resolve to the longest extension:
+        // largest i, then largest j. `>=` on i gives the largest i directly; the largest j comes
+        // from `arg_for_row`, whose bit stream was written under `ARG_LARGEST`'s non-strict
+        // `take` and so records the last tie.
+        let (mut best, mut bi) = (0i32, 0usize);
+        for i in 0..=last_row {
+            let v = self.row_max[i];
+            if v >= best {
+                best = v;
+                bi = i;
+            }
+        }
+        // The end_bonus candidate: the best cell that finishes the query. Applied once, here,
+        // never in the DP. Where the band cannot reach row `qlen` there is no cell that finishes
+        // the query, and `row_max[qlen]` is unfilled, so asking anyway would read garbage.
+        if last_row == qlen {
+            let finish = self.row_max[qlen] + end_bonus as i32;
+            if finish > best || (finish == best && qlen >= bi) {
+                best = finish;
+                bi = qlen;
+            }
+        }
+        // The argmax `j`, recovered for the ONE row that won, which is the whole reason the
+        // fill stores a bit per cell instead of a `j` per row.
+        let bj = if BANDED {
+            arg_for_row_banded::<B>(&self.nm, &self.tb_base, self.row0_arg, bi, qlen, rlen, w)
+        } else {
+            arg_for_row::<B>(&self.nm, &self.tb_base, self.row0_arg, bi, rlen)
+        };
+        // No early return for `best == 0`: (0,0) is the reduce's seed candidate, so the score
+        // can never go negative anyway, and bailing out at `best <= 0` would discard a *longer*
+        // extension that happens to score exactly 0, which the longest-extension tie-break says
+        // must win over (0,0).
+        debug_assert!(
+            best >= 0,
+            "(0,0) seeds the reduce, so the score cannot go negative"
+        );
+        debug_assert!(
+            !BANDED || bi.abs_diff(bj) <= w,
+            "the reduce picked ({bi}, {bj}), which is outside the band of {w}"
+        );
+
+        let cigar = self.replay::<REVERSED, BANDED>(query, refseq, bi, bj, w);
+        let (query_start, query_end) = query_span::<REVERSED>(qlen, bi);
+        let (ref_start, ref_end) = ref_span::<REVERSED>(rlen, bj);
+        AlignmentResult {
+            score: best,
+            query_start,
+            query_end,
+            ref_start,
+            ref_end,
+            cigar,
+        }
+    }
+
+    /// An upper bound on the chunks a **banded** fill writes, and therefore on the `tb`/`nm` it
+    /// needs.
+    ///
+    /// Derived from the fill's own accounting rather than from a cell count. `fill_generic`
+    /// advances its chunk counter once per live anti-diagonal, by `(hi - lo) / B::LANES + 1`, and
+    /// `band_rows::<true>` spans at most `w + 1` rows before the matrix clamps shrink it. There
+    /// are at most `qlen + rlen` live anti-diagonals, hence
+    ///
+    /// ```text
+    /// chunks <= (qlen + rlen) * (w / B::LANES + 1)
+    /// ```
+    ///
+    /// **`w / B::LANES + 1`, not `(w + 1) / B::LANES`.** A strip of `w + 1` rows can straddle a
+    /// chunk boundary, and the fill starts each anti-diagonal's chunks at the *band's* top row
+    /// rather than the matrix's, so the `+ 1` is the partial chunk and is not slack to be tuned
+    /// away. The `+ 2` on top is the same margin the unbanded bound carries.
+    ///
+    /// **The fill's stores are unchecked, so exceeding this bound is heap corruption rather than
+    /// a wrong answer.** `fill_generic` debug-asserts the final chunk count against the buffer it
+    /// was handed, so run the banded paths in a debug build after touching this.
+    #[inline]
+    fn banded_chunks_bound(qlen: usize, rlen: usize, w: usize) -> usize {
+        (qlen + rlen) * (w / B::LANES + 1) + 2
+    }
+
+    /// Size the traceback flag buffer and its per-anti-diagonal index. Shared by every mode.
+    ///
+    /// `NEED_NM` additionally sizes the new-max bit stream, which only the `TRACK_ROW_MAX` modes
+    /// write; grow-only means a program that only ever aligns globally never allocates it at all.
+    /// `BANDED`/`w` are what stop a band allocating for a matrix it will never visit; see
+    /// [`U8Probe::banded_chunks_bound`].
+    fn size_flags<const NEED_NM: bool, const BANDED: bool>(
+        &mut self,
+        qlen: usize,
+        rlen: usize,
+        w: usize,
+    ) {
+        // A bound, not an exact count: that would need its own O(qlen + rlen) pass, which at
+        // small n is comparable to the entire fill. Every cell lives on exactly one
+        // anti-diagonal, giving `qlen*rlen/B::LANES` chunks, plus at most one partial chunk per
+        // anti-diagonal.
+        let full_bound = qlen * rlen / B::LANES + qlen + rlen + 2;
+        // Under a band, take whichever bound is smaller. **Both are valid** (a banded fill
+        // visits a subset of the cells an unbanded one does, so `full_bound` never stops being
+        // an upper bound), and the `min` matters in both directions: `banded_chunks_bound`
+        // *exceeds* `full_bound` once `w` approaches the matrix, because it charges a partial
+        // chunk per anti-diagonal against a strip that is no longer narrow.
+        let chunks_bound = if BANDED {
+            full_bound.min(Self::banded_chunks_bound(qlen, rlen, w))
+        } else {
+            full_bound
+        };
+        if self.tb_base.len() < qlen + rlen + 1 {
+            self.tb_base.resize(qlen + rlen + 1, 0);
+        }
+        if self.tb.len() < chunks_bound * TB_WORDS {
+            self.tb.resize(chunks_bound * TB_WORDS, 0);
+        }
+        if NEED_NM && self.nm.len() < chunks_bound * NM_WORDS {
+            self.nm.resize(chunks_bound * NM_WORDS, 0);
+        }
+    }
+
+    /// One query aligned across **two** references, with a single jump point between them.
+    ///
+    /// Returns two [`AlignmentResult`]s that **partition the query exactly**: `right` covers
+    /// `query[..k]` from `right_reference[0]`, `left` covers `query[k..]` to the end of
+    /// `left_reference`, and `k` is chosen to maximize the total.
+    ///
+    /// # Reduction to two ordinary passes
+    ///
+    /// ```text
+    /// F[k] = max over j of H(query, right)[k][j]                   // best right arm handing over at k
+    /// G[k] = max over l of (best alignment of query[k..] vs left[l..])   // best left arm taking over
+    /// score = max over k in 0..=qlen of F[k] + G[k]
+    /// ```
+    ///
+    /// `F` is exactly `TRACK_ROW_MAX`'s output, and `G` is `F` on **reversed** inputs. The arms
+    /// interact *only* through `k`, so the whole decision is a one-dimensional scan over
+    /// `qlen + 1` values and everything before it is the ordinary kernel, run twice.
+    ///
+    /// Ties resolve to the smallest `|left.score - right.score|`, then the smallest `k`.
+    ///
+    /// # Panics
+    /// If `fits_u8_lanes` rejects the scheme or if `gap_open < gap_extend`.
+    #[allow(clippy::too_many_arguments)] // a kernel entry point: two references and the scheme
+    pub fn split_reference_alignment(
+        &mut self,
+        query: &[u8],
+        left_reference: &[u8],
+        right_reference: &[u8],
+        m: u8,
+        mm: u8,
+        go: u8,
+        ge: u8,
+        bandwidth: Option<usize>,
+    ) -> SplitReferenceAlignment {
+        match bandwidth {
+            Some(w) => {
+                // One band, both arms: each measured from its own arm's anchor. See
+                // `SimdAligner::split_reference_alignment`.
+                //
+                // The widening: the two arms must between them cover the whole query, and an arm
+                // can reach at most `reflen + w` query bases inside the band, so a `w` below
+                // `(qlen - llen - rrlen) / 2` admits no split at all. Widening to it is the
+                // narrowest band that still has an answer.
+                let deficit = query
+                    .len()
+                    .saturating_sub(left_reference.len() + right_reference.len());
+                let w = w.max(1).max(deficit.div_ceil(2));
+                // A band that reaches every cell is the exact mode, and the exact mode is
+                // cheaper; see `band_reaches_everything`. Both arms have to be reached, and
+                // they align against different references, so the wider of the two decides.
+                let widest = left_reference.len().max(right_reference.len());
+                if band_reaches_everything(query.len(), widest, w) {
+                    return self.split_reference::<false>(
+                        query,
+                        left_reference,
+                        right_reference,
+                        m,
+                        mm,
+                        go,
+                        ge,
+                        0,
+                    );
+                }
+                self.split_reference::<true>(
+                    query,
+                    left_reference,
+                    right_reference,
+                    m,
+                    mm,
+                    go,
+                    ge,
+                    w,
+                )
+            }
+            None => self.split_reference::<false>(
+                query,
+                left_reference,
+                right_reference,
+                m,
+                mm,
+                go,
+                ge,
+                0,
+            ),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)] // ditto, plus the bandwidth
+    fn split_reference<const BANDED: bool>(
+        &mut self,
+        query: &[u8],
+        left_reference: &[u8],
+        right_reference: &[u8],
+        m: u8,
+        mm: u8,
+        go: u8,
+        ge: u8,
+        w: usize,
+    ) -> SplitReferenceAlignment {
+        let qlen = query.len();
+
+        // --- pass A: forward against the right reference. row_max[k] == F[k]. ---
+        self.row_pass::<false, BANDED>(query, right_reference, m, mm, go, ge, w);
+        // Park A's results in the `_b` slots and let pass B use the primary ones.
+        std::mem::swap(&mut self.tb, &mut self.tb_b);
+        std::mem::swap(&mut self.tb_base, &mut self.tb_base_b);
+        std::mem::swap(&mut self.row_max, &mut self.row_max_b);
+        // `nm` and `row0_arg` travel with `tb_base`, and they have to: `arg_for_row` reads all
+        // three, and reading one pass's bit stream against the other pass's chunk index would
+        // silently return a `j` from the wrong matrix.
+        std::mem::swap(&mut self.nm, &mut self.nm_b);
+        std::mem::swap(&mut self.row0_arg, &mut self.row0_arg_b);
+        // From here: `*_b` holds pass A (right arm), `*` holds pass B (left arm).
+
+        // --- pass B: REVERSED against the left reference. row_max[qlen - k] == G[k]. ---
+        self.row_pass::<true, BANDED>(query, left_reference, m, mm, go, ge, w);
+
+        // --- the jump point: a 1-D scan over qlen+1 values ---
+        //
+        // Under a band the scan must not look at every `k`. Pass A filled rows `0..=min(qlen,
+        // rrlen + w)` and pass B rows `0..=min(qlen, llen + w)`, and `k` reads `row_max_b[k]`
+        // from A and `row_max[qlen - k]` from B, so both bounds bite, from opposite ends.
+        // Outside them the value is the previous call's leftovers, and being unbounded it would
+        // win. `split_reference_alignment` widened `w` so this range is never empty.
+        let (k_lo, k_hi) = if BANDED {
+            (
+                qlen.saturating_sub(left_reference.len() + w),
+                qlen.min(right_reference.len() + w),
+            )
+        } else {
+            (0, qlen)
+        };
+        debug_assert!(
+            k_lo <= k_hi,
+            "no jump point is in band: k_lo={k_lo} > k_hi={k_hi} at w={w}, qlen={qlen}"
+        );
+        let (mut best, mut best_diff, mut best_k) = (i64::MIN, i64::MAX, k_lo);
+        for k in k_lo..=k_hi {
+            let f = self.row_max_b[k] as i64;
+            let g = self.row_max[qlen - k] as i64;
+            let total = f + g;
+            let diff = (f - g).abs();
+            if total > best || (total == best && diff < best_diff) {
+                best = total;
+                best_diff = diff;
+                best_k = k;
+            }
+        }
+        let k = best_k;
+
+        // --- the right arm: query[..k] from right_reference[0], stopping wherever it scored ---
+        //
+        // Pass A's triple, explicitly: this reads before the `tb`/`tb_base` swap below, so the
+        // `_b` slots are the ones holding A.
+        let rj = if BANDED {
+            arg_for_row_banded::<B>(
+                &self.nm_b,
+                &self.tb_base_b,
+                self.row0_arg_b,
+                k,
+                qlen,
+                right_reference.len(),
+                w,
+            )
+        } else {
+            arg_for_row::<B>(
+                &self.nm_b,
+                &self.tb_base_b,
+                self.row0_arg_b,
+                k,
+                right_reference.len(),
+            )
+        };
+        std::mem::swap(&mut self.tb, &mut self.tb_b);
+        std::mem::swap(&mut self.tb_base, &mut self.tb_base_b);
+        let right = AlignmentResult {
+            score: self.row_max_b[k],
+            query_start: 0,
+            query_end: k,
+            ref_start: 0,
+            ref_end: rj,
+            cigar: self.replay::<false, BANDED>(query, right_reference, k, rj, w),
+        };
+        std::mem::swap(&mut self.tb, &mut self.tb_b);
+        std::mem::swap(&mut self.tb_base, &mut self.tb_base_b);
+
+        // --- the left arm: query[k..] ending at the end of left_reference ---
+        //
+        // The replay runs in the REVERSED frame, walking from (qlen-k, lj) back to the origin.
+        // Row `i` there is `query[qlen-i]`, so starting at `qlen-k` covers exactly `query[k..]`,
+        // and the CIGAR comes out in forward order without a flip.
+        let llen = left_reference.len();
+        // Pass B's triple: the swaps above have been undone, so the primary slots hold B.
+        let lj = if BANDED {
+            arg_for_row_banded::<B>(
+                &self.nm,
+                &self.tb_base,
+                self.row0_arg,
+                qlen - k,
+                qlen,
+                llen,
+                w,
+            )
+        } else {
+            arg_for_row::<B>(&self.nm, &self.tb_base, self.row0_arg, qlen - k, llen)
+        };
+        let left = AlignmentResult {
+            score: self.row_max[qlen - k],
+            query_start: k,
+            query_end: qlen,
+            ref_start: llen - lj,
+            ref_end: llen,
+            cigar: self.replay::<true, BANDED>(query, left_reference, qlen - k, lj, w),
+        };
+
+        SplitReferenceAlignment {
+            score: left.score + right.score,
+            left,
+            right,
+        }
+    }
+
+    /// One `TRACK_ROW_MAX` pass, leaving `row_max`/`nm`/`tb` populated.
+    ///
+    /// `ARG_LARGEST = false`: the row maxima pin the **smallest** `j`.
+    ///
+    /// `w` is read only when `BANDED`. Under a band **only rows `0..=min(qlen, rlen + w)` are
+    /// filled** (row `i`'s in-band columns are `[i - w, i + w]` intersected with `[0, rlen]`,
+    /// which is empty past that), so every caller must bound its scan over `row_max` by that
+    /// same `last_row`. Reading past it reads whatever the previous call left.
+    #[allow(clippy::too_many_arguments)] // a kernel entry point: the scheme plus the bandwidth
+    fn row_pass<const REVERSED: bool, const BANDED: bool>(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+        w: usize,
+    ) {
+        let (qlen, rlen) = (query.len(), refseq.len());
+        if rlen == 0 {
+            // No reference to align against: every row's best is its own column-0 cell, i.e.
+            // spanning that much query as one pure insertion.
+            if self.row_max.len() < qlen + 1 + B::LANES {
+                self.row_max.resize(qlen + 1 + B::LANES, 0);
+            }
+            for i in 0..=qlen {
+                self.row_max[i] = if i == 0 {
+                    0
+                } else {
+                    -(gap_open as i32) - (i as i32 - 1) * gap_extend as i32
+                };
+            }
+            // Every row's best is its column-0 cell, so every argmax is 0, including row 0's,
+            // which is carried scalar and would otherwise be whatever the previous call left.
+            self.row0_arg = 0;
+            self.tb_base.clear();
+            return;
+        }
+        self.prepare::<REVERSED>(query, refseq, match_score, gap_open, gap_extend);
+        self.size_flags::<true, BANDED>(qlen, rlen, w);
+        unsafe {
+            B::fill::<true, false, true, false, BANDED>(
+                self,
+                qlen,
+                rlen,
+                match_score,
+                mismatch,
+                gap_open,
+                gap_extend,
+                w,
+            )
+        };
+    }
+
+    /// The kernel behind every mode above.
+    ///
+    /// `TRACK_LAST_ROW` argmaxes `H[qlen][j]` instead of pinning the end cell at `(qlen, rlen)`;
+    /// `REVERSED` runs the whole thing back-to-front.
+    fn align<const TRACK_LAST_ROW: bool, const REVERSED: bool>(
+        &mut self,
+        query: &[u8],
+        refseq: &[u8],
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+    ) -> AlignmentResult {
+        let (qlen, rlen) = (query.len(), refseq.len());
+
+        // A zero-length side never reaches the kernel: there is no anti-diagonal to walk.
+        if qlen == 0 || rlen == 0 {
+            return self.degenerate::<TRACK_LAST_ROW, REVERSED>(qlen, rlen, gap_open, gap_extend);
+        }
+
+        self.prepare::<REVERSED>(query, refseq, match_score, gap_open, gap_extend);
+        self.size_flags::<false, false>(qlen, rlen, 0);
+
+        let (score, end_j) = unsafe {
+            B::fill::<true, TRACK_LAST_ROW, false, false, false>(
+                self,
+                qlen,
+                rlen,
+                match_score,
+                mismatch,
+                gap_open,
+                gap_extend,
+                0,
+            )
+        };
+        let cigar = self.replay::<REVERSED, false>(query, refseq, qlen, end_j, 0);
+        let (ref_start, ref_end) = ref_span::<REVERSED>(rlen, end_j);
+
+        AlignmentResult {
+            score,
+            query_start: 0,
+            query_end: qlen,
+            ref_start,
+            ref_end,
+            cigar,
+        }
+    }
+
+    /// The `qlen == 0` / `rlen == 0` cases, which skip the kernel entirely.
+    ///
+    /// Not merely a fast path: the modes genuinely differ here. With an empty query, `global`
+    /// must still consume the reference (`rlen` deletions), while `local_reference_end` stops
+    /// at `j = 0` and returns the empty alignment, because the reference tail is free.
+    fn degenerate<const TRACK_LAST_ROW: bool, const REVERSED: bool>(
+        &mut self,
+        qlen: usize,
+        rlen: usize,
+        gap_open: u8,
+        gap_extend: u8,
+    ) -> AlignmentResult {
+        let gap = |k: usize| -> i32 {
+            if k == 0 {
+                0
+            } else {
+                -(gap_open as i32) - (k as i32 - 1) * gap_extend as i32
+            }
+        };
+        let mut cigar = Cigar::default();
+        if qlen > 0 {
+            // The query must always be spanned in full, in every mode here.
+            cigar.push(CigarOperation::Insertion, qlen);
+            let (ref_start, ref_end) = ref_span::<REVERSED>(rlen, 0);
+            return AlignmentResult {
+                score: gap(qlen),
+                query_start: 0,
+                query_end: qlen,
+                ref_start,
+                ref_end,
+                cigar,
+            };
+        }
+        // qlen == 0. Global must still consume the reference; a free reference end need not.
+        let consumed = if TRACK_LAST_ROW { 0 } else { rlen };
+        if consumed > 0 {
+            cigar.push(CigarOperation::Deletion, consumed);
+        }
+        let (ref_start, ref_end) = ref_span::<REVERSED>(rlen, consumed);
+        AlignmentResult {
+            score: gap(consumed),
+            query_start: 0,
+            query_end: 0,
+            ref_start,
+            ref_end,
+            cigar,
+        }
+    }
+
+    /// Where cell `(i, j)`'s flags live, as `(word base, lane bit)`, with `p = i + j`.
+    ///
+    /// The address, not the flags: the replay's `H` state reads one word and sometimes two, and
+    /// the `E`/`F` states read exactly one, so returning all four packed would build bits nobody
+    /// looks at. The lane arithmetic is paid once per cell, the loads once per question.
+    #[inline(always)]
+    fn flag_at<const BANDED: bool>(
+        &self,
+        p: usize,
+        i: usize,
+        qlen: usize,
+        rlen: usize,
+        w: usize,
+    ) -> (*const u32, u32) {
+        // The lane is `i - lo(p)`, so it moves with the band: the fill starts each
+        // anti-diagonal's chunks at the band's top row, not the matrix's. Reading a banded
+        // fill's flags with the unbanded `lo` would silently address the wrong cell.
+        let (i_from, _) = band_rows::<BANDED>(p, qlen, rlen, w);
+        let lane = i - i_from;
+        debug_assert!(
+            i >= i_from && (self.tb_base[p] as usize + lane / B::LANES) * TB_WORDS < self.tb.len(),
+            "flag_at({p}, {i}) is outside the region the fill wrote"
+        );
+        // SAFETY: `p` is a live anti-diagonal and `i` one of its interior rows, so `base` is
+        // within the region the fill wrote. The replay only ever asks about cells it walked to,
+        // and the same argument covers `tb_base[p]`: `p <= qlen + rlen`, which is what
+        // `size_flags` sized it to.
+        unsafe {
+            let base = (*self.tb_base.get_unchecked(p) as usize + lane / B::LANES) * TB_WORDS;
+            (self.tb.as_ptr().add(base), 1u32 << (lane % B::LANES))
+        }
+    }
+
+    /// Walk the flags back from `(start_i, start_j)` to `(0, 0)` and build the CIGAR.
+    ///
+    /// `(qlen, rlen)` only for `global`; every other mode passes an argmax cell.
+    ///
+    /// Scalar, and unavoidably so: a traceback is a serial walk down one path. Only the flag
+    /// *generation* vectorises.
+    ///
+    /// # Diagonal-first priority minimises the edit distance
+    ///
+    /// Many alignments tie for optimal, and the score does not choose between them; this does.
+    /// Among equally-optimal paths a caller wants the **fewest edits**: `10X` rather than
+    /// `10I10D` at the same score.
+    ///
+    /// Checking the diagonal first delivers that **exactly for strongly affine schemes** such as
+    /// the default, where `gap_open` is large enough against `gap_extend` that the gappy
+    /// alternative rarely ties the clean one at all. Outside them it is a heuristic: a greedy
+    /// backward walk commits to a tied step knowing nothing about what it costs downstream, so
+    /// where `gap_open` approaches `gap_extend` and ties are dense it can return an optimal
+    /// alignment that is not the cleanest one. Exactness in general would need the lexicographic
+    /// `(score, -edits)` DP, and the edit count is the one quantity here with **no scheme-only
+    /// bound** (its differences grow with sequence length), so it would need an i32 lane and
+    /// per-row state back to anti-diagonal `p-2`, which this kernel never keeps.
+    ///
+    /// # The trap, and why `from_diag` is a stored bit
+    ///
+    /// Diagonal-first **cannot** be spelled "if neither gap achieved `A_G`'s max, go diagonal":
+    /// that fallthrough is unreachable on precisely the ties this exists to resolve. It needs
+    /// its own bit, and that bit needs the clamp correction; see [`TB_FROM_DIAG`].
+    ///
+    /// # Under a band the replay stays inside it, and does not check that it does
+    ///
+    /// Every step is decided by a flag, and the fill is what makes the flags safe to follow:
+    /// an out-of-band predecessor is sealed to `0`, the smallest value a lane can hold, so it
+    /// loses `A_G`'s max and its direction is never the one recorded. Two of the four
+    /// directions need an argument beyond "it lost the max", because a sealed `0` can *tie* an
+    /// `A_G` that is itself `0`:
+    ///
+    /// - **The band's lower edge is safe for free.** There `A_G = max(s_G, ΔE'_G, 0)`. If
+    ///   `A_G == 0` then `ΔE'_G == 0` too, so `from_e` is set and the replay leaves via E
+    ///   before it can fall through to F. If `A_G > 0` then either E achieved it (`from_e`
+    ///   set) or `s_G` did, and an `s_G` that is strictly positive is one that did not clamp,
+    ///   so `from_diag` is set and trustworthy. One of the two always fires, and both lead
+    ///   inwards.
+    /// - **The band's upper edge needs one bit cleared.** There the fallthrough F leads
+    ///   *inwards* and E leads out, so the fill clears `from_e` on that lane. Discarding it costs
+    ///   nothing: it can only ever have been the seal tying `A_G`.
+    ///
+    /// So `(i, j)` is always in band, which is exactly the condition under which `flag_at`
+    /// addresses a cell the fill wrote. The two closed-form exits are covered too: the replay can
+    /// only reach `(i, 0)` or `(0, j)` in band, which bounds `i` and `j` by `w`, and the straight
+    /// run to the origin it emits there is in band the whole way.
+    fn replay<const REVERSED: bool, const BANDED: bool>(
+        &self,
+        query: &[u8],
+        refseq: &[u8],
+        start_i: usize,
+        start_j: usize,
+        w: usize,
+    ) -> Cigar {
+        let (qlen, rlen) = (query.len(), refseq.len());
+        let mut cigar = Cigar::with_capacity(16);
+
+        enum St {
+            H,
+            E,
+            F,
+        }
+        let (mut i, mut j) = (start_i, start_j);
+        let mut st = St::H;
+
+        // The current run, held in registers and flushed only when the operation changes.
+        // `Cigar::push` already merges a repeated op, but it is the host's type and reaches it
+        // through the `Vec`; doing it here makes it a register compare and an add, and `push` is
+        // called once per *run* rather than once per *cell*. The emitted CIGAR is identical.
+        //
+        // `run_len == 0` means "nothing pending", which is why `run_op`'s initial value is never
+        // read.
+        let mut run_op = CigarOperation::Eq;
+        let mut run_len = 0usize;
+        macro_rules! emit {
+            ($op:expr, $n:expr) => {{
+                let op = $op;
+                if run_len != 0 && op == run_op {
+                    run_len += $n;
+                } else {
+                    if run_len != 0 {
+                        cigar.push(run_op, run_len);
+                    }
+                    run_op = op;
+                    run_len = $n;
+                }
+            }};
+        }
+
+        while i > 0 || j > 0 {
+            // The boundaries carry no flags and need none: down column 0 the only path is all
+            // insertions, along row 0 all deletions, whatever state we arrived in. And it is the
+            // *whole* remaining path, so emit it in closed form and stop.
+            if j == 0 {
+                emit!(CigarOperation::Insertion, i);
+                break;
+            }
+            if i == 0 {
+                emit!(CigarOperation::Deletion, j);
+                break;
+            }
+            let p = i + j;
+            // SAFETY: `(w, bit)` addresses cell (i, j)'s flag words, which the fill wrote; see
+            // `flag_at`. Each `read` below is one of the four adjacent words at that address.
+            debug_assert!(
+                !BANDED || i.abs_diff(j) <= w,
+                "the replay stepped out of the band of {w}, to ({i}, {j})"
+            );
+            let (word, bit) = self.flag_at::<BANDED>(p, i, qlen, rlen, w);
+            let flag = |which: usize| unsafe { (*word.add(which) & bit) != 0 };
+            match st {
+                St::H => {
+                    // Diagonal FIRST: on a tie it spends one edit where a gap pair would spend
+                    // two or more. See the tie-break note above.
+                    //
+                    // `from_f` is the fallthrough and is never stored: `A_G` is a max of three
+                    // operands, so if neither the diagonal nor E achieved it, `ΔF'_G` did.
+                    if flag(TB_FROM_DIAG) {
+                        // `=` vs `X` is **literal byte identity**, re-derived from the original
+                        // bytes rather than from how the kernel scored the cell; see `mod.rs`,
+                        // "Alphabet". Under REVERSED the kernel ran on back-to-front codes, so
+                        // cell (i, j) is the pair (query[qlen-i], refseq[rlen-j]) in the
+                        // caller's bytes.
+                        let (qb, rb) = if REVERSED {
+                            (query[qlen - i], refseq[rlen - j])
+                        } else {
+                            (query[i - 1], refseq[j - 1])
+                        };
+                        let op = if qb == rb {
+                            CigarOperation::Eq
+                        } else {
+                            CigarOperation::X
+                        };
+                        emit!(op, 1);
+                        i -= 1;
+                        j -= 1;
+                    } else if flag(TB_FROM_E) {
+                        // S[i,j] <- E[i-1,j]: the step consumes query base i.
+                        emit!(CigarOperation::Insertion, 1);
+                        i -= 1;
+                        st = St::E;
+                    } else {
+                        emit!(CigarOperation::Deletion, 1);
+                        j -= 1;
+                        st = St::F;
+                    }
+                }
+                St::E => {
+                    if flag(TB_E_OPEN) {
+                        // The run opened here: drop onto the score matrix without moving.
+                        st = St::H;
+                    } else {
+                        emit!(CigarOperation::Insertion, 1);
+                        i -= 1;
+                    }
+                }
+                St::F => {
+                    if flag(TB_F_OPEN) {
+                        st = St::H;
+                    } else {
+                        emit!(CigarOperation::Deletion, 1);
+                        j -= 1;
+                    }
+                }
+            }
+        }
+        // The last run has no following op to flush it. An empty alignment (start_i == start_j
+        // == 0, which `local_end` returns for a hopeless extension) never enters the loop and
+        // leaves `run_len == 0`, so this correctly emits nothing.
+        if run_len != 0 {
+            cigar.push(run_op, run_len);
+        }
+
+        // The replay walks backwards and so builds the CIGAR back-to-front, needing one flip.
+        // In the REVERSED frame, back-to-front IS forward order, so the two reversals annihilate
+        // and the flip is skipped.
+        if !REVERSED {
+            cigar.reverse();
+        }
+        cigar
+    }
+
+    /// # `TRACK_ROW_MAX`: per-cell absolute scores, exactly, with nothing to bound
+    ///
+    /// `local_end`, `local_start` and `split_reference` argmax over **absolute** `H[i][j]`,
+    /// which a difference kernel does not have. The paper's answer is a three-level
+    /// decomposition whose 8-bit small delta it does not bound ("too complex for rigorous
+    /// analysis"), which a contract reading "exact, always" cannot use.
+    ///
+    /// It is not needed. `S[i,j] - S[i,j-1] = ΔV[i,j]` *is* the definition of ΔV, and on
+    /// anti-diagonal `p` row `i` sits at column `j = p - i` while on `p-1` it sits at `j-1`. So
+    /// `abs[i] += ΔV[i, p-i]`: one add per cell, from a value the fill already stores, per-lane
+    /// and seeded from `S[i,0]` in closed form.
+    ///
+    /// The `i32` accumulator is **not a fallback to a wider kernel**: the DP stays u8 at
+    /// `B::LANES` lanes and `fits_u8_lanes` still has no length term. Its own bound is
+    /// `qlen + rlen < ~8.4M` at the worst possible u8 scores, and it is not even the first to
+    /// bind: `tb_base` stores a chunk index as `u32`, which wraps ~500x earlier, at roughly two
+    /// unbanded 370 kb sequences, past which `flag_at` and `arg_for_row` address the wrong chunk.
+    ///
+    /// The seed also disposes of a hazard: the partial chunk tail writes garbage to rows *above*
+    /// the live range, and those rows **are** read later. But garbage only lands on row `i` at
+    /// `p <= i`, and the boundary seed at `p = i` scrubs it.
+    ///
+    /// `ARG_LARGEST` picks the tie-break on `j`: `local_end` wants the **largest** (longest
+    /// extension), `split_reference`'s row maxima want the **smallest**.
+    ///
+    /// # `BANDED`: the strip, and the two rows either side of it that pay for it
+    ///
+    /// `BANDED` narrows each anti-diagonal's interior to `|i - j| <= w` (see [`band_rows`]). The
+    /// chunk loop does not change at all (it is handed a shorter range), and that is the whole
+    /// runtime win. What the band costs is at its **edges**, where the recurrence reads cells the
+    /// fill never visited:
+    ///
+    /// 1. **Two sealed bytes per anti-diagonal.** `A_G = max(s_G, ΔE'_G[i-1,j], ΔF'_G[i,j-1])`
+    ///    reaches one row above the strip's top and one row below its bottom. Both are sealed
+    ///    to `0`, the smallest value a `u8` lane can hold, so they lose every max they enter.
+    ///    That is not a sentinel but the bottom of the range every delta already lives in, so
+    ///    the `[0, upper]` invariant, the plain `sub_epi8`s and `fits_u8_lanes` are unaffected.
+    ///
+    /// 2. **Two garbage deltas per anti-diagonal, which are provably dead.** The *other* two
+    ///    reads at each edge (`ΔV_G[i-1,j]` at the top, `ΔH_G[i,j-1]` at the bottom) are
+    ///    subtrahends, and a seal cannot make a difference correct. So they are left as
+    ///    garbage, and the band's geometry retires them: each bound moves at half of `p`'s
+    ///    rate, so an edge that was flat at `p` **must** advance at `p+1`, and advancing is
+    ///    precisely what makes the cell that consumed the garbage fall outside the next
+    ///    anti-diagonal's reads.
+    ///
+    /// 3. **One seed per row, replacing the column-0 one.** `abs[i]` accumulates `ΔV` along
+    ///    row `i`, so it needs a starting absolute. Unbanded that is `H[i][0]`, seeded at the
+    ///    matrix corner. Under a band, row `i > w` has no column-0 cell and enters at column
+    ///    `i - w` instead, where its own `ΔV` is the garbage of (2). But `ΔH` at that same cell
+    ///    is **not** garbage: `ΔH` reads *upwards*, and the cell above is in band. So
+    ///    `abs[i] = abs[i-1] + ΔH_G[i, i-w] - gap_open` seeds the row exactly.
+    ///
+    /// That seed doubles as the scrub, and has to: the partial chunk's tail writes garbage to
+    /// rows *below* the strip, and under a band those rows are reached far later than the
+    /// unbanded corner seed would have scrubbed them. The row is seeded at the moment it enters
+    /// the band, which is after the last garbage write to it and before its first real read.
+    /// # Which mode compiles which flags
+    ///
+    /// Every public mode reaches this function through one of three wrappers. `REVERSED` is
+    /// threaded separately (see `prepare`) and never reaches `fill_generic`.
+    ///
+    /// | mode | wrapper | TRACE | LAST_ROW | ROW_MAX | ARG_LARGEST | BANDED | score read from |
+    /// |---|---|---|---|---|---|---|---|
+    /// | `global`, exact | `align` | y | - | - | - | - | `anchor` |
+    /// | `global`, banded | `row_pass` | y | - | y | - | y | `abs[qlen]` |
+    /// | `local_reference_*`, exact | `align` | y | y | - | - | - | `best_score` |
+    /// | `local_reference_*`, banded | `row_pass` | y | - | y | - | y | `row_max[qlen]` |
+    /// | `local_end` / `local_start` | `local` | y | - | y | y | opt | reduce over `row_max` |
+    /// | `split_reference` (two passes) | `row_pass` | y | - | y | - | opt | `row_max_b[k] + row_max[qlen-k]` |
+    ///
+    /// **`TRACK_LAST_ROW` and `BANDED` are never compiled together**: `align` is the only user
+    /// of the former and is never banded, because its `anchor` walk cannot survive a band (see
+    /// [`U8Probe::local_reference`]).
+    ///
+    #[allow(clippy::too_many_arguments)] // the scheme is five scalars, plus the bandwidth
+    #[inline(always)]
+    pub(super) unsafe fn fill_generic<
+        const TRACE: bool,
+        const TRACK_LAST_ROW: bool,
+        const TRACK_ROW_MAX: bool,
+        const ARG_LARGEST: bool,
+        const BANDED: bool,
+    >(
+        &mut self,
+        qlen: usize,
+        rlen: usize,
+        match_score: u8,
+        mismatch: u8,
+        gap_open: u8,
+        gap_extend: u8,
+        w: usize,
+    ) -> (i32, usize) {
+        unsafe {
+            let m = match_score as i64;
+            let mm = mismatch as i64;
+            let go = gap_open as i64 - gap_extend as i64;
+            let ge = gap_extend as i64;
+            let c = 2 * (go + ge); // == 2 * gap_open
+            let upper = (m + c) as u8;
+
+            // The two values of s_G, broadcast once. Only the mismatch side needs the clamp:
+            // s_G(mismatch) = C - mismatch can be negative (any scheme with
+            // mismatch > 2*gap_open), and clamping it to zero is lossless because A_G only ever
+            // maxes it against ΔE'_G/ΔF'_G, which are >= 0. Wrapping instead would make the
+            // worst substitution the largest value in the lane and win every max.
+            let s_g_match = upper;
+            let s_g_mismatch = (c - mm).max(0) as u8;
+            let go_u8 = go as u8;
+
+            // ΔV = ΔV_G - gap_open, un-offset, widened to the accumulator's lane type.
+            let gap_open_vec32 = B::splat32(gap_open as i32);
+
+            let match_vec = B::splat8(s_g_match);
+            let mismatch_vec = B::splat8(s_g_mismatch);
+            let go_vec = B::splat8(go_u8);
+            // All-ones exactly when `s_G(mismatch)` did NOT clamp, i.e. when `cmpeq(A_G, s_G)`
+            // means what it says at every cell. See TB_FROM_DIAG.
+            let unclamped_vec = if c - mm >= 0 {
+                B::splat8(0xFF)
+            } else {
+                B::splat8(0)
+            };
+
+            let q_ptr = self.q_codes.as_ptr();
+            let r_ptr = self.r_rev.as_ptr();
+
+            // Hoist every buffer to a raw pointer, ONCE, and ping-pong the pointers rather than
+            // the `Vec`s: swapping two `Deltas` would move eight `Vec` headers per
+            // anti-diagonal, which dominates at small `n` where the ramp runs more
+            // anti-diagonals than chunks of actual DP.
+            let mut p_dh = self.prev.dh.as_mut_ptr();
+            let mut p_dv = self.prev.dv.as_mut_ptr();
+            let mut p_de = self.prev.de.as_mut_ptr();
+            let mut p_df = self.prev.df.as_mut_ptr();
+            let mut c_dh = self.cur.dh.as_mut_ptr();
+            let mut c_dv = self.cur.dv.as_mut_ptr();
+            let mut c_de = self.cur.de.as_mut_ptr();
+            let mut c_df = self.cur.df.as_mut_ptr();
+            let tb_ptr = self.tb.as_mut_ptr();
+            let tb_base_ptr = self.tb_base.as_mut_ptr();
+            let abs_ptr = self.abs.as_mut_ptr();
+            let row_max_ptr = self.row_max.as_mut_ptr();
+            let nm_ptr = self.nm.as_mut_ptr();
+
+            // The running absolute value at the anti-diagonal's bottom row: the paper's 64-bit
+            // large offset, reduced to what a global score actually needs: one i64, not a
+            // per-lane middle delta.
+            let mut anchor: i64 = 0;
+            // `local_reference_end`'s objective, for free. `anchor` holds the absolute score at
+            // the anti-diagonal's *bottom* row, hi(p) = min(qlen, p), so for every p >= qlen it
+            // is exactly S[qlen][p - qlen]: it already walks the row this mode maximizes, one
+            // cell per anti-diagonal.
+            //
+            // Ties resolve to the smallest `ref_end`, which falls out of updating on a strict
+            // improvement only, since p (and therefore j) increases monotonically.
+            let mut best_score = i64::MIN;
+            let mut best_j = 0usize;
+
+            // Row 0, in closed form.
+            //
+            // `H[0][j]` is "consume j reference bases, align no query": 0 at j=0, and
+            // `-(gap_open + (j-1)*gap_extend) <= 0` beyond it. Both gap costs are unsigned, so
+            // **row 0's max is always 0**, attained at j=0, and the only question is which `j`
+            // the tie-break names:
+            //
+            //   * `!ARG_LARGEST` wants the smallest `j`, and j=0 attains the max, so: 0.
+            //   * `gap_open > 0` makes every j>=1 strictly negative, so: 0.
+            //   * `gap_open == 0 < gap_extend` leaves `H[0][1] == 0` tying with j=0 and
+            //     everything past it negative, so: 1.
+            //   * both zero ties the whole row at 0, so the largest j is `rlen`, the free-gap
+            //     case `local_end` has a test for. Under a band it is `min(rlen, w)`, the
+            //     furthest cell the band still reaches.
+            //
+            // `abs[0]` is deliberately not seeded: the group loop starts at `i_from >= 1`, so
+            // row 0 has no lane and nothing reads it.
+            let row0_arg: i32 = if !ARG_LARGEST || gap_open > 0 {
+                0
+            } else if gap_extend > 0 {
+                1.min(rlen) as i32
+            } else if BANDED {
+                rlen.min(w) as i32
+            } else {
+                rlen as i32
+            };
+            if TRACK_ROW_MAX {
+                *row_max_ptr.add(0) = 0;
+            }
+            // The running chunk counter, so `tb_base` is filled by the fill itself rather than
+            // by a separate O(qlen+rlen) pass. The flag address is recomputed per chunk rather
+            // than carried as a bumped pointer: a live `*mut u32` across the chunk loop stops
+            // LLVM proving it does not alias the delta buffers, so it stops keeping their
+            // pointers in registers.
+            let mut chunk: usize = 0;
+
+            // The interior row range, maintained INCREMENTALLY rather than recomputed. Both
+            // `i_from = max(1, p - rlen)` and `i_to = min(qlen, p - 1)` are monotone step
+            // functions of `p`, so carrying them costs two perfectly-predicted branches instead
+            // of three ALU ops on the dependency path.
+            let mut i_from = 1usize;
+            let mut i_to = 0usize;
+
+            // The band's own two bounds, carried the same way. `b_lo = ceil((p - w) / 2)` and
+            // `b_hi = floor((p + w) / 2)` advance on alternating anti-diagonals, and since their
+            // parities are opposite **exactly one of the two advances every step**, so the pair
+            // costs one branch on a parity bit rather than two divisions.
+            //
+            // These are `band_rows`' two band terms at `p = 1`, written the way they are
+            // *defined* rather than the way they are shortest: clippy would have `(1 + w) / 2` as
+            // `w.div_ceil(2)`, which hides that this is `floor((p + w) / 2)` at `p = 1`, and the
+            // `debug_assert` against `band_rows` below can only check the pair if they stay
+            // recognisable.
+            #[allow(clippy::manual_div_ceil)]
+            let (mut b_lo, mut b_hi) = if BANDED {
+                (1usize.saturating_sub(w).div_ceil(2), (1 + w) / 2)
+            } else {
+                (0, usize::MAX)
+            };
+            // `(lo, hi)` at `p - 1`, which is what says whether each edge just advanced, and
+            // therefore whether the cell beyond it is one the last anti-diagonal wrote or one
+            // the seal has to cover. Seeded at `p = 0`'s empty range.
+            let (mut prev_lo, mut prev_hi) = (1usize, 0usize);
+
+            for p in 1..=(qlen + rlen) {
+                debug_assert_eq!(i_from, 1.max(p.saturating_sub(rlen)));
+                debug_assert_eq!(i_to, qlen.min(p - 1));
+
+                // The interior, band included. Under `!BANDED` these fold to `i_from`/`i_to`
+                // and every branch guarded by `BANDED` below disappears with them.
+                let lo = if BANDED { i_from.max(b_lo) } else { i_from };
+                let hi = if BANDED { i_to.min(b_hi) } else { i_to };
+                debug_assert_eq!((lo, hi), band_rows::<BANDED>(p, qlen, rlen, w));
+
+                // Is this anti-diagonal's top (bottom) row sitting exactly ON the band's edge,
+                // so that the cell beyond it is outside the strip?
+                //
+                // Row `i` sits at `i - j = 2i - p`, so the top row is at `+w` exactly when it is
+                // the band's own bound *and* `p - w` is even; at odd `p - w` the bound rounds
+                // inwards and the row above is still in the strip. `lo == b_lo` is what says the
+                // band, not the matrix corner, is limiting here; without it a top row pinned by
+                // `max(1, p - rlen)` would be sealed against a neighbour that is perfectly real.
+                //
+                // The two share a parity: the bounds move at half of `p`'s rate on opposite
+                // phases, so the strip is `w + 1` rows wide with both edges live, then `w` rows
+                // wide with neither. Every edge fix below fires only on the wide ones.
+                //
+                // `live` is not pedantry. An anti-diagonal with no interior still *has* band
+                // bounds, and they can sit anywhere: the strip runs off the end of the query
+                // long before `p` does whenever `qlen` is short against the band. Without this
+                // the edge fixes below would write a row nothing computed and, worse, `|=` a
+                // flag word at `chunk_base` that belongs to the *next* anti-diagonal, because an
+                // empty one advances `chunk` by zero.
+                let live = lo <= hi;
+                let edge_phase = BANDED && live && (p + w).is_multiple_of(2);
+                let top_sealed = edge_phase && lo == b_lo;
+                let bottom_sealed = edge_phase && hi == b_hi;
+                debug_assert!(
+                    !(top_sealed && bottom_sealed) || lo < hi,
+                    "both edges live means a strip {} rows wide, so they cannot be the same row",
+                    w + 1
+                );
+                // Once the strip leaves the matrix it never comes back, so a live anti-diagonal
+                // always has a live predecessor to read from. `p <= 2` is the one exception, and
+                // it is the ordinary one: `p = 1` has no interior in any mode, banded or not,
+                // and `p = 2`'s reads land on the boundary cells rather than on `p = 1`'s
+                // interior.
+                debug_assert!(
+                    !BANDED || !live || p <= 2 || prev_lo <= prev_hi,
+                    "anti-diagonal {p} is live but {} was empty: its reads land on rows that \
+                     nothing wrote",
+                    p - 1
+                );
+
+                if TRACE {
+                    *tb_base_ptr.add(p) = chunk as u32;
+                }
+                // `chunk` is advanced past this anti-diagonal before the TRACK_ROW_MAX pass
+                // runs, so that pass cannot use it directly: it needs THIS anti-diagonal's
+                // base, which is what the flags were written against.
+                let chunk_base = chunk;
+
+                let mut i0 = lo;
+                while i0 <= hi {
+                    // Two loads from anti-diagonal p-1, one byte apart: the addressing is what
+                    // replaces the paper's shiftl/shiftr.
+                    let dv_up = B::load8(p_dv.add(i0 - 1));
+                    let de_up = B::load8(p_de.add(i0 - 1));
+                    let dh_left = B::load8(p_dh.add(i0));
+                    let df_left = B::load8(p_df.add(i0));
+
+                    // `rlen + i0 - p`, never `rlen - p + i0`: the index is provably non-negative
+                    // on every live lane, but `rlen - p` alone underflows the moment the
+                    // anti-diagonal stops growing and starts sliding right.
+                    let qv = B::load8(q_ptr.add(i0 - 1));
+                    let rv = B::load8(r_ptr.add(rlen + i0 - p));
+                    // Hoisted out of the blend because the traceback needs it too: on a clamped
+                    // scheme `from_diag` is only trustworthy at match cells. See TB_FROM_DIAG.
+                    let eq_qr = B::eq8(qv, rv);
+                    let s_g = B::blend8(mismatch_vec, match_vec, eq_qr);
+
+                    // Critical path 4: two maxes with nothing feeding them. ΔE'_G and ΔF'_G have
+                    // already absorbed ΔV and ΔH, so A_G reads them directly rather than adding
+                    // first, the entire reason Eq 3 exists.
+                    let a_g = B::max8(B::max8(s_g, de_up), df_left);
+
+                    let de_next = B::max8(a_g, B::add8(de_up, go_vec));
+                    let df_next = B::max8(a_g, B::add8(df_left, go_vec));
+
+                    // The traceback flags: equalities on values already in registers, extracted
+                    // a bit per lane. `const TRACE` so the score-only path monomorphizes without
+                    // them entirely.
+                    if TRACE {
+                        let tb = tb_ptr.add((chunk + (i0 - lo) / B::LANES) * TB_WORDS);
+                        // `from_diag`/`from_e`: which operands achieved A_G's max. `from_f` is
+                        // NOT stored: it is the replay's fallthrough. See TB_WORDS.
+                        //
+                        // `unclamped_vec` is all-ones for every scheme that does not clamp
+                        // `s_G`, making the `or` a no-op and the `and` an identity, so the
+                        // correction costs nothing where it is not needed and does not need a
+                        // second monomorphization of this loop.
+                        *tb.add(TB_FROM_DIAG) =
+                            B::movemask8(B::and8(B::eq8(a_g, s_g), B::or8(eq_qr, unclamped_vec)));
+                        *tb.add(TB_FROM_E) = B::movemask8(B::eq8(a_g, de_up));
+                        // `e_open`/`f_open`: whether the gap state opened from A_G rather than
+                        // extending.
+                        *tb.add(TB_E_OPEN) = B::movemask8(B::eq8(de_next, a_g));
+                        *tb.add(TB_F_OPEN) = B::movemask8(B::eq8(df_next, a_g));
+                    }
+
+                    // Plain subs, no saturation: every result is provably in [0, upper], so the
+                    // minuend is always >= the subtrahend.
+                    B::store8(c_dh.add(i0), B::sub8(a_g, dv_up));
+                    B::store8(c_dv.add(i0), B::sub8(a_g, dh_left));
+                    B::store8(c_de.add(i0), B::sub8(de_next, dh_left));
+                    B::store8(c_df.add(i0), B::sub8(df_next, dv_up));
+
+                    i0 += B::LANES;
+                }
+                if TRACE && lo <= hi {
+                    chunk += (hi - lo) / B::LANES + 1;
+                }
+
+                // Does row `hi` enter the band here, at its own first in-band column rather
+                // than at the matrix corner? Then its `abs` has to be seeded rather than
+                // accumulated; see (3) in this function's docs.
+                //
+                // `bottom_sealed` IS "row `hi` enters the band here": the band's lower bound
+                // reaches row `hi` for the first time exactly at `p = 2*hi - w`, which is the
+                // anti-diagonal where it is the bound and the parity is even. Rows within `w` of
+                // the origin enter at the matrix corner instead and are seeded there;
+                // `bottom_sealed` never fires for them, since it needs `hi = (p + w) / 2` and
+                // `hi <= p - 1`, which together force `hi > w`.
+                let seeds_row = bottom_sealed && TRACK_ROW_MAX;
+                debug_assert!(
+                    !seeds_row || hi > w,
+                    "a corner-seeded row cannot also band-enter"
+                );
+                // `abs[hi - 1]` **before** the group loop overwrites it: it must be row
+                // `hi - 1`'s absolute at anti-diagonal `p - 1`, i.e. `S[hi-1, p-hi]`, which is
+                // the cell diagonally up-left of the one being seeded. One anti-diagonal later
+                // and it is the wrong cell.
+                //
+                // `hi > w >= 1` puts `hi - 1` at 1 or above, so this never reaches row 0,
+                // which has no `abs` and needs none.
+                let seed_carry = if seeds_row { *abs_ptr.add(hi - 1) } else { 0 };
+
+                // The per-row absolutes and their running maxima, for the interior of this
+                // anti-diagonal. A second pass over the same rows rather than work folded into
+                // the chunk loop: it needs `cur.dv`, which the chunk loop is still writing, and
+                // interleaving narrow i32 work into the full-width u8 loop would spill registers
+                // there for the benefit of the three modes that use this.
+                if TRACK_ROW_MAX {
+                    // One `LANES32`-lane i32 group. A macro rather than a closure so both call
+                    // sites inline identically.
+                    macro_rules! group {
+                        ($base:expr) => {{
+                            let base = $base;
+                            // `LANES32` u8 deltas -> `LANES32` i32, un-offset to true ΔV.
+                            let dv = B::widen8to32(c_dv.add(base));
+                            let a = B::add32(
+                                B::load32(abs_ptr.add(base)),
+                                B::sub32(dv, gap_open_vec32),
+                            );
+                            B::store32(abs_ptr.add(base), a);
+
+                            // No `j` or `i` is built here: the bit stream records *that* a cell
+                            // took the max, not which, and `arg_for_row` reconstructs the
+                            // coordinates from the bit's `(p, lane)` position afterwards.
+                            let m = B::load32(row_max_ptr.add(base));
+
+                            // STAY OFF PORT 5 (x86 reasoning; harmless elsewhere). `blendv_epi8`
+                            // and the `cvtepu8_epi32` above both issue only on the shuffle port,
+                            // which this block saturates. So `max32` takes the max with no blend
+                            // and `eq32(new, a)` recovers the mask, both on p0/p1; a blend is
+                            // fewer instructions here and slower.
+                            let new_m = B::max32(m, a);
+                            // `eq32(max(m,a), a)` is `a >= m`, which IS the largest-j rule.
+                            // The smallest-j rule needs a strict `a > m`.
+                            let take = if ARG_LARGEST {
+                                B::eq32(new_m, a)
+                            } else {
+                                B::gt32(a, m)
+                            };
+                            B::store32(
+                                row_max_ptr.add(base),
+                                if ARG_LARGEST { new_m } else { B::max32(m, a) },
+                            );
+                            // The group *returns* its `LANES32` bits rather than storing them:
+                            // the caller packs all four into one word and stores once per chunk.
+                            B::movemask32(take)
+                        }};
+                    }
+
+                    // A CONSTANT trip count, so the four groups unroll. Bounding it to skip the
+                    // dead lanes of a partial chunk takes the unroll with it and costs more than
+                    // the lanes are worth.
+                    let mut i0 = lo;
+                    while i0 <= hi {
+                        // Four groups, four `LANES32`-bit masks, ONE 32-bit store for the chunk:
+                        // `nm` is written once and never re-read, so it streams, and four 4-byte
+                        // streaming stores per chunk miss D1 badly where one 32-bit store does
+                        // not.
+                        //
+                        // **Four** groups on every backend, not `LANES / 8`: `AssertLaneRatio`
+                        // pins `LANES == 4 * LANES32`, so only the stride and the shift move with
+                        // the width. That is what keeps one `u32` per chunk true everywhere, and
+                        // with it the `(p, lane)` flag format `arg_for_row` and `replay` decode.
+                        let m0 = group!(i0);
+                        let m1 = group!(i0 + B::LANES32);
+                        let m2 = group!(i0 + 2 * B::LANES32);
+                        let m3 = group!(i0 + 3 * B::LANES32);
+                        *nm_ptr.add(chunk_base + (i0 - lo) / B::LANES) = m0
+                            | (m1 << B::LANES32)
+                            | (m2 << (2 * B::LANES32))
+                            | (m3 << (3 * B::LANES32));
+                        i0 += B::LANES;
+                    }
+                }
+
+                // The band's seals and its one seed, AFTER both loops and BEFORE the boundary
+                // cells. Both halves of that ordering are load-bearing:
+                //
+                //  * after the chunk loop, for the reason the boundary cells are: a full-width
+                //    store is unconditional, so the partial last chunk scribbles over the row
+                //    just past the interior, which is exactly the row the bottom seal owns;
+                //  * before the boundary cells, because at the matrix corners the seals aim at
+                //    rows that ARE the boundary (`hi + 1 == p` while the anti-diagonal is still
+                //    growing, `lo - 1 == 0` before it lifts off). The boundary is the truth
+                //    there; letting it land second is cheaper than teaching the seals to duck.
+                if BANDED && live {
+                    // --- the seals: the two cells the recurrence reaches past the strip ---
+                    //
+                    // `live` is what keeps these in bounds, and it is not a formality: once the
+                    // strip slides off the bottom of the query, `lo` keeps climbing with `p`
+                    // while the buffers stop at `qlen + 1 + B::LANES`, so `c_de[lo - 1]` walks
+                    // straight off the end of the allocation. Nothing reads those anti-diagonals
+                    // (the strip never re-enters the matrix, which is what the `debug_assert`
+                    // above pins), so there is nothing to seal.
+                    //
+                    // Given `live`: `1 <= lo <= hi <= qlen`, so `lo - 1` and `hi + 1` are both
+                    // inside every delta buffer. Where they land on a boundary cell that
+                    // legitimately exists (row 0 while the band still reaches it, row `p` while
+                    // the anti-diagonal is still growing), the boundary block below runs second
+                    // and takes it back.
+                    *c_de.add(lo - 1) = 0;
+                    *c_df.add(hi + 1) = 0;
+
+                    // --- the edges: where a seal of `0` is not enough ---
+                    //
+                    // A seal makes the *three-way* max fall the right way, but **it does not
+                    // survive the gap recurrence**: `ΔE'_G[i,j] = max(A_G, ΔE'_G[i-1,j] + go)`
+                    // adds `go` to the seal *before* the max, so a sealed `0` arrives as `go`,
+                    // which beats `A_G` whenever `A_G < go`, most cells under a strongly affine
+                    // scheme. The result is a `ΔE'_G` too large by `go - A_G` and an `e_open` bit
+                    // saying the gap extends from a cell outside the band, so the score comes out
+                    // wrong and the replay walks up out of the strip into flags nothing wrote.
+                    //
+                    // Both are fixed by saying what the band means: at the strip's top edge
+                    // `E[i-1,j]` is unreachable, so the E-run **must open here**, and
+                    // `ΔE'_G[i,j] = A_G[i,j] - ΔH_G[i,j-1]`, exactly what the chunk loop just
+                    // stored in `ΔV_G[i,j]`. So the correction is a byte copy, and the F edge
+                    // mirrors it with `ΔF'_G[i,j] = A_G[i,j] - ΔV_G[i-1,j]`, which is `ΔH_G[i,j]`.
+                    //
+                    // Each edge copies from the delta whose own inputs are in band: `ΔV_G` reads
+                    // leftwards and the top edge's left neighbour is inside; `ΔH_G` reads upwards
+                    // and the bottom edge's upper neighbour is inside. The copies cannot cross:
+                    // `top_sealed && bottom_sealed` implies a strip `w + 1 >= 2` rows wide.
+                    if top_sealed {
+                        *c_de.add(lo) = *c_dv.add(lo);
+                        if TRACE {
+                            // In `St::H`, "H came from E[i-1,j]" is out of band, so clear it. It
+                            // could only ever have been the seal tying an `A_G` of 0. The replay
+                            // then falls through to F, which at this edge leads *inwards*.
+                            *tb_ptr.add(chunk_base * TB_WORDS + TB_FROM_E) &= !1u32;
+                            // In `St::E`, "the run opened here", which it must have.
+                            *tb_ptr.add(chunk_base * TB_WORDS + TB_E_OPEN) |= 1u32;
+                        }
+                    }
+                    if bottom_sealed {
+                        *c_df.add(hi) = *c_dh.add(hi);
+                        if TRACE {
+                            // In `St::F`: "the run opened here". `from_f` itself needs no mask:
+                            // it is the replay's fallthrough, and at this edge one of the two
+                            // flags it falls through *from* is always set. See `replay`.
+                            let lane = hi - lo;
+                            *tb_ptr.add((chunk_base + lane / B::LANES) * TB_WORDS + TB_F_OPEN) |=
+                                1u32 << (lane % B::LANES);
+                        }
+                    }
+
+                    // Row `hi` enters the band at column `hi - w`: seed its running absolute
+                    // from the cell above-left, which is in band. See (3) in this function's
+                    // docs. `row_max` is *assigned*, not maxed: this is the row's first
+                    // candidate, and whatever is sitting there is the partial chunk's garbage.
+                    if seeds_row {
+                        let s = seed_carry + *c_dh.add(hi) as i32 - gap_open as i32;
+                        *abs_ptr.add(hi) = s;
+                        *row_max_ptr.add(hi) = s;
+                        // No `nm` bit is written for it: `arg_for_row_banded` returns this column
+                        // when its scan finds nothing above, which is precisely when this cell
+                        // is still the row's argmax.
+                    }
+                }
+
+                // Boundary cells, AFTER the chunk loop; see the hazard note in the module docs.
+                // The values are Eq 3's initial conditions.
+                //
+                // Under a band they are **conditional**: `H[0][j]` sits `j` off the diagonal and
+                // `H[i][0]` sits `i` off it, so the boundary leaves the strip after `w` steps and
+                // past that these cells do not exist. Writing them anyway would hand the
+                // recurrence a reachable-looking predecessor outside the band: the one thing the
+                // seals are there to prevent, undone one line after them. Past `w` the seals are
+                // the truth, and they cover the only two rows that get read.
+                if p <= rlen && (!BANDED || p <= w) {
+                    let b = if p == 1 { 0 } else { go_u8 };
+                    *c_dv.add(0) = b;
+                    *c_de.add(0) = b;
+                    // Row 0's max and argmax are hoisted out of the loop; see the closed form
+                    // above it. `abs[0]` goes with them: it is never read, because `i_from >= 1`
+                    // means the group loop never touches row 0.
+                }
+                if p <= qlen && (!BANDED || p <= w) {
+                    let b = if p == 1 { 0 } else { go_u8 };
+                    *c_dh.add(p) = b;
+                    *c_df.add(p) = b;
+                    // The corner seed, gated with the boundary it reads. Rows past `w` are
+                    // seeded at their real first column instead, by `seeds_row` above; between
+                    // the two, every row is seeded exactly once.
+                    if TRACK_ROW_MAX {
+                        // Row p enters the matrix here, at its column-0 cell. Seeding from
+                        // S[p,0] is load-bearing twice over: H[i][0] is a real argmax candidate,
+                        // and for a query segment nothing explains it is the only one; and this
+                        // write scrubs the garbage the partial chunk tail left on this row at
+                        // earlier anti-diagonals.
+                        //
+                        // No arg store: `j = 0` is what `arg_for_row` returns when no interior
+                        // cell of the row ever took the max, so the column-0 seed is implicit.
+                        let s_i0 = -(gap_open as i32) - (p as i32 - 1) * gap_extend as i32;
+                        *abs_ptr.add(p) = s_i0;
+                        *row_max_ptr.add(p) = s_i0;
+                    }
+                }
+
+                // While the anti-diagonal still grows downwards the bottom cell is (p, 0), a
+                // boundary known in closed form. Once it slides right the bottom row is pinned
+                // at qlen and each step adds one ΔV, un-offset. At p = qlen + rlen that lands
+                // exactly on S[qlen][rlen].
+                //
+                // `anchor` is dead in the `TRACK_ROW_MAX` modes but needs no gate: every call
+                // site is in this crate, so the unused return value should be enough for LLVM to
+                // kill the chain including the `c_dv[qlen]` load. If it ever does not, the cost
+                // is one stale in-bounds read, not a wrong answer.
+                anchor = if p <= qlen {
+                    if p == 1 {
+                        -(gap_open as i64)
+                    } else {
+                        anchor - ge
+                    }
+                } else {
+                    anchor + *c_dv.add(qlen) as i64 - (go + ge)
+                };
+
+                if TRACK_LAST_ROW && p >= qlen && anchor > best_score {
+                    best_score = anchor;
+                    best_j = p - qlen;
+                }
+
+                std::mem::swap(&mut p_dh, &mut c_dh);
+                std::mem::swap(&mut p_dv, &mut c_dv);
+                std::mem::swap(&mut p_de, &mut c_de);
+                std::mem::swap(&mut p_df, &mut c_df);
+
+                // Advance the row range for p+1. AFTER the body, not before: incrementing on
+                // entry reads min(qlen, p) where the body wants min(qlen, p-1), which is what
+                // the debug_assert above pins.
+                if i_to < qlen {
+                    i_to += 1;
+                }
+                if p > rlen {
+                    i_from += 1;
+                }
+                if BANDED {
+                    (prev_lo, prev_hi) = (lo, hi);
+                    // Which of the two band edges advances is a single parity bit:
+                    // `b_hi = floor((p + w) / 2)` steps when `p + w` becomes even, `b_lo` when
+                    // it becomes odd. This is that test for `p + 1`.
+                    //
+                    // `p + 1 > w` is `band_rows`' `saturating_sub`, carried rather than
+                    // recomputed: until the band's lower edge lifts off row 0 it must not move
+                    // at all, or the strip walks off the top of the matrix.
+                    if (p + 1 + w).is_multiple_of(2) {
+                        b_hi += 1;
+                    } else if p + 1 > w {
+                        b_lo += 1;
+                    }
+                }
+            }
+
+            // The bound `size_flags` computed, against the chunks this fill actually wrote.
+            // `chunk` is one past the last one written, so `<=` is the exact condition. Every
+            // store above is unchecked, so a bound that is too tight is heap corruption rather
+            // than a wrong score.
+            //
+            // Read the lengths here rather than hoisting them beside `tb_ptr`: the chunk loop is
+            // register-starved, and down here the whole thing is inside the `debug_assert!` so a
+            // release build reads nothing at all.
+            debug_assert!(
+                !TRACE || chunk * TB_WORDS <= self.tb.len(),
+                "the fill wrote {chunk} chunks but tb holds {} ({TB_WORDS} words per chunk): \
+                 the chunk bound is too tight, and every store past it was heap corruption",
+                self.tb.len() / TB_WORDS,
+            );
+            debug_assert!(
+                !(TRACE && TRACK_ROW_MAX) || chunk * NM_WORDS <= self.nm.len(),
+                "the fill wrote {chunk} chunks but nm holds {} - see the tb assert above",
+                self.nm.len() / NM_WORDS
+            );
+            if TRACK_ROW_MAX {
+                self.row0_arg = row0_arg;
+            }
+            if TRACK_LAST_ROW {
+                (best_score as i32, best_j)
+            } else {
+                (anchor as i32, rlen)
+            }
+        }
+    }
+}

--- a/src/simdaligner/mod.rs
+++ b/src/simdaligner/mod.rs
@@ -82,7 +82,7 @@ mod kernel;
 #[cfg(test)]
 mod tests;
 
-pub use aligner::SimdAligner;
+pub use aligner::{InvalidScores, SimdAligner, check_scores};
 
 // Re-exported so the kernel can reach them as `super::Cigar` without a conversion at the
 // boundary.

--- a/src/simdaligner/mod.rs
+++ b/src/simdaligner/mod.rs
@@ -1,0 +1,175 @@
+//! Exact pairwise sequence alignment with affine gap costs.
+//!
+//! The entry point is [`SimdAligner`]: build one with a [`Scores`] scheme (or
+//! [`Scores::default()`]) and call an alignment method on it repeatedly. Construct
+//! one per thread and reuse it; the scoring matrix and every scratch buffer live
+//! inside it and are reused across calls.
+//!
+//! Five alignment types are named on a single axis, *which side is local*, i.e. free
+//! to stop or start wherever it scores best:
+//!
+//! - [`SimdAligner::global_alignment`]: nothing is local; both sequences are aligned
+//!   end to end.
+//! - [`SimdAligner::local_reference_end_alignment`]: the query is still spanned in
+//!   full, but the reference may stop anywhere and its trailing tail is free.
+//! - [`SimdAligner::local_reference_start_alignment`]: the mirror. The reference may
+//!   *begin* anywhere and its leading prefix is free.
+//! - [`SimdAligner::local_end_alignment`]: both sequences start at 0 and the alignment
+//!   ends wherever it scores best; both trailing tails are free, and
+//!   [`Scores::end_bonus`] nudges it towards covering the whole query.
+//! - [`SimdAligner::local_start_alignment`]: the mirror. The alignment *begins*
+//!   wherever it scores best and both leading prefixes are free.
+//!
+//! And one on a second axis, *which side is split*, taking **two** references:
+//!
+//! - [`SimdAligner::split_reference_alignment`]: one query aligned across a
+//!   `left_reference` and a `right_reference` with a single jump between them,
+//!   returning two [`AlignmentResult`]s that partition the query exactly. Built for
+//!   spotting a tandem duplication that a linear aligner reported as an insertion.
+//!
+//! ```
+//! use strobealign::simdaligner::{SimdAligner, Scores};
+//! let mut aligner = SimdAligner::new(Scores::default());
+//! let result = aligner.global_alignment(b"ACGTACGT", b"ACGTTACGT", None);
+//! assert_eq!(result.cigar.to_string(), "3=1D5=");
+//! ```
+//!
+//! Every alignment method takes a trailing `bandwidth: Option<usize>`: `None` aligns
+//! exactly, `Some(w)` confines the fill to `w` diagonals either side of the anchor
+//! diagonal. Each method's own `# bandwidth` section says where its band is anchored and
+//! whether `w` can be widened.
+//!
+//! # Alphabet
+//! The alphabet is **A, C, G, T and U** (case-insensitive), and nothing else. `U` is RNA's
+//! T-equivalent and scores identically to `T`.
+//!
+//! Any other byte (`N`, an IUPAC ambiguity code, a `-` from a gapped FASTA, a stray `\n`) is
+//! **unknown**, and an unknown byte never scores as a match against anything, *including
+//! another unknown byte*.
+//!
+//! `=`/`X` in the CIGAR are **literal byte identity**, deliberately decoupled from how a
+//! position scored. So `U` against `T` scores as a match but reports `X`, and an unknown byte
+//! against a byte-identical copy of itself scores as a mismatch but reports `=`. Scoring is
+//! about biology; `=`/`X` is about the bytes the caller handed us.
+//!
+//! # Guarantees
+//! With `bandwidth: None` the alignment is *exact* at every length: the reported score is the
+//! optimal score under the given scheme, and the CIGAR is an alignment achieving it. There is
+//! no x-drop and no early exit. With `Some(w)` it is optimal among alignments staying inside
+//! the band. Either way every input pair produces an alignment, including ones whose optimal
+//! score is negative.
+//!
+//! `piecewisealigner.rs` passes `None` between anchors and `Some(w)` for the end extensions, so
+//! "exact" is not a property of the aligner as strobealign uses it.
+//!
+//! # The kernel
+//! One kernel (u8 lanes on a difference recurrence) and every call takes it. Written once,
+//! generic over [`backend::Backend`], and instantiated per instruction set: AVX2 at 32 lanes,
+//! SSE4.1 / NEON / wasm simd128 at 16, and a portable [`backend::Scalar`] fallback at 16 that
+//! uses arrays instead of registers. [`SimdAligner::new`] picks the fastest one this machine can
+//! run and **never panics for want of an instruction set**; [`SimdAligner::is_supported`] reports
+//! whether that pick was a vectorized one.
+//!
+//! The **scoring scheme** is bounded, though (`match + 3*gap_open - gap_extend <= 255`, i.e.
+//! `gap_open <= ~84` at `match = 2`), and [`SimdAligner::new`] rejects anything past it rather
+//! than silently wrap a lane. Sequence *lengths* are not: every stored value is bounded by the
+//! scheme alone, with no length term.
+
+mod aligner;
+pub mod backend;
+mod kernel;
+
+#[cfg(test)]
+mod tests;
+
+pub use aligner::SimdAligner;
+
+// Re-exported so the kernel can reach them as `super::Cigar` without a conversion at the
+// boundary.
+pub use super::{
+    aligner::Scores,
+    cigar::{Cigar, CigarOperation},
+};
+
+/// Kernel internals, for tests. **Not part of the alignment API.**
+#[doc(hidden)]
+pub mod internal {
+    pub use super::backend::{Backend, Scalar};
+    pub use super::kernel::{U8Probe, fits_u8_lanes};
+
+    #[cfg(all(
+        target_arch = "aarch64",
+        target_feature = "neon",
+        target_endian = "little"
+    ))]
+    pub use super::backend::Neon;
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    pub use super::backend::Simd128;
+    #[cfg(target_arch = "x86_64")]
+    pub use super::backend::{Avx2, Sse41};
+
+    /// The lane count of the widest kernel this build has. Anything backend-aware should read
+    /// `B::LANES` instead; this stays 32 on x86_64 so that an out-of-tree oracle written against
+    /// the AVX2 kernel does not silently start testing a different width.
+    #[cfg(target_arch = "x86_64")]
+    pub const U8_LANES: usize = <Avx2 as Backend>::LANES;
+    #[cfg(not(target_arch = "x86_64"))]
+    pub const U8_LANES: usize = 16;
+}
+
+/// Result of aligning a query against a reference.
+///
+/// `query_start`/`query_end`/`ref_start`/`ref_end` are half-open ranges into the
+/// original slices, and the `cigar` covers exactly those ranges and nothing else: a
+/// free end gap is **not** represented in the CIGAR.
+///
+/// Which of the four coordinates can move depends on the alignment type:
+///
+/// - [`SimdAligner::global_alignment`]: both spans cover their inputs in full.
+/// - [`SimdAligner::local_reference_end_alignment`]: the query span is still the whole
+///   query, but `ref_end` is wherever the alignment chose to stop.
+/// - [`SimdAligner::local_reference_start_alignment`]: likewise, but it is `ref_start`
+///   that moves and `ref_end` is always `reference.len()`.
+/// - [`SimdAligner::local_end_alignment`]: `query_end` and `ref_end` both move.
+/// - [`SimdAligner::local_start_alignment`]: `query_start` and `ref_start` both move.
+///
+/// `Default` is the **empty alignment**: score 0, all four coordinates at 0, and an empty
+/// CIGAR. It is a real result, returned by [`SimdAligner::local_end_alignment`] when no
+/// extension scores better than stopping immediately.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AlignmentResult {
+    pub score: i32,
+    pub query_start: usize,
+    pub query_end: usize,
+    pub ref_start: usize,
+    pub ref_end: usize,
+    pub cigar: Cigar,
+}
+
+/// Result of [`SimdAligner::split_reference_alignment`]: one query aligned across two
+/// references, with a single jump point between them.
+///
+/// The two arms **partition the query exactly**: `right.query_start` is 0,
+/// `left.query_end` is `query.len()`, and `right.query_end == left.query_start` (the
+/// jump point). Each arm's CIGAR covers its own half of the query against its own
+/// reference span, and the two CIGARs together consume every query base once.
+///
+/// `right` is anchored at the start of `right_reference` (`ref_start == 0`) and may
+/// stop anywhere; `left` is anchored at the end of `left_reference`
+/// (`ref_end == left_reference.len()`) and may begin anywhere.
+///
+/// `score` is `left.score + right.score`, and unlike the local types it **can be
+/// negative**: the query must be covered whether or not either reference explains it.
+/// An arm may be the empty alignment, or may consume no reference at all and report its
+/// query segment as one pure insertion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SplitReferenceAlignment {
+    /// The arm against `left_reference`: covers the query *suffix*, and ends at the
+    /// end of the left reference.
+    pub left: AlignmentResult,
+    /// The arm against `right_reference`: covers the query *prefix*, and starts at the
+    /// start of the right reference.
+    pub right: AlignmentResult,
+    /// `left.score + right.score`.
+    pub score: i32,
+}

--- a/src/simdaligner/tests.rs
+++ b/src/simdaligner/tests.rs
@@ -1,0 +1,451 @@
+//! Fast, hardcoded sanity tests for the public aligner API, against whichever backend
+//! `select_backend` picks on the host.
+//!
+//! These are deliberately *not* an oracle suite: nothing sweeps randomized inputs, and the
+//! differential testing against the portable kernel lives in `backend/tests.rs`. They are
+//! hand-written cases with hand-checked expected values, meant to catch an obvious break quickly.
+//!
+//! Two invariants are worth more than the individual cases, and every test that produces an
+//! alignment routes through them via [`check`]:
+//!
+//! 1. **The CIGAR re-scores to the reported score.** A wrong traceback under a right score is
+//!    this kernel's characteristic failure (see `TB_FROM_DIAG` in `kernel.rs`), and comparing
+//!    scores alone cannot see it.
+//! 2. **The CIGAR's consumption matches the reported spans**, so the coordinates and the
+//!    operations cannot disagree about how much sequence was used.
+
+use super::{AlignmentResult, Scores, SimdAligner};
+
+const SCORES: Scores = Scores {
+    match_: 2,
+    mismatch: 8,
+    gap_open: 12,
+    gap_extend: 1,
+    end_bonus: 10,
+};
+
+fn aligner() -> SimdAligner {
+    SimdAligner::new(SCORES)
+}
+
+/// The kernel's scoring alphabet: A/C/G/T/U, case-insensitive. Anything else is unknown and
+/// never matches, *including another unknown byte*.
+fn scores_as_match(q: u8, r: u8) -> bool {
+    fn code(b: u8) -> Option<u8> {
+        match b.to_ascii_uppercase() {
+            b'A' => Some(0),
+            b'C' => Some(1),
+            b'G' => Some(2),
+            b'T' | b'U' => Some(3),
+            _ => None,
+        }
+    }
+    matches!((code(q), code(r)), (Some(a), Some(b)) if a == b)
+}
+
+/// Parse a CIGAR string back into `(len, op)` pairs.
+fn parse(cigar: &str) -> Vec<(usize, char)> {
+    let mut out = vec![];
+    let mut len = 0usize;
+    for ch in cigar.chars() {
+        if let Some(d) = ch.to_digit(10) {
+            len = len * 10 + d as usize;
+        } else {
+            out.push((len, ch));
+            len = 0;
+        }
+    }
+    assert_eq!(
+        len, 0,
+        "CIGAR ended with a length and no operation: {cigar}"
+    );
+    out
+}
+
+/// Re-score `result`'s CIGAR against the sequences it claims to align, and assert it agrees
+/// with the reported score and spans. `end_bonus` is added by the caller for the modes that
+/// earn it, since the CIGAR itself cannot show whether the query was spanned.
+fn check(result: &AlignmentResult, query: &[u8], reference: &[u8], end_bonus: i32) {
+    let (mut qi, mut ri) = (result.query_start, result.ref_start);
+    let mut score = 0i32;
+
+    for (len, op) in parse(&result.cigar.to_string()) {
+        match op {
+            '=' | 'X' | 'M' => {
+                for _ in 0..len {
+                    let (q, r) = (query[qi], reference[ri]);
+                    score += if scores_as_match(q, r) {
+                        SCORES.match_ as i32
+                    } else {
+                        -(SCORES.mismatch as i32)
+                    };
+                    // `=`/`X` are literal byte identity, decoupled from how the cell scored.
+                    if op != 'M' {
+                        let identical = q.eq_ignore_ascii_case(&r);
+                        assert_eq!(
+                            identical,
+                            op == '=',
+                            "op {op} at query[{qi}]={} reference[{ri}]={} disagrees with byte identity",
+                            q as char,
+                            r as char
+                        );
+                    }
+                    qi += 1;
+                    ri += 1;
+                }
+            }
+            'I' => {
+                score -= SCORES.gap_open as i32 + (len as i32 - 1) * SCORES.gap_extend as i32;
+                qi += len;
+            }
+            'D' => {
+                score -= SCORES.gap_open as i32 + (len as i32 - 1) * SCORES.gap_extend as i32;
+                ri += len;
+            }
+            other => panic!("unexpected CIGAR operation {other}"),
+        }
+    }
+
+    assert_eq!(
+        qi, result.query_end,
+        "CIGAR consumed query up to {qi} but result says {}",
+        result.query_end
+    );
+    assert_eq!(
+        ri, result.ref_end,
+        "CIGAR consumed reference up to {ri} but result says {}",
+        result.ref_end
+    );
+    assert_eq!(
+        score + end_bonus,
+        result.score,
+        "CIGAR {} re-scores to {} but result says {}",
+        result.cigar,
+        score + end_bonus,
+        result.score
+    );
+}
+
+/// Assert a global alignment's score and CIGAR, and re-score it.
+fn global_case(query: &[u8], reference: &[u8], score: i32, cigar: &str) {
+    let result = aligner().global_alignment(query, reference, None);
+    check(&result, query, reference, 0);
+    assert_eq!(result.score, score);
+    assert_eq!(result.cigar.to_string(), cigar);
+    assert_eq!((result.query_start, result.query_end), (0, query.len()));
+    assert_eq!((result.ref_start, result.ref_end), (0, reference.len()));
+}
+
+// ---------------------------------------------------------------------------------
+// Global.
+// ---------------------------------------------------------------------------------
+
+#[test]
+fn global_perfect_match() {
+    global_case(b"AAATTT", b"AAATTT", 6 * 2, "6=");
+}
+
+#[test]
+fn global_complete_mismatch() {
+    global_case(b"AAA", b"TTT", 3 * -8, "3X");
+}
+
+#[test]
+fn global_single_mismatch() {
+    global_case(b"AAATAA", b"AAAAAA", 5 * 2 - 8, "3=1X2=");
+}
+
+#[test]
+fn global_gap_in_query() {
+    global_case(b"AAATTT", b"AAAATTTT", 6 * 2 - 12 - 1, "3=2D3=");
+}
+
+#[test]
+fn global_gap_in_reference() {
+    global_case(b"AAAATTTT", b"AAATTT", 6 * 2 - 12 - 1, "3=2I3=");
+}
+
+// The four end-gap cases exercise the boundary cells, which the fill writes after the chunk
+// loop rather than before, a hazard called out in the kernel's module docs.
+
+#[test]
+fn global_gap_at_query_start() {
+    global_case(b"AAATTT", b"TTAAATTT", 6 * 2 - 12 - 1, "2D6=");
+}
+
+#[test]
+fn global_gap_at_query_end() {
+    global_case(b"AAATTT", b"AAATTTAA", 6 * 2 - 12 - 1, "6=2D");
+}
+
+#[test]
+fn global_gap_at_reference_start() {
+    global_case(b"TTAAATTT", b"AAATTT", 6 * 2 - 12 - 1, "2I6=");
+}
+
+#[test]
+fn global_gap_at_reference_end() {
+    global_case(b"AAATTTAA", b"AAATTT", 6 * 2 - 12 - 1, "6=2I");
+}
+
+#[test]
+fn global_multiple_mismatches() {
+    global_case(
+        b"ATATATATAT",
+        b"AAAAAAAAAA",
+        5 * 2 - 5 * 8,
+        "1=1X1=1X1=1X1=1X1=1X",
+    );
+}
+
+#[test]
+fn global_complex_alignment() {
+    global_case(
+        b"AAACTTAAACCTT",
+        b"AAAATTGAAATT",
+        10 * 2 - 8 - 2 * 12 - 1,
+        "3=1X2=1D3=2I2=",
+    );
+}
+
+#[test]
+fn global_empty_query_is_all_deletion() {
+    let result = aligner().global_alignment(b"", b"ACGT", None);
+    check(&result, b"", b"ACGT", 0);
+    assert_eq!(result.score, -(12 + 3));
+    assert_eq!(result.cigar.to_string(), "4D");
+}
+
+#[test]
+fn global_both_empty() {
+    let result = aligner().global_alignment(b"", b"", None);
+    assert_eq!(result.score, 0);
+    assert!(result.cigar.is_empty());
+}
+
+// ---------------------------------------------------------------------------------
+// The local modes the piecewise extension path actually calls.
+// ---------------------------------------------------------------------------------
+
+#[test]
+fn local_end_stops_before_a_bad_tail() {
+    // The reference matches for 6 bases then diverges completely. Extending into the tail
+    // costs more than it earns, so the alignment stops at the divergence.
+    let (query, reference) = (b"AAATTTGGGGGG", b"AAATTTCCCCCC");
+    let result = aligner().local_end_alignment(query, reference, None);
+    check(&result, query, reference, 0);
+    assert_eq!(result.score, 6 * 2);
+    assert_eq!(result.cigar.to_string(), "6=");
+    assert_eq!((result.query_start, result.query_end), (0, 6));
+    assert_eq!((result.ref_start, result.ref_end), (0, 6));
+}
+
+#[test]
+fn local_end_spans_the_query_for_the_end_bonus() {
+    // A single trailing mismatch is worth crossing: -8 for the mismatch against +10 of
+    // end_bonus for reaching the end of the query.
+    let (query, reference) = (b"AAATTTG", b"AAATTTC");
+    let result = aligner().local_end_alignment(query, reference, None);
+    check(&result, query, reference, SCORES.end_bonus as i32);
+    assert_eq!(result.score, 6 * 2 - 8 + 10);
+    assert_eq!(result.cigar.to_string(), "6=1X");
+    assert_eq!(result.query_end, 7);
+}
+
+#[test]
+fn local_end_never_scores_below_zero() {
+    // Nothing is worth aligning, so the empty alignment wins.
+    let result = aligner().local_end_alignment(b"GGGG", b"CCCC", None);
+    assert_eq!(result.score, 0);
+    assert!(result.cigar.is_empty());
+    assert_eq!((result.query_end, result.ref_end), (0, 0));
+}
+
+#[test]
+fn local_start_is_the_mirror_of_local_end() {
+    // Same shape as `local_end_stops_before_a_bad_tail`, reversed: the junk is a leading
+    // prefix and the alignment begins after it.
+    let (query, reference) = (b"GGGGGGAAATTT", b"CCCCCCAAATTT");
+    let result = aligner().local_start_alignment(query, reference, None);
+    check(&result, query, reference, 0);
+    assert_eq!(result.score, 6 * 2);
+    assert_eq!(result.cigar.to_string(), "6=");
+    assert_eq!((result.query_start, result.query_end), (6, 12));
+    assert_eq!((result.ref_start, result.ref_end), (6, 12));
+}
+
+#[test]
+fn local_reference_end_spans_the_whole_query() {
+    // The query is spanned in full; only the reference's trailing tail is free.
+    let (query, reference) = (b"AAATTT", b"AAATTTGGGGGGGG");
+    let result = aligner().local_reference_end_alignment(query, reference, None);
+    check(&result, query, reference, 0);
+    assert_eq!(result.score, 6 * 2);
+    assert_eq!((result.query_start, result.query_end), (0, 6));
+    assert_eq!(result.ref_end, 6);
+}
+
+#[test]
+fn local_reference_start_spans_the_whole_query() {
+    let (query, reference) = (b"AAATTT", b"GGGGGGGGAAATTT");
+    let result = aligner().local_reference_start_alignment(query, reference, None);
+    check(&result, query, reference, 0);
+    assert_eq!(result.score, 6 * 2);
+    assert_eq!((result.query_start, result.query_end), (0, 6));
+    assert_eq!((result.ref_start, result.ref_end), (8, 14));
+}
+
+// ---------------------------------------------------------------------------------
+// Banding. `piecewisealigner.rs` always passes `Some(bandwidth)` for the end extensions and
+// lets the aligner decide, so at the default `--bw 1024` a short-read extension takes the exact
+// path anyway and only long reads are really banded. These pin the two things that make it safe:
+// a band wide enough to reach every cell reproduces the exact answer, and a band too narrow for
+// the optimum still returns a consistent alignment.
+// ---------------------------------------------------------------------------------
+
+#[test]
+fn a_band_wider_than_the_problem_matches_the_exact_answer() {
+    let query = b"ACGTACGTAAGGTTCCAACGTTGGCCAATTGGCCAAGGTTCCAA";
+    let reference = b"ACGTACGTAAGGTACCAACGTTGGCCAATTGCCCAAGGTTCCAA";
+    let mut aligner = aligner();
+
+    let exact = aligner.global_alignment(query, reference, None);
+    for w in [64, 128, 1024] {
+        let banded = aligner.global_alignment(query, reference, Some(w));
+        assert_eq!(banded.score, exact.score, "band {w} changed the score");
+        assert_eq!(
+            banded.cigar.to_string(),
+            exact.cigar.to_string(),
+            "band {w} changed the CIGAR"
+        );
+    }
+}
+
+#[test]
+fn a_narrow_band_still_returns_a_consistent_alignment() {
+    // A band too narrow to contain the optimum must still produce a self-consistent result:
+    // the score it reports is the score its own CIGAR achieves.
+    let query = b"AAAAAAAAAACCCCCCCCCCGGGGGGGGGGTTTTTTTTTT";
+    let reference = b"AAAAAAAAAAGGGGGGGGGGTTTTTTTTTT";
+    let result = aligner().global_alignment(query, reference, Some(2));
+    check(&result, query, reference, 0);
+}
+
+#[test]
+fn a_band_is_never_worse_than_the_exact_optimum() {
+    let query = b"AAAAAAAAAACCCCCCCCCCGGGGGGGGGGTTTTTTTTTT";
+    let reference = b"AAAAAAAAAAGGGGGGGGGGTTTTTTTTTT";
+    let mut aligner = aligner();
+    let exact = aligner.global_alignment(query, reference, None);
+    let banded = aligner.global_alignment(query, reference, Some(2));
+    assert!(
+        banded.score <= exact.score,
+        "banded score {} beat the exact optimum {}",
+        banded.score,
+        exact.score
+    );
+}
+
+// ---------------------------------------------------------------------------------
+// Alphabet. Scoring is biological; `=`/`X` is literal byte identity. They disagree on
+// purpose, and `check` asserts the byte-identity half on every case above.
+// ---------------------------------------------------------------------------------
+
+#[test]
+fn u_scores_as_t_but_reports_a_mismatch_operation() {
+    let result = aligner().global_alignment(b"ACGU", b"ACGT", None);
+    assert_eq!(result.score, 4 * 2, "U should score as T");
+    assert_eq!(
+        result.cigar.to_string(),
+        "3=1X",
+        "U vs T is not byte-identical, so it reports X"
+    );
+}
+
+#[test]
+fn case_is_ignored() {
+    let result = aligner().global_alignment(b"acgt", b"ACGT", None);
+    assert_eq!(result.score, 4 * 2);
+}
+
+#[test]
+fn unknown_bytes_never_match_even_themselves() {
+    // Two identical `N`s: byte-identical, so the CIGAR says `=`, but they score as mismatches.
+    let result = aligner().global_alignment(b"ANNT", b"ANNT", None);
+    assert_eq!(
+        result.score,
+        2 * 2 - 2 * 8,
+        "N must not match N; got {}",
+        result.cigar
+    );
+    assert_eq!(result.cigar.to_string(), "4=");
+}
+
+// ---------------------------------------------------------------------------------
+// Split reference: one query across two references with a single jump.
+// ---------------------------------------------------------------------------------
+
+#[test]
+fn split_reference_partitions_the_query() {
+    let query = b"AAAATTTTCCCCGGGG";
+    let left = b"CCCCGGGG";
+    let right = b"AAAATTTT";
+    let result = aligner().split_reference_alignment(query, left, right, None);
+
+    check(&result.right, query, right, 0);
+    check(&result.left, query, left, 0);
+
+    assert_eq!(result.score, result.left.score + result.right.score);
+    assert_eq!(
+        result.right.query_start, 0,
+        "the right arm covers the query prefix"
+    );
+    assert_eq!(
+        result.left.query_end,
+        query.len(),
+        "the left arm covers the query suffix"
+    );
+    assert_eq!(
+        result.right.query_end, result.left.query_start,
+        "the two arms must meet at the jump point"
+    );
+    assert_eq!(result.score, 16 * 2);
+}
+
+// ---------------------------------------------------------------------------------
+// Scale: enough to cross the 32-lane chunking and the anti-diagonal bookkeeping, still fast.
+// ---------------------------------------------------------------------------------
+
+#[test]
+fn a_few_hundred_bases_stay_consistent() {
+    let unit = b"ACGTTGCAAGGCTTAC";
+    let query: Vec<u8> = unit.iter().cycle().take(500).copied().collect();
+    let mut reference = query.clone();
+    reference[100] = b'A';
+    reference[101] = b'A';
+    reference.remove(300);
+
+    let result = aligner().global_alignment(&query, &reference, None);
+    check(&result, &query, &reference, 0);
+    assert_eq!(result.query_end, query.len());
+    assert_eq!(result.ref_end, reference.len());
+    assert!(
+        result.score > 400 * 2,
+        "a near-identical 500-base pair should score well; got {}",
+        result.score
+    );
+}
+
+#[test]
+fn identical_long_sequences_are_one_run_of_matches() {
+    let query: Vec<u8> = b"ACGTTGCAAGGCTTAC"
+        .iter()
+        .cycle()
+        .take(300)
+        .copied()
+        .collect();
+    let result = aligner().global_alignment(&query, &query, None);
+    check(&result, &query, &query, 0);
+    assert_eq!(result.score, 300 * 2);
+    assert_eq!(result.cigar.to_string(), "300=");
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -37,6 +37,26 @@ fn fail_with_unknown_argument() {
     cmd.arg("-G").assert().failure();
 }
 
+/// A scoring scheme the aligner cannot use must be reported, not panicked on, and must be
+/// rejected before the reference is indexed.
+#[test]
+fn fail_gracefully_on_unusable_scoring_scheme() {
+    for args in [
+        ["-O", "100"].as_slice(),          // exceeds the kernel's 8-bit lanes
+        ["-O", "1", "-E", "5"].as_slice(), // gap open below gap extend
+        ["-L", "3000000000"].as_slice(),   // end bonus past i32
+    ] {
+        let mut cmd = cmd();
+        cmd.args(args)
+            .args(["tests/phix.fasta", "tests/phix.1.fastq"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Invalid scoring scheme"))
+            .stderr(predicate::str::contains("panicked").not())
+            .stderr(predicate::str::contains("Total time indexing").not());
+    }
+}
+
 #[test]
 fn success_when_printing_help() {
     let mut cmd = cmd();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -57,6 +57,19 @@ fn fail_gracefully_on_unusable_scoring_scheme() {
     }
 }
 
+/// The bound belongs to the piecewise kernel, so --ssw must still accept a scheme that only the
+/// kernel cannot represent.
+#[test]
+fn accept_any_scoring_scheme_with_ssw() {
+    let mut cmd = cmd();
+    cmd.args(["--ssw", "-O", "100"])
+        .args(["tests/phix.fasta", "tests/phix.1.fastq"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Invalid scoring scheme").not())
+        .stderr(predicate::str::contains("panicked").not());
+}
+
 #[test]
 fn success_when_printing_help() {
     let mut cmd = cmd();


### PR DESCRIPTION
Replace block-aligner with an in-house SIMD aligner in `src/simdaligner`, for both places the piecewise path used it: the global alignments between anchors and the extensions off the first and last anchor. Single-end only, since paired-end still extends with SSW.

I wanted this for two reasons. It is faster, and it is custom, so we can add the alignment types we need instead of working around what our dependency offers. `split_reference_alignment` is the first of those, aligning one query across two references with a single jump, which is what I will need to tell a tandem duplication from an insertion. strobealign calls three of the six modes the module exposes, `split_reference_alignment` and the two `local_reference_*` modes are unused for now.

This has 3000+ lines of code, written with Claude... I made sure to read ALL of them before making this PR. I don't claim that every line is perfect, or that the code is written like we would normally have written it, for example about 40% of it is documentation, and uses rust compile-time boolean const generics that we never use in the codebase before. I would treat the module more like a separate internal component than an ordinary extension of the existing codebase. That said, I am comfortable guaranteeing the high-level logic and design, and I have reviewed the implementation closely enough to be confident of it's correctness. The backend tests, end-to-end equivalence tests, and alignment level checks are also intended to put some guardrails around the parts that are easiest to get wrong. This is not a claim that the codebase is flawless, it is a deliberate tradeoff to get a custom, substantially faster aligner into strobealign while keeping the implementation self-contained and testable in a short amount of time.


## The kernel

Affine-gap alignment on the difference recurrence of Suzuki & Kasahara ([BMC Bioinformatics, 2018](https://link.springer.com/article/10.1186/s12859-018-2014-8)). Storing differences instead of absolute cell values bounds every stored value by the scoring scheme alone, with no length term, so 8-bit lanes hold at any sequence length and an AVX2 register holds 32 cells. The problem is that not every scoring scheme fits the bound.

It is written once and generic over a `Backend` of 21 operations, each a single intrinsic, so an instruction set costs a transcription rather than an aligner: AVX2 at 32 lanes, SSE4.1, NEON and wasm simd128 at 16, and a portable fallback for anything else. The pick happens at runtime on x86_64 and never panics for want of an instruction set. CI covers AVX2 and SSE4.1 on `ubuntu-latest` and NEON on `macos-latest`, but no wasm target is built, so treat simd128 as untested.

Vector code adds 93 `unsafe` blocks, all of them under `src/simdaligner`. 80 are in the backends, and 72 of those are a single intrinsic call, unsafe only because the intrinsic needs a target feature the CPU may not have. Of the remaining 8, five forward to the kernel and three build a movemask out of a shift and a reduction. That leaves 9 blocks in the shared kernel doing the pointer work, unchecked loads and stores into the DP and traceback buffers, and 4 in tests. `backend/tests.rs` checks all 21 operations of every backend and then checks the backends against each other end to end.

## What changes

Between anchors the call is unbanded and exact. block-aligner capped its block size (8192), so a long anchor gap could come back as a heuristic alignment and not an exact one. Among equally scoring alignments the CIGAR is the one minimising the edit distance, and it is built straight into strobealign's `Cigar`, so the three block-aligner translation helpers are gone.

Off the ends we now do a local start or end alignment, with no x-drop and no dynamic block sizes. We do use a heuristic, a bandwidth: confined to `w` diagonals either side of the anchor diagonal, optimal inside the band, and an alignment needing more than `w` bases of net indel out to the end of the read is unreachable. `--xdrop` is removed, `--bw` sets `w` and defaults to 1024. The band is there for runtime: an unbanded extension costs the read length times the reference extent, and is what makes very long reads with low chain coverage expensive (e.g. sim6 chrY at 20kb+ ).

The second commit checks `-A/-B/-O/-E/-L` at startup, because the kernel cannot represent every scoring scheme and previously found out by panicking after the whole index build. The third narrows that check to the piecewise path so `--ssw` does not reject schemes SSW handles fine. It is separable and droppable if we want.

`src/piecewisealigner.rs` loses 829 lines net, including the 23 block-aligner unit tests. `src/simdaligner` has 28 tests covering the six modes, re-scoring every returned CIGAR against its reported score and spans, plus the 11 backend-equivalence tests.

## Results

Accuracy vs runtime on 8 threads [ends.pdf](https://github.com/user-attachments/files/30547647/ends.pdf).

Table [ends-se-accuracy-table.pdf](https://github.com/user-attachments/files/30547649/ends-se-accuracy-table.pdf).

I evaluated single-end `align`, fruitfly/maize/chrY/CHM13 crossed with sim0/sim4/sim6, 50 to 30000 bp. Total wall clock over the sweep went from 2780 s to 882 s, a 3.15x. Replacing the global alignment alone takes it to 1207 s, the banded ends account for the rest. Per configuration the median speedup is 1.3-1.9x at 1 kb and below and 1.9-3.7x from 2.5 kb up, peaking at 3.7x at 20 kb. `map` mode is identical for all three tools, since nothing there aligns.

Replacing the global alignment changes nothing: accuracy is identical to main in all configurations, to the last digit reported, so that half is purely a runtime win. Only the end extensions change output. 52 of the 156 configurations move, 32 up and 20 down. The gains concentrate at 30 kb and go up to +0.40 points; every loss is at most 0.05 points. The fraction of reads aligned is unchanged everywhere.

Paired-end output is unchanged.

Closes #26 