### PR TITLE
Suggestion: Change -L description to bonus and not penality

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,7 @@ struct Args {
     #[arg(short = 'E', default_value_t = Scores::default().gap_extend, value_name = "N", help_heading = "Alignment")]
     gap_extension_penalty: u8,
 
-    /// Soft-clipping penalty
+    /// Bonus added to the alignment score when no soft-clipping occurs
     #[arg(short = 'L', default_value_t = Scores::default().end_bonus, value_name = "N", help_heading = "Alignment")]
     end_bonus: u32,
 


### PR DESCRIPTION
`-L` is described as "Soft-clipping penalty", but it sets the end bonus, which is added to the score when the alignment reaches the end of the read. Nothing is subtracted for clipped bases, and the value does not scale with how many there are.

I propose we change the description to explicitly say it's a bonus, which is also how CHANGES.md describes it (PR #250).