### PR TITLE
Fix --aux-len

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ struct Args {
 
     /// No. of bits to use from secondary strobe hash
     #[arg(long, default_value_t = DEFAULT_AUX_LEN, value_name = "N", help_heading = "Seeding")]
-    aux_len: u8,
+    aux_len: u32,
 
     /// Multi-context seed strategy for finding hits
     #[arg(long = "mcs", value_enum, default_value_t = McsStrategy::default(), help_heading = "Search parameters")]

--- a/src/seeding/parameters.rs
+++ b/src/seeding/parameters.rs
@@ -182,13 +182,12 @@ impl SeedingParameters {
         let profile = t.into();
         let bitcount = 8;
         let q = 2u64.pow(bitcount) - 1;
-        let main_hash_mask = !0u64 << (9 + DEFAULT_AUX_LEN);
 
         match profile {
             Profile::Noisy => SeedingParameters {
                 profile,
                 syncmer: SyncmerParameters::try_new(16, 12).unwrap(),
-                randstrobe: RandstrobeParameters::try_new(2, 2, q, 84, main_hash_mask).unwrap(),
+                randstrobe: RandstrobeParameters::try_new(2, 2, q, 84, DEFAULT_AUX_LEN).unwrap(),
             },
             profile => {
                 let read_length = profile.length().unwrap();
@@ -212,7 +211,7 @@ impl SeedingParameters {
                         read_length_profile.w_max,
                         q,
                         max_dist,
-                        main_hash_mask,
+                        DEFAULT_AUX_LEN,
                     )
                     .unwrap(),
                 }
@@ -284,13 +283,8 @@ impl SeedingParameters {
     }
 
     /// Returns parameters with updated main_hash_mask, computed from aux_len.
-    pub fn with_aux_len(mut self, aux_len: u8) -> Result<Self, InvalidSeedingParameter> {
-        if aux_len > 63 {
-            return Err(InvalidSeedingParameter::InvalidParameter(
-                "aux length must be less than 64",
-            ));
-        }
-        self.randstrobe.main_hash_mask = !0u64 << (9 + aux_len);
+    pub fn with_aux_len(mut self, aux_len: u32) -> Result<Self, InvalidSeedingParameter> {
+        self.randstrobe = self.randstrobe.with_aux_len(aux_len)?;
 
         Ok(self)
     }

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use super::{InvalidSeedingParameter, Syncmer};
 use crate::index::{REF_RANDSTROBE_HASH_MASK, STROBE2_OFFSET_BITS};
 
-pub const DEFAULT_AUX_LEN: u8 = 17;
+pub const DEFAULT_AUX_LEN: u32 = 17;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RandstrobeParameters {
@@ -28,19 +28,19 @@ impl RandstrobeParameters {
         w_max: usize,
         q: u64,
         max_dist: u8,
-        main_hash_mask: u64,
+        aux_len: u32,
     ) -> Result<Self, InvalidSeedingParameter> {
-        let partial_orientation_pos = main_hash_mask.trailing_zeros() - 1;
         RandstrobeParameters {
             w_min,
             w_max,
             q,
             max_dist,
-            main_hash_mask,
-            forward_main_hash_mask: main_hash_mask | (1u64 << partial_orientation_pos),
-            partial_orientation_pos,
+            main_hash_mask: 0,
+            forward_main_hash_mask: 0,
+            partial_orientation_pos: 0,
         }
-        .with_window(Some(w_min), Some(w_max))
+        .with_window(Some(w_min), Some(w_max))?
+        .with_aux_len(aux_len)
     }
 
     pub fn with_window(
@@ -59,6 +59,20 @@ impl RandstrobeParameters {
 
         self.w_min = new_w_min;
         self.w_max = new_w_max;
+
+        Ok(self)
+    }
+
+    /// Returns parameters with updated main_hash_mask etc., computed from aux_len.
+    pub fn with_aux_len(mut self, aux_len: u32) -> Result<Self, InvalidSeedingParameter> {
+        if aux_len > 63 {
+            return Err(InvalidSeedingParameter::InvalidParameter(
+                "aux length must be less than 64",
+            ));
+        }
+        self.main_hash_mask = !0u64 << (9 + aux_len);
+        self.partial_orientation_pos = 8 + aux_len;
+        self.forward_main_hash_mask = self.main_hash_mask | (1u64 << self.partial_orientation_pos);
 
         Ok(self)
     }
@@ -232,5 +246,17 @@ mod test {
         let randstrobe_count = randstrobe_iter.count();
 
         assert_eq!(randstrobe_count, syncmer_count);
+    }
+
+    #[test]
+    fn randstrobe_parameters_custom_aux_len() {
+        let sp = SeedingParameters::new(150);
+        let rp = sp.randstrobe.clone();
+        assert_ne!(rp.main_hash_mask, rp.forward_main_hash_mask);
+
+        let rp18 = rp.clone().with_aux_len(18).unwrap();
+        assert_ne!(rp18.main_hash_mask, rp18.forward_main_hash_mask);
+        assert_ne!(rp.main_hash_mask, rp18.main_hash_mask);
+        assert_ne!(rp.partial_orientation_pos, rp18.partial_orientation_pos);
     }
 }


### PR DESCRIPTION
Setting `--aux-len` to a value different than the default did not work because the with_aux_len() function only updated the main_hash_mask and not the forward_main_hash_mask nor partial_orientation_pos.

Changing the type of aux_len from u8 to u32 was not necessary for the fix, but I did it for consistency with partial_orientation_pos, which is also u32.