### PR TITLE
Single-end: Remove is_consistent and verify anchor k-mers before the piecewise extension

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -21,7 +21,7 @@ use crate::io::sam::{
 };
 use crate::math::normal_pdf;
 use crate::mcsstrategy::McsStrategy;
-use crate::piecewisealigner::remove_spurious_anchors;
+use crate::piecewisealigner::{remove_spurious_anchors, retain_verified_anchors};
 use crate::read::Read;
 use crate::refseq::RefSequence;
 use crate::revcomp::reverse_complement;
@@ -399,7 +399,9 @@ pub fn align_single_end_read(
         let consistent_chain = chain.is_consistent(&read, refseq, k);
         if !consistent_chain {
             details.inconsistent_chains += 1;
-            continue;
+            if mapping_parameters.use_ssw {
+                continue;
+            }
         }
         let Some(alignment) = extend_seed(
             aligner,
@@ -408,6 +410,7 @@ pub fn align_single_end_read(
             &read,
             consistent_chain,
             mapping_parameters.use_ssw,
+            k,
         ) else {
             continue;
         };
@@ -534,6 +537,7 @@ fn extend_seed(
     read: &Read,
     consistent_chain: bool,
     use_ssw: bool,
+    k: usize,
 ) -> Option<Alignment> {
     let query = if chain.is_revcomp {
         read.rc()
@@ -590,7 +594,7 @@ fn extend_seed(
             let decode_start = chain.ref_start.saturating_sub(query.len() + padding);
             let decode_end = (chain.ref_end + query.len() + padding).min(seq.len());
             let decoded_ref = seq.decode(decode_start, decode_end);
-            let adjusted_anchors: Vec<Anchor> = chain
+            let mut adjusted_anchors: Vec<Anchor> = chain
                 .anchors
                 .iter()
                 .map(|a| Anchor {
@@ -599,6 +603,10 @@ fn extend_seed(
                     query_start: a.query_start,
                 })
                 .collect();
+            retain_verified_anchors(&mut adjusted_anchors, query, &decoded_ref, k);
+            if adjusted_anchors.is_empty() {
+                return None;
+            }
             info = aligner.align_piecewise(query, &decoded_ref, &adjusted_anchors, padding)?;
             result_ref_start = info.ref_start + decode_start;
         }
@@ -857,6 +865,7 @@ fn extend_paired_seeds(
             read1,
             consistent_chain1,
             true, // SSW
+            k,
         );
         let alignment2 = extend_seed(
             aligner,
@@ -865,6 +874,7 @@ fn extend_paired_seeds(
             read2,
             consistent_chain2,
             true, // SSW
+            k,
         );
         if let (Some(alignment1), Some(alignment2)) = (alignment1, alignment2) {
             details[0].tried_alignment += 1;
@@ -900,6 +910,7 @@ fn extend_paired_seeds(
             reads[i],
             consistent_chain,
             true, // SSW
+            k,
         );
         details[i].tried_alignment += 1;
         details[i].gapped += a_indv_max[i].as_ref().map_or(0, |a| a.gapped as usize);
@@ -938,6 +949,7 @@ fn extend_paired_seeds(
                         reads[i],
                         consistent_chain,
                         true, // SSW
+                        k,
                     );
                     details[i].tried_alignment += 1;
                     details[i].gapped += alignment.as_ref().map_or(0, |a| a.gapped as usize);
@@ -1039,7 +1051,8 @@ fn rescue_read(
         }
         let consistent_chain = reverse_chain_if_needed(chain, read1, refseq, k);
         details[0].inconsistent_chains += !consistent_chain as usize;
-        if let Some(alignment) = extend_seed(aligner, chain, refseq, read1, consistent_chain, true)
+        if let Some(alignment) =
+            extend_seed(aligner, chain, refseq, read1, consistent_chain, true, k)
         {
             details[0].gapped += alignment.gapped as usize;
             alignments1.push(alignment);

--- a/src/piecewisealigner.rs
+++ b/src/piecewisealigner.rs
@@ -718,6 +718,14 @@ pub fn remove_spurious_anchors(anchors: &mut Vec<Anchor>) {
     }
 }
 
+/// Drop anchors whose k-mer is not actually identical between query and reference.
+pub fn retain_verified_anchors(anchors: &mut Vec<Anchor>, query: &[u8], refseq: &[u8], k: usize) {
+    anchors.retain(|a| {
+        let (q, r) = (a.query_start, a.ref_start);
+        q + k <= query.len() && r + k <= refseq.len() && query[q..q + k] == refseq[r..r + k]
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1246,6 +1254,144 @@ mod tests {
         assert_eq!(result.ref_start, 0);
         assert_eq!(result.ref_end, 10);
         assert_eq!(result.cigar.to_string(), "3=2D5=");
+    }
+
+    #[test]
+    fn retain_verified_anchors_drops_a_false_anchor() {
+        let seq = b"ACGTACGTACGTACGTACGTACGTACGTAC";
+        let mut anchors = vec![
+            Anchor {
+                ref_id: 0,
+                ref_start: 20,
+                query_start: 20,
+            },
+            Anchor {
+                ref_id: 0,
+                ref_start: 13,
+                query_start: 10,
+            },
+            Anchor {
+                ref_id: 0,
+                ref_start: 0,
+                query_start: 0,
+            },
+        ];
+
+        retain_verified_anchors(&mut anchors, seq, seq, 5);
+
+        let expected = vec![
+            Anchor {
+                ref_id: 0,
+                ref_start: 20,
+                query_start: 20,
+            },
+            Anchor {
+                ref_id: 0,
+                ref_start: 0,
+                query_start: 0,
+            },
+        ];
+        assert_eq!(expected, anchors);
+    }
+
+    #[test]
+    fn retain_verified_anchors_empties_the_chain_when_nothing_verifies() {
+        let query = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let refseq = b"TTTTTTTTTTTTTTTTTTTTTTTTTTTTTT";
+        let mut anchors = vec![
+            Anchor {
+                ref_id: 0,
+                ref_start: 20,
+                query_start: 20,
+            },
+            Anchor {
+                ref_id: 0,
+                ref_start: 10,
+                query_start: 10,
+            },
+            Anchor {
+                ref_id: 0,
+                ref_start: 0,
+                query_start: 0,
+            },
+        ];
+
+        retain_verified_anchors(&mut anchors, query, refseq, 5);
+
+        assert!(anchors.is_empty());
+    }
+
+    #[test]
+    fn retain_verified_anchors_treats_out_of_bounds_as_false() {
+        let seq = b"ACGTACGTACGTACGTACGTACGTACGTAC";
+        let mut anchors = vec![
+            Anchor {
+                ref_id: 0,
+                ref_start: 28,
+                query_start: 28,
+            },
+            Anchor {
+                ref_id: 0,
+                ref_start: 0,
+                query_start: 0,
+            },
+        ];
+
+        retain_verified_anchors(&mut anchors, seq, seq, 5);
+
+        let expected = vec![Anchor {
+            ref_id: 0,
+            ref_start: 0,
+            query_start: 0,
+        }];
+        assert_eq!(expected, anchors);
+    }
+
+    #[test]
+    fn extend_piecewise_trusts_its_anchors_so_a_false_one_forces_an_indel() {
+        let aligner = PiecewiseAligner::new(
+            Scores {
+                match_: 2,
+                mismatch: 8,
+                gap_open: 12,
+                gap_extend: 1,
+                end_bonus: 10,
+            },
+            5,
+            100,
+        );
+        let seq = b"ACGTACGTACGTACGTACGTACGTACGTAC";
+        // Query 10 and reference 13 are both ACGTA, three bases out of phase in a
+        // period-4 repeat, so the middle anchor is a hash collision.
+        let mut anchors = vec![
+            Anchor {
+                ref_id: 0,
+                ref_start: 20,
+                query_start: 20,
+            },
+            Anchor {
+                ref_id: 0,
+                ref_start: 13,
+                query_start: 10,
+            },
+            Anchor {
+                ref_id: 0,
+                ref_start: 0,
+                query_start: 0,
+            },
+        ];
+
+        let spurious = aligner.extend_piecewise(seq, seq, &anchors, 5).unwrap();
+        assert_eq!(spurious.cigar.to_string(), "10=3D5=3I12=");
+        assert_eq!(spurious.edit_distance, 6);
+        assert_eq!(spurious.score, 46);
+
+        retain_verified_anchors(&mut anchors, seq, seq, 5);
+
+        let verified = aligner.extend_piecewise(seq, seq, &anchors, 5).unwrap();
+        assert_eq!(verified.cigar.to_string(), "30=");
+        assert_eq!(verified.edit_distance, 0);
+        assert_eq!(verified.score, 30 * 2 + 10 * 2);
     }
 
     #[test]


### PR DESCRIPTION
`is_consistent` checks the first and last k-mer of a chain against the reference and throws the whole chain away if either one is a hash collision. It comes from NAMs, where the start and the end were the only positions we had. A chain gives us every anchor, so the check now looks at two of them and discards what the rest say. When the collision is on one end and that chain was the only one we found, the read comes out unmapped even though the chain pointed at the right place.

`retain_verified_anchors` compares each anchor's k-mer base by base between query and reference and drops only the ones that do not match. It runs in `extend_seed` right before the extension, on the decoded reference, and after the other anchor pruning so it works on as few anchors as possible. If none of them survive we return no alignment for that chain and move on to the next one. The `is_consistent` gate now applies only when we extend with SSW.

This is a fix, and ideally we would catch these at seeding instead, which would save the N * k base comparisons that cleaning a chain costs here.

## Results

