### PR TITLE
Scale the chaining lookback with read length

### DIFF
--- a/src/chainer.rs
+++ b/src/chainer.rs
@@ -88,6 +88,8 @@ impl Chainer {
             return ChainingResult::default();
         }
 
+        // dynamic maximum lookback window based on read length
+        let max_lookback = self.parameters.max_lookback.max(read_len / 200);
         // dynamic maximum allowed ref gap based on read length
         let max_ref_gap = self.parameters.max_ref_gap.unwrap_or(read_len);
 
@@ -97,7 +99,7 @@ impl Chainer {
         let mut best_index = usize::MAX;
 
         for i in 0..n {
-            let lookup_end = i.saturating_sub(self.parameters.max_lookback);
+            let lookup_end = i.saturating_sub(max_lookback);
             let ai = &anchors[i];
             for j in (lookup_end..i).rev() {
                 let aj = &anchors[j];


### PR DESCRIPTION
`max_lookback` (`-H`) is a number of anchors, default 50. The number of anchors on a read grows with the read length, so 50 is too small for long reads. At 30 kb the correct previous anchor is often further back than 50 positions in the sorted array, so the DP never looks at it, and the chain either breaks or comes out biased towards insertions.

`-H` is now a floor and the lookback scales above it, `max_lookback.max(read_len / 200)`, so nothing changes at or below 10 kb.

## Results
Ran with 16 threads (runtime might fluctuate a bit):
[ends.pdf](https://github.com/user-attachments/files/30750977/ends.pdf)
[ends-se-accuracy-table.pdf](https://github.com/user-attachments/files/30750980/ends-se-accuracy-table.pdf)

I evaluated single-end only, as the accuracy will only change for long reads. Accuracy is identical to main in all read length from 50 bp to 10 kb, which is expected since the lookback only grows past 50 above 10 kb. It moves for 20kb and 30kb and every one of the changes is an improvement.

This is more of a "fix" for long reads above 10kbp, I have not evaluated if we could use a fully dynamic look-back window based on read length with no floor.
