### PR TITLE
Use a relative score threshold for secondary alignment output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@
   of runtime.
 * #596: Fix not properly paired reads getting MAPQ 60 even if there were
   alternative equally good mapping locations.
+* #624: Fix for secondary alignments: Secondary alignments are now output if
+  their score is at least 0.95 times the score of the primary alignment.
+  This "secondary threshold" can now be set with command-line option `--st`.
 
 ## v0.17.0 (2025-12-18)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,15 @@ struct Args {
     #[arg(short = 'N', default_value_t = 0, value_name = "N", help_heading = "SAM output")]
     max_secondary: usize,
 
+    /// Output secondary alignments with alignment score at least st of primary alignment score
+    #[arg(
+        long = "st",
+        default_value_t = MappingParameters::default().secondary_threshold,
+        value_name = "SECONDARY_THRESHOLD",
+        help_heading = "SAM output"
+    )]
+    secondary_threshold: f32,
+
     // Seeding arguments
 
     /// Mean read length. Default: estimated from the first 500 records in the input file
@@ -499,6 +508,7 @@ fn run() -> Result<(), CliError> {
     let timer = Instant::now();
     let mapping_parameters = MappingParameters {
         max_secondary: args.max_secondary,
+        secondary_threshold: args.secondary_threshold,
         max_tries: args.max_tries,
         dropoff_threshold: args.dropoff_threshold,
         rescue_distance: args.rescue_distance,

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,11 +149,11 @@ struct Args {
     )]
     max_secondary: i64,
 
-    /// Output secondary alignments with alignment score at least st of primary alignment score
+    /// Secondary threshold. Output only secondary alignments with score at least FRACTION of primary alignment score
     #[arg(
         long = "st",
         default_value_t = MappingParameters::default().secondary_threshold,
-        value_name = "SECONDARY_THRESHOLD",
+        value_name = "FRACTION",
         help_heading = "SAM output"
     )]
     secondary_threshold: f32,
@@ -513,7 +513,7 @@ fn run() -> Result<(), CliError> {
 
     let timer = Instant::now();
     let mapping_parameters = MappingParameters {
-        // Replaced with usize::MAX to turn off the max_secondary threshold
+        // Negative -N argument disables limit
         max_secondary: if args.max_secondary < 0 {
             usize::MAX
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,9 +139,15 @@ struct Args {
     #[arg(short = 'C', help_heading = "SAM output")]
     fastq_comments: bool,
 
-    /// Retain at most N secondary alignments (is upper bounded by -M and depends on -S)
-    #[arg(short = 'N', default_value_t = 0, value_name = "N", help_heading = "SAM output")]
-    max_secondary: usize,
+    /// Retain at most N secondary alignments (is upper bounded by -M and depends on -S). Use -1 for no limit
+    #[arg(
+        short = 'N',
+        default_value_t = 0,
+        value_name = "N",
+        allow_negative_numbers = true,
+        help_heading = "SAM output"
+    )]
+    max_secondary: i64,
 
     /// Output secondary alignments with alignment score at least st of primary alignment score
     #[arg(
@@ -507,7 +513,12 @@ fn run() -> Result<(), CliError> {
 
     let timer = Instant::now();
     let mapping_parameters = MappingParameters {
-        max_secondary: args.max_secondary,
+        // Replaced with usize::MAX to turn off the max_secondary threshold
+        max_secondary: if args.max_secondary < 0 {
+            usize::MAX
+        } else {
+            args.max_secondary as usize
+        },
         secondary_threshold: args.secondary_threshold,
         max_tries: args.max_tries,
         dropoff_threshold: args.dropoff_threshold,

--- a/src/main.rs
+++ b/src/main.rs
@@ -353,7 +353,7 @@ fn run() -> Result<(), CliError> {
             "Secondary threshold (--st) must be between 0 and 1, got {}",
             args.secondary_threshold
         );
-        exit(1);
+        exit(2);
     }
 
     // Open R1 FASTQ file and estimate read length if necessary
@@ -378,7 +378,7 @@ fn run() -> Result<(), CliError> {
     } else {
         if !args.create_index {
             error!("FASTQ path is required");
-            exit(1);
+            exit(2);
         }
         if let Some(rl) = args.read_length {
             read_length = rl;
@@ -386,7 +386,7 @@ fn run() -> Result<(), CliError> {
             error!(
                 "With --create-index, either provide a FASTQ path or specify the read length with -r"
             );
-            exit(1);
+            exit(2);
         }
         reads_reader1 = None;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,6 +348,14 @@ fn run() -> Result<(), CliError> {
     }
     debug!("RUSTFLAGS='{}'", RUSTFLAGS.unwrap_or(""));
 
+    if !(0.0..=1.0).contains(&args.secondary_threshold) {
+        error!(
+            "Secondary threshold (--st) must be between 0 and 1, got {}",
+            args.secondary_threshold
+        );
+        exit(1);
+    }
+
     // Open R1 FASTQ file and estimate read length if necessary
     let read_length;
     let reads_reader1;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1427,8 +1427,10 @@ fn aligned_pairs_to_sam(
         let s_max = best_aln_pair.score;
         // Expressed as a maximum allowed drop from the best score rather than as
         // `s_score >= secondary_threshold * s_max`, since `s_max` can be negative.
-        let max_drop = (1.0 - secondary_threshold) * s_max.abs();
-        for aln_pair in high_scores.iter().take(max_secondary) {
+        let max_drop = ((1.0 - secondary_threshold) * s_max.abs()).max(0.0);
+        // The primary pair is the first element here, so take one more than the
+        // requested number of secondaries.
+        for aln_pair in high_scores.iter().take(max_secondary.saturating_add(1)) {
             let alignment1 = &aln_pair.alignment1;
             let alignment2 = &aln_pair.alignment2;
             let s_score = aln_pair.score;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1427,7 +1427,7 @@ fn aligned_pairs_to_sam(
         let s_max = best_aln_pair.score;
         // Expressed as a maximum allowed drop from the best score rather than as
         // `s_score >= secondary_threshold * s_max`, since `s_max` can be negative.
-        let max_drop = ((1.0 - secondary_threshold) * s_max.abs()).max(0.0);
+        let max_drop = (1.0 - secondary_threshold) * s_max.abs();
         // The primary pair is the first element here, so take one more than the
         // requested number of secondaries.
         for aln_pair in high_scores.iter().take(max_secondary.saturating_add(1)) {

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -32,6 +32,7 @@ const MAX_PAIR_CHAINS: usize = 1000;
 #[derive(Debug)]
 pub struct MappingParameters {
     pub max_secondary: usize,
+    pub secondary_threshold: f32,
     pub dropoff_threshold: f32,
     pub rescue_distance: usize,
     pub max_tries: usize,
@@ -44,6 +45,7 @@ impl Default for MappingParameters {
     fn default() -> Self {
         MappingParameters {
             max_secondary: 0,
+            secondary_threshold: 0.95,
             dropoff_threshold: 0.5,
             rescue_distance: 100,
             max_tries: 20,
@@ -512,10 +514,9 @@ pub fn align_single_end_read(
 
         // Output secondary alignments
         //let max_out = min(alignments.len(), mapping_parameters.max_secondary + 1);
+        let min_secondary_score = mapping_parameters.secondary_threshold * best_score as f32;
         for alignment in alignments.iter().take(mapping_parameters.max_secondary) {
-            if alignment.score.saturating_sub(best_score)
-                > 2 * aligner.scores.mismatch as u32 + aligner.scores.gap_open as u32
-            {
+            if (alignment.score as f32) < min_secondary_score {
                 break;
             }
             // TODO .clone()
@@ -753,13 +754,12 @@ pub fn align_paired_end_read(
                 }
             };
 
-            let secondary_dropoff = 2 * aligner.scores.mismatch + aligner.scores.gap_open;
             sam_records.extend(aligned_pairs_to_sam(
                 &alignment_pairs,
                 sam_output,
                 refseq,
                 mapping_parameters.max_secondary,
-                secondary_dropoff as f64,
+                mapping_parameters.secondary_threshold as f64,
                 r1,
                 r2,
                 insert_size_distribution.mu,
@@ -1392,7 +1392,7 @@ fn aligned_pairs_to_sam(
     sam_output: &SamOutput,
     refseq: &RefSequence,
     max_secondary: usize,
-    secondary_dropoff: f64,
+    secondary_threshold: f64,
     record1: &SequenceRecord,
     record2: &SequenceRecord,
     mu: f32,
@@ -1425,11 +1425,14 @@ fn aligned_pairs_to_sam(
     } else {
         let mut alignment_status = AlignmentStatus::Primary;
         let s_max = best_aln_pair.score;
+        // Expressed as a maximum allowed drop from the best score rather than as
+        // `s_score >= secondary_threshold * s_max`, since `s_max` can be negative.
+        let max_drop = (1.0 - secondary_threshold) * s_max.abs();
         for aln_pair in high_scores.iter().take(max_secondary) {
             let alignment1 = &aln_pair.alignment1;
             let alignment2 = &aln_pair.alignment2;
             let s_score = aln_pair.score;
-            if s_max - s_score < secondary_dropoff {
+            if s_max - s_score <= max_drop {
                 let pair_status =
                     is_proper_pair_opt(alignment1.as_ref(), alignment2.as_ref(), mu, sigma);
                 let effective_mapqs = if alignment_status == AlignmentStatus::Primary {


### PR DESCRIPTION
This changes the filter for secondary alignment outputs. Currently, the filter is hardcoded as

```
if alignment.score.saturating_sub(best_score)
    > 2 * aligner.scores.mismatch as u32 + aligner.scores.gap_open as u32
```
This seems bugged, since `alignment.score` never exceeds `best_score`. 

The hardcoded threshold was replaced with user-defined `secondary_threshold` (0.95 by default), i.e. the score should satisfy

`alignment.score >= secondary_threshold * best_score`. User-defined threshold was requested in [#598 ](https://github.com/ksahlin/strobealign/issues/598)

Additionally, the `-N` upper bound for the number of secondary alignments can be turned off by using a negative value.

Sanity check results (accuracy should be the same, since secondary alignments are not used in the strobealign-evaluation benchmark)
[ends.pdf](https://github.com/user-attachments/files/31373862/ends.pdf)
