### PR TITLE
Scale the chaining lookback with read length, and precompute its log2 penalty

### DIFF
--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -57,19 +57,26 @@ pub struct Chainer {
     k: usize,
     parameters: ChainingParameters,
     precomputed_scores: [f32; N_PRECOMPUTED],
+    precomputed_log2: [f32; N_PRECOMPUTED],
 }
 
 impl Chainer {
     pub fn new(k: usize, parameters: ChainingParameters) -> Self {
+        let mut precomputed_log2 = [0f32; N_PRECOMPUTED];
+        #[allow(clippy::needless_range_loop)]
+        for d in 0..N_PRECOMPUTED {
+            precomputed_log2[d] = (d as f32 + 1f32).log2();
+        }
         let mut precomputed_scores = [0f32; N_PRECOMPUTED];
         #[allow(clippy::needless_range_loop)]
         for i in 0..N_PRECOMPUTED {
-            precomputed_scores[i] = compute_score(i, i, k, &parameters);
+            precomputed_scores[i] = compute_score(i, i, k, &parameters, &precomputed_log2);
         }
         Chainer {
             k,
             parameters,
             precomputed_scores,
+            precomputed_log2,
         }
     }
 
@@ -78,7 +85,7 @@ impl Chainer {
         if dq == dr && dq < N_PRECOMPUTED {
             self.precomputed_scores[dq]
         } else {
-            compute_score(dq, dr, self.k, &self.parameters)
+            compute_score(dq, dr, self.k, &self.parameters, &self.precomputed_log2)
         }
     }
 
@@ -285,7 +292,14 @@ impl Chainer {
 /// - `chaining_params`: Parameters controlling penalties:
 ///   - `diag_diff_penalty`: Multiplier for the absolute difference |dr - dq|, penalizing non-diagonal moves.
 ///   - `gap_length_penalty`: Multiplier for min(dq, dr), penalizing longer gaps.
-fn compute_score(dq: usize, dr: usize, k: usize, parameters: &ChainingParameters) -> f32 {
+/// - `precomputed_log2`: Table whose entry `d` equals `(d as f32 + 1.0).log2()`.
+fn compute_score(
+    dq: usize,
+    dr: usize,
+    k: usize,
+    parameters: &ChainingParameters,
+    precomputed_log2: &[f32; N_PRECOMPUTED],
+) -> f32 {
     let dd = dr.abs_diff(dq);
     let dg = dq.min(dr);
     let mut score = k.min(dg) as f32;
@@ -293,10 +307,11 @@ fn compute_score(dq: usize, dr: usize, k: usize, parameters: &ChainingParameters
 
     let lin_penalty =
         parameters.diag_diff_penalty * dd as f32 + parameters.gap_length_penalty * dg as f32;
-    let log_penalty = if dd >= 1 {
-        (dd as f32 + 1f32).log2()
+
+    let log_penalty = if dd < N_PRECOMPUTED {
+        precomputed_log2[dd]
     } else {
-        0.0
+        (dd as f32 + 1f32).log2()
     };
     score -= lin_penalty + 0.5 * log_penalty;
 
@@ -452,7 +467,7 @@ impl ChainingResult {
 
 #[cfg(test)]
 mod test {
-    use super::{Anchor, Chainer, ChainingParameters};
+    use super::*;
 
     #[test]
     fn chainer_early_break() {
@@ -511,5 +526,32 @@ mod test {
         // dr=11, dq=1 gives a diagonal ratio of 11.0, exceeding the default max of 10.
         // The two anchors cannot be chained, so the best score is that of a single anchor.
         assert_eq!(chaining_result.best_score, chainer.k as f32);
+    }
+
+    #[test]
+    fn precomputed_log2_is_exact() {
+        let chainer = Chainer::new(20, ChainingParameters::default());
+        for d in 0..N_PRECOMPUTED {
+            assert_eq!(
+                chainer.precomputed_log2[d].to_bits(),
+                (d as f32 + 1f32).log2().to_bits(),
+                "precomputed_log2[{d}] differs from the libm value"
+            );
+        }
+    }
+
+    #[test]
+    fn precomputed_scores_agree_with_computed() {
+        let parameters = ChainingParameters::default();
+        let chainer = Chainer::new(20, parameters.clone());
+        for dq in [0usize, 1, 7, 21, 64, 500, 1023, 1024, 5000] {
+            for dr in [0usize, 1, 7, 21, 64, 500, 1023, 1024, 5000] {
+                assert_eq!(
+                    chainer.compute_score_cached(dq, dr).to_bits(),
+                    compute_score(dq, dr, 20, &parameters, &chainer.precomputed_log2).to_bits(),
+                    "score differs at dq={dq} dr={dr}"
+                );
+            }
+        }
     }
 }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -88,6 +88,8 @@ impl Chainer {
             return ChainingResult::default();
         }
 
+        // dynamic maximum lookback window based on read length
+        let max_lookback = self.parameters.max_lookback.max(read_len / 200);
         // dynamic maximum allowed ref gap based on read length
         let max_ref_gap = self.parameters.max_ref_gap.unwrap_or(read_len);
 
@@ -97,7 +99,7 @@ impl Chainer {
         let mut best_index = usize::MAX;
 
         for i in 0..n {
-            let lookup_end = i.saturating_sub(self.parameters.max_lookback);
+            let lookup_end = i.saturating_sub(max_lookback);
             let ai = &anchors[i];
             for j in (lookup_end..i).rev() {
                 let aj = &anchors[j];


### PR DESCRIPTION
Two independent changes in `chainer.rs`.

`max_lookback` (`-H`) is a number of anchors, default 50. The number of anchors on a read grows with the read length, so 50 is too small for all long reads. At 30 kb the correct previous anchor is often further back than 50 positions in the sorted array, so the DP never looks at it, and the chain either breaks or comes out biased towards insertions. `-H` is now a floor and the lookback scales above it, `max_lookback.max(read_len / 200)`, so nothing changes at or below 10 kb.

The second commit precomputes log2. `compute_score` calls `log2f` for the diagonal penalty on the innermost line of the DP. It is now a 1024 entry table built in `Chainer::new`, and we still call libm for `dd >= 1024`. The table holds exactly what the call returns so the output is bit identical. This helps cut a little bit of the runtime at no cost to the outputs.

## Results

The `max_lookback` change is the only one affecting accuracy, while runtime is affected my the log2 change.

Accuracy vs runtime: [ends.pdf](https://github.com/user-attachments/files/30585951/ends.pdf)

Accuracy table: [ends-se-accuracy-table.pdf](https://github.com/user-attachments/files/30585952/ends-se-accuracy-table.pdf)

I evaluated single-end only, as the accuracy will only change for long reads. Accuracy is identical to main in all 12 cells at every length from 50 bp to 10 kb, which is expected since the lookback only grows past 50 above 10 kb. It moves in 19 of the 156 cells, all of them at 20 and 30 kb, and every one of the 19 is an improvement.

This is more of a "fix" for long reads above 10kbp, I have not evaluated if we could use a fully fine-tuned dynamic look-back window based on read length for all datasets.