### PR TITLE
Verify anchor k-mers before chaining and remove is_consistent checks

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -45,24 +45,6 @@ impl Chain {
             .saturating_sub(self.query_start)
             .max(self.ref_contig_start)
     }
-
-    /// Returns whether a chain represents a consistent match between read and
-    /// reference by comparing the nucleotide sequences of the first and last
-    /// strobe (taking orientation into account).
-    pub fn is_consistent(&self, read: &Read, refseq: &RefSequence, k: usize) -> bool {
-        let ref_start_kmer = refseq.decode(self.ref_start, self.ref_start + k);
-        let ref_end_kmer = refseq.decode(self.ref_end - k, self.ref_end);
-
-        let seq = if self.is_revcomp {
-            read.rc()
-        } else {
-            read.seq()
-        };
-        let read_start_kmer = &seq[self.query_start..self.query_start + k];
-        let read_end_kmer = &seq[self.query_end - k..self.query_end];
-
-        ref_start_kmer == read_start_kmer && ref_end_kmer == read_end_kmer
-    }
 }
 
 impl Display for Chain {
@@ -81,63 +63,17 @@ impl Display for Chain {
     }
 }
 
-/// Determine whether the chain represents a match to the forward or
-/// reverse-complemented sequence by checking in which orientation the
-/// first and last strobe in the chain match
-///
-/// - If first and last strobe match in forward orientation, return true.
-/// - If first and last strobe match in reverse orientation, update the chain
-///   in place and return true.
-/// - If first and last strobe do not match consistently, return false.
-pub fn reverse_chain_if_needed(
-    chain: &mut Chain,
-    read: &Read,
-    refseq: &RefSequence,
-    k: usize,
-) -> bool {
-    let ref_start_kmer = refseq.decode(chain.ref_start, chain.ref_start + k);
-    let ref_end_kmer = refseq.decode(chain.ref_end - k, chain.ref_end);
-
-    let (seq, seq_rc) = if chain.is_revcomp {
-        (read.rc(), read.seq())
-    } else {
-        (read.seq(), read.rc())
-    };
-    let read_start_kmer = &seq[chain.query_start..chain.query_start + k];
-    let read_end_kmer = &seq[chain.query_end - k..chain.query_end];
-    if ref_start_kmer == read_start_kmer && ref_end_kmer == read_end_kmer {
-        return true;
-    }
-
-    // False forward or false reverse (possible due to symmetrical hash values)
-    // we need two extra checks for this - hopefully this will remove all the false matches we see
-    // (true hash collisions should be very few)
-    let read_len = read.len();
-    let q_start_tmp = read_len - chain.query_end;
-    let q_end_tmp = read_len - chain.query_start;
-    // false reverse match, change coordinates in chain to forward
-    let read_start_kmer = &seq_rc[q_start_tmp..q_start_tmp + k];
-    let read_end_kmer = &seq_rc[q_end_tmp - k..q_end_tmp];
-    if ref_start_kmer == read_start_kmer && ref_end_kmer == read_end_kmer {
-        chain.is_revcomp = !chain.is_revcomp;
-        chain.query_start = q_start_tmp;
-        chain.query_end = q_end_tmp;
-        true
-    } else {
-        false
-    }
-}
-
 /// Obtain chains for a sequence record, doing rescue if needed.
 pub fn get_chains(
-    sequence: &[u8],
+    read: &Read,
     index: &StrobemerIndex,
+    refseq: &RefSequence,
     chainer: &Chainer,
     rescue_distance: usize,
     mcs_strategy: McsStrategy,
 ) -> (ChainDetails, Vec<Chain>) {
     let timer = Instant::now();
-    let query_randstrobes = randstrobes_query(sequence, &index.parameters);
+    let query_randstrobes = randstrobes_query(read.seq(), &index.parameters);
     let time_randstrobes = timer.elapsed().as_secs_f64();
 
     trace!(
@@ -151,7 +87,8 @@ pub fn get_chains(
         index,
         rescue_distance,
         mcs_strategy,
-        sequence.len(),
+        read,
+        refseq,
     );
 
     chain_details.time_randstrobes = time_randstrobes;

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -1,3 +1,4 @@
+use std::ops;
 use std::time::Instant;
 
 use log::trace;
@@ -19,6 +20,31 @@ const N_PRECOMPUTED: usize = 1024;
 pub struct Anchor {
     pub ref_start: usize,
     pub query_start: usize,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CollisionStats {
+    pub n_full_lookups: usize,
+    pub n_full_collisions_first: usize,
+    pub n_full_collisions_second: usize,
+    pub n_partial_lookups: usize,
+    pub n_partial_collisions: usize,
+}
+
+impl CollisionStats {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ops::AddAssign<CollisionStats> for CollisionStats {
+    fn add_assign(&mut self, rhs: CollisionStats) {
+        self.n_full_lookups += rhs.n_full_lookups;
+        self.n_full_collisions_first += rhs.n_full_collisions_first;
+        self.n_full_collisions_second += rhs.n_full_collisions_second;
+        self.n_partial_lookups += rhs.n_partial_lookups;
+        self.n_partial_collisions += rhs.n_partial_collisions;
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -234,7 +260,7 @@ impl Chainer {
         }
 
         let mut n_anchors = 0;
-        let mut total_collisions = 0;
+        let mut collision_stats = CollisionStats::default();
         let mut time_chaining = 0.0;
         let mut chains = vec![];
         for &is_revcomp in &orientations {
@@ -249,7 +275,7 @@ impl Chainer {
             let query = PackedSeq::from_slice(query);
             let (mut anchors, collisions) =
                 hits_to_anchors(&hits[is_revcomp], index, &query, refseq);
-            total_collisions += collisions;
+            collision_stats += collisions;
             time_find_hits += hits_timer.elapsed().as_secs_f64();
             n_anchors += anchors.len();
             let chaining_timer = Instant::now();
@@ -288,7 +314,7 @@ impl Chainer {
             n_reads: 1,
             n_randstrobes: query_randstrobes[0].len() + query_randstrobes[1].len(),
             n_anchors,
-            n_collisions: total_collisions,
+            collisions: collision_stats,
             n_chains: chains.len(),
             time_randstrobes: 0.0,
             time_find_hits,
@@ -344,8 +370,8 @@ fn add_to_anchors_full(
     entry: IndexEntry,
     query: &PackedSeq,
     refseq: &RefSequence,
-) -> usize {
-    let mut collisions = 0;
+) -> CollisionStats {
+    let mut stats = CollisionStats::default();
     let mut min_length_diff = usize::MAX;
     let forward_hash = entry.hash();
     for i in entry.position..index.len() {
@@ -359,13 +385,14 @@ fn add_to_anchors_full(
         if length_diff <= min_length_diff {
             let k = index.k();
 
+            stats.n_full_lookups += 1;
             if query.kmer_bits(query_start, k) == refseq.kmer_bits(ref_start, k) {
                 anchors.push(Anchor {
                     ref_start,
                     query_start,
                 });
             } else {
-                collisions += 1;
+                stats.n_full_collisions_first += 1;
             }
             if query.kmer_bits(query_end - k, k) == refseq.kmer_bits(ref_end - k, k) {
                 anchors.push(Anchor {
@@ -373,13 +400,13 @@ fn add_to_anchors_full(
                     query_start: query_end - k,
                 });
             } else {
-                collisions += 1;
+                stats.n_full_collisions_second += 1;
             }
             min_length_diff = length_diff;
         }
     }
 
-    collisions
+    stats
 }
 
 fn add_to_anchors_partial(
@@ -389,8 +416,8 @@ fn add_to_anchors_partial(
     entry: IndexEntry,
     query: &PackedSeq,
     refseq: &RefSequence,
-) -> usize {
-    let mut collisions = 0;
+) -> CollisionStats {
+    let mut stats = CollisionStats::default();
     let forward_hash = entry.get_hash_partial_forward();
     for i in entry.position..index.len() {
         let entry = index.entry(i);
@@ -401,17 +428,18 @@ fn add_to_anchors_partial(
         let ref_start = entry.strobe_extent_partial().0;
         let k = index.k();
 
+        stats.n_partial_lookups += 1;
         if query.kmer_bits(query_start, k) == refseq.kmer_bits(ref_start, k) {
             anchors.push(Anchor {
                 ref_start,
                 query_start,
             });
         } else {
-            collisions += 1;
+            stats.n_partial_collisions += 1;
         }
     }
 
-    collisions
+    stats
 }
 
 fn hits_to_anchors(
@@ -419,9 +447,9 @@ fn hits_to_anchors(
     index: &StrobemerIndex,
     query: &PackedSeq,
     refseq: &RefSequence,
-) -> (Vec<Anchor>, usize) {
+) -> (Vec<Anchor>, CollisionStats) {
     let mut anchors = vec![];
-    let mut collisions = 0;
+    let mut collisions = CollisionStats::default();
     for hit in hits {
         if hit.is_filtered {
             continue;

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -7,7 +7,10 @@ use crate::details::ChainDetails;
 use crate::hit::{Hit, HitsDetails, find_hits};
 use crate::index::{IndexEntry, StrobemerIndex};
 use crate::mcsstrategy::McsStrategy;
+use crate::packed_seq::PackedSeq;
+use crate::read::Read;
 use crate::refseq::ContigStarts;
+use crate::refseq::RefSequence;
 use crate::seeding::QueryRandstrobe;
 
 const N_PRECOMPUTED: usize = 1024;
@@ -198,8 +201,10 @@ impl Chainer {
         index: &StrobemerIndex,
         rescue_distance: usize,
         mcs_strategy: McsStrategy,
-        read_len: usize,
+        read: &Read,
+        refseq: &RefSequence,
     ) -> (ChainDetails, Vec<Chain>) {
+        let read_len = read.len();
         let hits_timer = Instant::now();
 
         let mut hits = [vec![], vec![]];
@@ -233,7 +238,15 @@ impl Chainer {
         let mut chains = vec![];
         for &is_revcomp in &orientations {
             let hits_timer = Instant::now();
-            let mut anchors = hits_to_anchors(&hits[is_revcomp], index);
+            let query = if is_revcomp == 1 {
+                read.rc()
+            } else {
+                read.seq()
+            };
+            // Packed once per read so each anchor costs one integer comparison
+            // instead of k base comparisons.
+            let query = PackedSeq::from_slice(query);
+            let mut anchors = hits_to_anchors(&hits[is_revcomp], index, &query, refseq);
             time_find_hits += hits_timer.elapsed().as_secs_f64();
             n_anchors += anchors.len();
             let chaining_timer = Instant::now();
@@ -325,6 +338,8 @@ fn add_to_anchors_full(
     query_end: usize,
     index: &StrobemerIndex,
     entry: IndexEntry,
+    query: &PackedSeq,
+    refseq: &RefSequence,
 ) {
     let mut min_length_diff = usize::MAX;
     let forward_hash = entry.hash();
@@ -337,14 +352,20 @@ fn add_to_anchors_full(
         let ref_end = ref_start + entry.strobe2_offset() + index.k();
         let length_diff = (query_end - query_start).abs_diff(ref_end - ref_start);
         if length_diff <= min_length_diff {
-            anchors.push(Anchor {
-                ref_start,
-                query_start,
-            });
-            anchors.push(Anchor {
-                ref_start: ref_end - index.k(),
-                query_start: query_end - index.k(),
-            });
+            let k = index.k();
+
+            if query.kmer_bits(query_start, k) == refseq.kmer_bits(ref_start, k) {
+                anchors.push(Anchor {
+                    ref_start,
+                    query_start,
+                });
+            }
+            if query.kmer_bits(query_end - k, k) == refseq.kmer_bits(ref_end - k, k) {
+                anchors.push(Anchor {
+                    ref_start: ref_end - k,
+                    query_start: query_end - k,
+                });
+            }
             min_length_diff = length_diff;
         }
     }
@@ -355,6 +376,8 @@ fn add_to_anchors_partial(
     query_start: usize,
     index: &StrobemerIndex,
     entry: IndexEntry,
+    query: &PackedSeq,
+    refseq: &RefSequence,
 ) {
     let forward_hash = entry.get_hash_partial_forward();
     for i in entry.position..index.len() {
@@ -364,15 +387,23 @@ fn add_to_anchors_partial(
             break;
         }
         let ref_start = entry.strobe_extent_partial().0;
+        let k = index.k();
 
-        anchors.push(Anchor {
-            ref_start,
-            query_start,
-        });
+        if query.kmer_bits(query_start, k) == refseq.kmer_bits(ref_start, k) {
+            anchors.push(Anchor {
+                ref_start,
+                query_start,
+            });
+        }
     }
 }
 
-fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
+fn hits_to_anchors(
+    hits: &Vec<Hit>,
+    index: &StrobemerIndex,
+    query: &PackedSeq,
+    refseq: &RefSequence,
+) -> Vec<Anchor> {
     let mut anchors = vec![];
     for hit in hits {
         if hit.is_filtered {
@@ -380,7 +411,14 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
         }
         if hit.is_partial {
             if let Some(forward_entry) = index.get_partial_forward_from(hit.hash, hit.position) {
-                add_to_anchors_partial(&mut anchors, hit.query_start, index, forward_entry);
+                add_to_anchors_partial(
+                    &mut anchors,
+                    hit.query_start,
+                    index,
+                    forward_entry,
+                    query,
+                    refseq,
+                );
             }
         } else {
             add_to_anchors_full(
@@ -389,6 +427,8 @@ fn hits_to_anchors(hits: &Vec<Hit>, index: &StrobemerIndex) -> Vec<Anchor> {
                 hit.query_end,
                 index,
                 index.entry(hit.position),
+                query,
+                refseq,
             );
         }
     }

--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -234,6 +234,7 @@ impl Chainer {
         }
 
         let mut n_anchors = 0;
+        let mut total_collisions = 0;
         let mut time_chaining = 0.0;
         let mut chains = vec![];
         for &is_revcomp in &orientations {
@@ -246,7 +247,9 @@ impl Chainer {
             // Packed once per read so each anchor costs one integer comparison
             // instead of k base comparisons.
             let query = PackedSeq::from_slice(query);
-            let mut anchors = hits_to_anchors(&hits[is_revcomp], index, &query, refseq);
+            let (mut anchors, collisions) =
+                hits_to_anchors(&hits[is_revcomp], index, &query, refseq);
+            total_collisions += collisions;
             time_find_hits += hits_timer.elapsed().as_secs_f64();
             n_anchors += anchors.len();
             let chaining_timer = Instant::now();
@@ -285,6 +288,7 @@ impl Chainer {
             n_reads: 1,
             n_randstrobes: query_randstrobes[0].len() + query_randstrobes[1].len(),
             n_anchors,
+            n_collisions: total_collisions,
             n_chains: chains.len(),
             time_randstrobes: 0.0,
             time_find_hits,
@@ -340,7 +344,8 @@ fn add_to_anchors_full(
     entry: IndexEntry,
     query: &PackedSeq,
     refseq: &RefSequence,
-) {
+) -> usize {
+    let mut collisions = 0;
     let mut min_length_diff = usize::MAX;
     let forward_hash = entry.hash();
     for i in entry.position..index.len() {
@@ -359,16 +364,22 @@ fn add_to_anchors_full(
                     ref_start,
                     query_start,
                 });
+            } else {
+                collisions += 1;
             }
             if query.kmer_bits(query_end - k, k) == refseq.kmer_bits(ref_end - k, k) {
                 anchors.push(Anchor {
                     ref_start: ref_end - k,
                     query_start: query_end - k,
                 });
+            } else {
+                collisions += 1;
             }
             min_length_diff = length_diff;
         }
     }
+
+    collisions
 }
 
 fn add_to_anchors_partial(
@@ -378,7 +389,8 @@ fn add_to_anchors_partial(
     entry: IndexEntry,
     query: &PackedSeq,
     refseq: &RefSequence,
-) {
+) -> usize {
+    let mut collisions = 0;
     let forward_hash = entry.get_hash_partial_forward();
     for i in entry.position..index.len() {
         let entry = index.entry(i);
@@ -394,8 +406,12 @@ fn add_to_anchors_partial(
                 ref_start,
                 query_start,
             });
+        } else {
+            collisions += 1;
         }
     }
+
+    collisions
 }
 
 fn hits_to_anchors(
@@ -403,15 +419,16 @@ fn hits_to_anchors(
     index: &StrobemerIndex,
     query: &PackedSeq,
     refseq: &RefSequence,
-) -> Vec<Anchor> {
+) -> (Vec<Anchor>, usize) {
     let mut anchors = vec![];
+    let mut collisions = 0;
     for hit in hits {
         if hit.is_filtered {
             continue;
         }
         if hit.is_partial {
             if let Some(forward_entry) = index.get_partial_forward_from(hit.hash, hit.position) {
-                add_to_anchors_partial(
+                collisions += add_to_anchors_partial(
                     &mut anchors,
                     hit.query_start,
                     index,
@@ -421,7 +438,7 @@ fn hits_to_anchors(
                 );
             }
         } else {
-            add_to_anchors_full(
+            collisions += add_to_anchors_full(
                 &mut anchors,
                 hit.query_start,
                 hit.query_end,
@@ -433,7 +450,7 @@ fn hits_to_anchors(
         }
     }
 
-    anchors
+    (anchors, collisions)
 }
 
 impl ChainingResult {

--- a/src/details.rs
+++ b/src/details.rs
@@ -48,8 +48,6 @@ impl ops::AddAssign<ChainDetails> for ChainDetails {
 pub struct Details {
     pub chain: ChainDetails,
 
-    pub inconsistent_chains: usize,
-
     /// No. of times rescue by local alignment was attempted
     pub mate_rescue: usize,
 
@@ -68,7 +66,6 @@ pub struct Details {
 impl ops::AddAssign<Details> for Details {
     fn add_assign(&mut self, rhs: Details) {
         self.chain += rhs.chain;
-        self.inconsistent_chains += rhs.inconsistent_chains;
         self.mate_rescue += rhs.mate_rescue;
         self.tried_alignment += rhs.tried_alignment;
         self.gapped += rhs.gapped;

--- a/src/details.rs
+++ b/src/details.rs
@@ -2,7 +2,7 @@
 
 use std::ops;
 
-use crate::hit::HitsDetails;
+use crate::{chainer::CollisionStats, hit::HitsDetails};
 
 #[derive(Default, Debug, Clone)]
 pub struct ChainDetails {
@@ -17,7 +17,7 @@ pub struct ChainDetails {
 
     /// Number of hash collisions (hits that were not turned into an anchor
     /// because the query k-mers did not match the reference k-mer)
-    pub n_collisions: usize,
+    pub collisions: CollisionStats,
 
     /// Number of chains found
     pub n_chains: usize,
@@ -38,7 +38,7 @@ impl ops::AddAssign<ChainDetails> for ChainDetails {
         self.n_reads += rhs.n_reads;
         self.n_randstrobes += rhs.n_randstrobes;
         self.n_anchors += rhs.n_anchors;
-        self.n_collisions += rhs.n_collisions;
+        self.collisions += rhs.collisions;
         self.n_chains += rhs.n_chains;
         self.time_randstrobes += rhs.time_randstrobes;
         self.time_find_hits += rhs.time_find_hits;

--- a/src/details.rs
+++ b/src/details.rs
@@ -15,6 +15,10 @@ pub struct ChainDetails {
 
     pub n_anchors: usize,
 
+    /// Number of hash collisions (hits that were not turned into an anchor
+    /// because the query k-mers did not match the reference k-mer)
+    pub n_collisions: usize,
+
     /// Number of chains found
     pub n_chains: usize,
 
@@ -34,6 +38,7 @@ impl ops::AddAssign<ChainDetails> for ChainDetails {
         self.n_reads += rhs.n_reads;
         self.n_randstrobes += rhs.n_randstrobes;
         self.n_anchors += rhs.n_anchors;
+        self.n_collisions += rhs.n_collisions;
         self.n_chains += rhs.n_chains;
         self.time_randstrobes += rhs.time_randstrobes;
         self.time_find_hits += rhs.time_find_hits;

--- a/src/main.rs
+++ b/src/main.rs
@@ -794,6 +794,11 @@ fn run() -> Result<(), CliError> {
         details.chain.n_anchors as f64 / details.chain.n_reads as f64
     );
     debug!(
+        "Detected hash collisions:                 {:12}               Per read: {:7.1}",
+        details.chain.n_collisions,
+        details.chain.n_collisions as f64 / details.chain.n_reads as f64
+    );
+    debug!(
         "Found chains:                             {:12}               Per read: {:7.1}",
         details.chain.n_chains,
         details.chain.n_chains as f64 / details.chain.n_reads as f64

--- a/src/main.rs
+++ b/src/main.rs
@@ -802,7 +802,6 @@ fn run() -> Result<(), CliError> {
     debug!("## Other");
     debug!("");
     debug!("Total mapping sites tried: {}", details.tried_alignment);
-    debug!("Inconsistent NAM ends: {}", details.inconsistent_chains);
     debug!("Mates rescued by alignment: {}", details.mate_rescue);
 
     info!("Total time mapping: {:.2} s", timer.elapsed().as_secs_f64());
@@ -961,8 +960,8 @@ impl Mapper<'_> {
                     } else {
                         abundances_single_end_read(
                             &r1,
-                            self.refseq,
                             self.index,
+                            self.refseq,
                             &mut self.abundances,
                             self.mapping_parameters.rescue_distance,
                             self.mapping_parameters.mcs_strategy,

--- a/src/main.rs
+++ b/src/main.rs
@@ -793,11 +793,36 @@ fn run() -> Result<(), CliError> {
         details.chain.n_anchors,
         details.chain.n_anchors as f64 / details.chain.n_reads as f64
     );
+    debug!("");
+    debug!("## Hash collisions");
+    let collisions = details.chain.collisions;
+    // note that one "full lookup" is actually two (first and second strobe)
     debug!(
-        "Detected hash collisions:                 {:12}               Per read: {:7.1}",
-        details.chain.n_collisions,
-        details.chain.n_collisions as f64 / details.chain.n_reads as f64
+        "Full strobemer lookups:    {:12}",
+        collisions.n_full_lookups
     );
+    debug!(
+        "First strobe collisions:   {:12} {:.3} %",
+        collisions.n_full_collisions_first,
+        collisions.n_full_collisions_first as f64 * 100.0 / collisions.n_full_lookups as f64
+    );
+    debug!(
+        "Second strobe collisions:  {:12} {:.3} %",
+        collisions.n_full_collisions_second,
+        collisions.n_full_collisions_second as f64 * 100.0 / collisions.n_full_lookups as f64
+    );
+    debug!("");
+    debug!(
+        "Partial strobemer lookups: {:12}",
+        collisions.n_partial_lookups
+    );
+    debug!(
+        "Partial collisions:        {:12} {:.3} %",
+        collisions.n_partial_collisions,
+        collisions.n_partial_collisions as f64 * 100.0 / collisions.n_partial_lookups as f64
+    );
+
+    debug!("");
     debug!(
         "Found chains:                             {:12}               Per read: {:7.1}",
         details.chain.n_chains,

--- a/src/maponly.rs
+++ b/src/maponly.rs
@@ -10,6 +10,7 @@ use crate::io::record::{End, SequenceRecord};
 use crate::mapper::mapping_quality;
 use crate::math::normal_pdf;
 use crate::mcsstrategy::McsStrategy;
+use crate::read::Read;
 use crate::refseq::{ContigPosition, ContigStarts, RefSequence};
 
 /// Map a single-end read to the reference and return PAF records
@@ -24,13 +25,9 @@ pub fn map_single_end_read(
     chainer: &Chainer,
     rng: &mut Rng,
 ) -> (Vec<PafRecord>, Details) {
-    let (mut chain_details, mut chains) = get_chains(
-        &record.sequence,
-        index,
-        chainer,
-        rescue_distance,
-        mcs_strategy,
-    );
+    let read = Read::new(&record.sequence);
+    let (mut chain_details, mut chains) =
+        get_chains(&read, index, refseq, chainer, rescue_distance, mcs_strategy);
     chain_details.time_sort_chains = sort_chains(&mut chains, rng);
 
     if chains.is_empty() {
@@ -58,21 +55,16 @@ pub fn map_single_end_read(
 /// This implements abundance estimation mode (`--aemb`)
 pub fn abundances_single_end_read(
     record: &SequenceRecord,
-    refseq: &RefSequence,
     index: &StrobemerIndex,
+    refseq: &RefSequence,
     abundances: &mut [f64],
     rescue_distance: usize,
     mcs_strategy: McsStrategy,
     chainer: &Chainer,
     rng: &mut Rng,
 ) {
-    let (_, mut chains) = get_chains(
-        &record.sequence,
-        index,
-        chainer,
-        rescue_distance,
-        mcs_strategy,
-    );
+    let read = Read::new(&record.sequence);
+    let (_, mut chains) = get_chains(&read, index, refseq, chainer, rescue_distance, mcs_strategy);
     sort_chains(&mut chains, rng);
 
     let n_best = chains
@@ -131,10 +123,24 @@ pub fn map_paired_end_read(
     chainer: &Chainer,
     rng: &mut Rng,
 ) -> (Vec<PafRecord>, Details) {
-    let (mut chain_details1, mut chains1) =
-        get_chains(&r1.sequence, index, chainer, rescue_distance, mcs_strategy);
-    let (mut chain_details2, mut chains2) =
-        get_chains(&r2.sequence, index, chainer, rescue_distance, mcs_strategy);
+    let read1 = Read::new(&r1.sequence);
+    let read2 = Read::new(&r2.sequence);
+    let (mut chain_details1, mut chains1) = get_chains(
+        &read1,
+        index,
+        refseq,
+        chainer,
+        rescue_distance,
+        mcs_strategy,
+    );
+    let (mut chain_details2, mut chains2) = get_chains(
+        &read2,
+        index,
+        refseq,
+        chainer,
+        rescue_distance,
+        mcs_strategy,
+    );
 
     if chains1.is_empty() && chains2.is_empty() {
         chain_details1 += chain_details2;
@@ -223,10 +229,24 @@ pub fn abundances_paired_end_read(
     chainer: &Chainer,
     rng: &mut Rng,
 ) {
-    let (chain_details1, mut chains1) =
-        get_chains(&r1.sequence, index, chainer, rescue_distance, mcs_strategy);
-    let (chain_details2, mut chains2) =
-        get_chains(&r2.sequence, index, chainer, rescue_distance, mcs_strategy);
+    let read1 = Read::new(&r1.sequence);
+    let read2 = Read::new(&r2.sequence);
+    let (chain_details1, mut chains1) = get_chains(
+        &read1,
+        index,
+        refseq,
+        chainer,
+        rescue_distance,
+        mcs_strategy,
+    );
+    let (chain_details2, mut chains2) = get_chains(
+        &read2,
+        index,
+        refseq,
+        chainer,
+        rescue_distance,
+        mcs_strategy,
+    );
 
     if chains1.is_empty() && chains2.is_empty() {
         return;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -9,7 +9,7 @@ use memchr::memmem;
 
 use crate::aligner::Aligner;
 use crate::aligner::{AlignmentInfo, hamming_align, hamming_distance};
-use crate::chain::{Chain, get_chains, reverse_chain_if_needed, sort_chains};
+use crate::chain::{Chain, get_chains, sort_chains};
 use crate::chainer::{Anchor, Chainer};
 use crate::cigar::{Cigar, CigarOperation};
 use crate::details::Details;
@@ -363,9 +363,11 @@ pub fn align_single_end_read(
     aligner: &Aligner,
     rng: &mut Rng,
 ) -> (Vec<SamRecord>, Details) {
+    let read = Read::new(&record.sequence);
     let (mut chain_details, mut chains) = get_chains(
-        &record.sequence,
+        &read,
         index,
+        refseq,
         chainer,
         mapping_parameters.rescue_distance,
         mapping_parameters.mcs_strategy,
@@ -390,8 +392,6 @@ pub fn align_single_end_read(
     let mut alignments_with_best_score = 0;
     let mut best_alignment = None;
 
-    let k = index.k();
-    let read = Read::new(&record.sequence);
     for (tries, chain) in chains
         .iter_mut()
         .take(mapping_parameters.max_tries)
@@ -405,19 +405,9 @@ pub fn align_single_end_read(
         {
             break;
         }
-        let consistent_chain = chain.is_consistent(&read, refseq, k);
-        if !consistent_chain {
-            details.inconsistent_chains += 1;
-            continue;
-        }
-        let Some(alignment) = extend_seed(
-            aligner,
-            chain,
-            refseq,
-            &read,
-            consistent_chain,
-            mapping_parameters.use_ssw,
-        ) else {
+        let Some(alignment) =
+            extend_seed(aligner, chain, refseq, &read, mapping_parameters.use_ssw)
+        else {
             continue;
         };
 
@@ -425,13 +415,13 @@ pub fn align_single_end_read(
         // if log::log_enabled!(log::Level::Trace) {
         //     let (mut ssw, mut pw) = if !mapping_parameters.use_ssw {
         //         (
-        //             extend_seed(aligner, chain, references, &read, consistent_chain, true).unwrap(),
+        //             extend_seed(aligner, chain, references, &read, true).unwrap(),
         //             alignment.clone(),
         //         )
         //     } else {
         //         (
         //             alignment.clone(),
-        //             extend_seed(aligner, chain, references, &read, consistent_chain, false).unwrap(),
+        //             extend_seed(aligner, chain, references, &read, false).unwrap(),
         //         )
         //     };
         //     // manually adds the soft clips
@@ -541,7 +531,6 @@ fn extend_seed(
     chain: &mut Chain,
     refseq: &RefSequence,
     read: &Read,
-    consistent_chain: bool,
     use_ssw: bool,
 ) -> Option<Alignment> {
     let query = if chain.is_revcomp {
@@ -570,7 +559,7 @@ fn extend_seed(
     };
     let mut result_start = 0;
     let mut gapped = true;
-    if projected_start + query.len() == projected_end && consistent_chain {
+    if projected_start + query.len() == projected_end {
         let segment = contig.decode(projected_start, projected_end);
         if let Some(hamming_dist) = hamming_distance(query, &segment)
             && (hamming_dist as f32 / query.len() as f32) < 0.05
@@ -649,9 +638,11 @@ pub fn align_paired_end_read(
 
     for is_r1 in [0, 1] {
         let record = if is_r1 == 0 { r1 } else { r2 };
+        let read = Read::new(&record.sequence);
         let (mut chain_details, mut chains) = get_chains(
-            &record.sequence,
+            &read,
             index,
+            refseq,
             chainer,
             mapping_parameters.rescue_distance,
             mapping_parameters.mcs_strategy,
@@ -857,17 +848,11 @@ fn extend_paired_seeds(
         let mut ch_max1 = chains[0][0].clone();
         let mut ch_max2 = chains[1][0].clone();
 
-        let consistent_chain1 = ch_max1.is_consistent(read1, refseq, k);
-        details[0].inconsistent_chains += !consistent_chain1 as usize;
-        let consistent_chain2 = ch_max2.is_consistent(read2, refseq, k);
-        details[1].inconsistent_chains += !consistent_chain2 as usize;
-
         let alignment1 = extend_seed(
             aligner,
             &mut ch_max1,
             refseq,
             read1,
-            consistent_chain1,
             true, // SSW
         );
         let alignment2 = extend_seed(
@@ -875,7 +860,6 @@ fn extend_paired_seeds(
             &mut ch_max2,
             refseq,
             read2,
-            consistent_chain2,
             true, // SSW
         );
         if let (Some(alignment1), Some(alignment2)) = (alignment1, alignment2) {
@@ -903,14 +887,11 @@ fn extend_paired_seeds(
     // the paired-end read as two single-end reads.
     let mut a_indv_max = [None, None];
     for i in 0..2 {
-        let consistent_chain = reverse_chain_if_needed(&mut chains[i][0], reads[i], refseq, k);
-        details[i].inconsistent_chains += !consistent_chain as usize;
         a_indv_max[i] = extend_seed(
             aligner,
             &mut chains[i][0],
             refseq,
             reads[i],
-            consistent_chain,
             true, // SSW
         );
         details[i].tried_alignment += 1;
@@ -940,15 +921,11 @@ fn extend_paired_seeds(
             let alignment;
             if let Some(mut this_chain) = chainsp[i].clone() {
                 if let Entry::Vacant(e) = alignment_cache[i].entry(this_chain.id) {
-                    let consistent_chain =
-                        reverse_chain_if_needed(&mut this_chain, reads[i], refseq, k);
-                    details[i].inconsistent_chains += !consistent_chain as usize;
                     alignment = extend_seed(
                         aligner,
                         &mut this_chain,
                         refseq,
                         reads[i],
-                        consistent_chain,
                         true, // SSW
                     );
                     details[i].tried_alignment += 1;
@@ -958,9 +935,7 @@ fn extend_paired_seeds(
                     alignment = alignment_cache[i].get(&this_chain.id).unwrap().clone();
                 }
             } else {
-                let mut other_chain = chainsp[1 - i].clone().unwrap();
-                details[1 - i].inconsistent_chains +=
-                    !reverse_chain_if_needed(&mut other_chain, reads[1 - i], refseq, k) as usize;
+                let other_chain = chainsp[1 - i].clone().unwrap();
                 alignment = rescue_align(aligner, &other_chain, refseq, reads[i], mu, sigma, k);
                 if alignment.is_some() {
                     details[i].mate_rescue += 1;
@@ -1049,10 +1024,7 @@ fn rescue_read(
         if score_dropoff1 < dropoff {
             break;
         }
-        let consistent_chain = reverse_chain_if_needed(chain, read1, refseq, k);
-        details[0].inconsistent_chains += !consistent_chain as usize;
-        if let Some(alignment) = extend_seed(aligner, chain, refseq, read1, consistent_chain, true)
-        {
+        if let Some(alignment) = extend_seed(aligner, chain, refseq, read1, true) {
             details[0].gapped += alignment.gapped as usize;
             alignments1.push(alignment);
             details[0].tried_alignment += 1;

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -74,6 +74,7 @@ impl PackedSeq {
     /// Build a `PackedSeq` by packing every byte of a slice.
     pub fn from_slice(s: &[u8]) -> Self {
         let mut seq = PackedSeq::new();
+        seq.data.reserve(s.len().div_ceil(32));
         for &c in s {
             seq.push(c);
         }

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -128,6 +128,21 @@ impl PackedSeq {
         DECODE[self.nucleotide_bits(i) as usize]
     }
 
+    /// Return bases `i..i + k` as one 2-bit packed integer
+    pub fn kmer_bits(&self, i: usize, k: usize) -> u64 {
+        debug_assert!(k <= 32);
+        debug_assert!(i + k <= self.len);
+
+        let word = i >> 5;
+        let bit = (i & 31) * 2;
+        let mut kmer = self.data[word] >> bit;
+        if bit > 0 && word + 1 < self.data.len() {
+            kmer |= self.data[word + 1] << (64 - bit);
+        }
+
+        kmer & (u64::MAX >> (64 - 2 * k))
+    }
+
     /// Decode bases `start..end` as ASCII bytes.
     pub fn decode(&self, start: usize, end: usize) -> Vec<u8> {
         (start..end).map(|i| self.decode_at(i)).collect()
@@ -175,5 +190,48 @@ impl<'a> PackedSeqSlice<'a> {
         ps.extend(decoded);
 
         ps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kmer_bits_packs_two_bits_per_base() {
+        let seq = PackedSeq::from_slice(b"ACGT");
+
+        assert_eq!(seq.kmer_bits(0, 1), 0b00);
+        assert_eq!(seq.kmer_bits(1, 1), 0b01);
+        assert_eq!(seq.kmer_bits(2, 1), 0b10);
+        assert_eq!(seq.kmer_bits(3, 1), 0b11);
+        assert_eq!(seq.kmer_bits(0, 4), 0b11_10_01_00);
+    }
+
+    #[test]
+    fn kmer_bits_crosses_the_word_boundary() {
+        let bases = b"ACGTACGTACGTACGTACGTACGTACGTACGTTTTTGGGG";
+        let seq = PackedSeq::from_slice(bases);
+
+        assert_eq!(
+            seq.kmer_bits(30, 8),
+            PackedSeq::from_slice(&bases[30..38]).kmer_bits(0, 8)
+        );
+        assert_eq!(
+            seq.kmer_bits(8, 32),
+            PackedSeq::from_slice(&bases[8..40]).kmer_bits(0, 32)
+        );
+        assert_eq!(
+            seq.kmer_bits(33, 5),
+            PackedSeq::from_slice(&bases[33..38]).kmer_bits(0, 5)
+        );
+    }
+
+    #[test]
+    fn kmer_bits_differs_for_different_kmers() {
+        let seq = PackedSeq::from_slice(b"ACGTACGTACGTACGTACGTACGTACGTACGT");
+
+        assert_eq!(seq.kmer_bits(4, 20), seq.kmer_bits(8, 20));
+        assert_ne!(seq.kmer_bits(4, 20), seq.kmer_bits(5, 20));
     }
 }

--- a/src/refseq.rs
+++ b/src/refseq.rs
@@ -90,6 +90,10 @@ impl RefSequence {
         self.sequence.decode(start, end)
     }
 
+    pub fn kmer_bits(&self, i: usize, k: usize) -> u64 {
+        self.sequence.kmer_bits(i, k)
+    }
+
     pub fn contig<'a>(&'a self, index: usize) -> PackedSeqSlice<'a> {
         let start = self.starts.0[index];
         let len = self.starts.0[index + 1] - start;


### PR DESCRIPTION
In single-end reads, `is_consistent` checks the first and last k-mer of a chain against the reference and throws the whole chain away if either one is a hash collision. It comes from NAMs, where the start and the end were the only positions we had. When the collision is on one end and that chain was the only one we found, the read comes out unmapped even though the chain pointed at the right place.

We now check every anchor as it is built in `hits_to_anchors` and keep only the ones whose k-mer really matches, so a collision never becomes an anchor. No collisions means no more `is_consistent` check, and no more `reverse_chain_if_needed` either. Both are removed.

The reference is already 2-bit packed and we pack the query once per read, so checking a k-mer is one `u64` comparison, O(1) instead of O(k).

This fixes paired-end too.

## Results
Ran with 8 threads:
Runtime and accuracy plots: [ends.pdf](https://github.com/user-attachments/files/30710702/ends.pdf)
Accuracy table+: [ends-se-accuracy-table.pdf](https://github.com/user-attachments/files/30710706/ends-se-accuracy-table.pdf)

Accuracy is up in 64 of the 156 cells and down in 29, and the gains are the bigger ones, 0.019 points on average against 0.014.

I have not checked paired-end results.
