### PR TITLE
Remove invalid anchors after chaining

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,10 @@
 * #614: The piecewise extension for single-end reads now uses a custom SIMD
   aligner, extension length is controlled by a bandwidth parameter (`--bw`, 
   default 1024) in place of `--xdrop`.
-  
+* #628/#619: Fix some incorrect alignments caused by invalid anchors (which
+  arise due to hash collisions). These anchors are now removed from the chain
+  they are in before computing the alignment.
+
 ## v0.18.0 (2026-09-01)
 
 Strobealign has been ported to Rust. The Rust version is at least as fast and

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -10,8 +10,6 @@ use crate::chainer::Chainer;
 use crate::details::ChainDetails;
 use crate::index::StrobemerIndex;
 use crate::mcsstrategy::McsStrategy;
-use crate::read::Read;
-use crate::refseq::RefSequence;
 use crate::seeding::randstrobes_query;
 use crate::shuffle::shuffle_best;
 
@@ -45,24 +43,6 @@ impl Chain {
             .saturating_sub(self.query_start)
             .max(self.ref_contig_start)
     }
-
-    /// Returns whether a chain represents a consistent match between read and
-    /// reference by comparing the nucleotide sequences of the first and last
-    /// strobe (taking orientation into account).
-    pub fn is_consistent(&self, read: &Read, refseq: &RefSequence, k: usize) -> bool {
-        let ref_start_kmer = refseq.decode(self.ref_start, self.ref_start + k);
-        let ref_end_kmer = refseq.decode(self.ref_end - k, self.ref_end);
-
-        let seq = if self.is_revcomp {
-            read.rc()
-        } else {
-            read.seq()
-        };
-        let read_start_kmer = &seq[self.query_start..self.query_start + k];
-        let read_end_kmer = &seq[self.query_end - k..self.query_end];
-
-        ref_start_kmer == read_start_kmer && ref_end_kmer == read_end_kmer
-    }
 }
 
 impl Display for Chain {
@@ -78,53 +58,6 @@ impl Display for Chain {
             self.score
         )?;
         Ok(())
-    }
-}
-
-/// Determine whether the chain represents a match to the forward or
-/// reverse-complemented sequence by checking in which orientation the
-/// first and last strobe in the chain match
-///
-/// - If first and last strobe match in forward orientation, return true.
-/// - If first and last strobe match in reverse orientation, update the chain
-///   in place and return true.
-/// - If first and last strobe do not match consistently, return false.
-pub fn reverse_chain_if_needed(
-    chain: &mut Chain,
-    read: &Read,
-    refseq: &RefSequence,
-    k: usize,
-) -> bool {
-    let ref_start_kmer = refseq.decode(chain.ref_start, chain.ref_start + k);
-    let ref_end_kmer = refseq.decode(chain.ref_end - k, chain.ref_end);
-
-    let (seq, seq_rc) = if chain.is_revcomp {
-        (read.rc(), read.seq())
-    } else {
-        (read.seq(), read.rc())
-    };
-    let read_start_kmer = &seq[chain.query_start..chain.query_start + k];
-    let read_end_kmer = &seq[chain.query_end - k..chain.query_end];
-    if ref_start_kmer == read_start_kmer && ref_end_kmer == read_end_kmer {
-        return true;
-    }
-
-    // False forward or false reverse (possible due to symmetrical hash values)
-    // we need two extra checks for this - hopefully this will remove all the false matches we see
-    // (true hash collisions should be very few)
-    let read_len = read.len();
-    let q_start_tmp = read_len - chain.query_end;
-    let q_end_tmp = read_len - chain.query_start;
-    // false reverse match, change coordinates in chain to forward
-    let read_start_kmer = &seq_rc[q_start_tmp..q_start_tmp + k];
-    let read_end_kmer = &seq_rc[q_end_tmp - k..q_end_tmp];
-    if ref_start_kmer == read_start_kmer && ref_end_kmer == read_end_kmer {
-        chain.is_revcomp = !chain.is_revcomp;
-        chain.query_start = q_start_tmp;
-        chain.query_end = q_end_tmp;
-        true
-    } else {
-        false
     }
 }
 

--- a/src/details.rs
+++ b/src/details.rs
@@ -48,8 +48,6 @@ impl ops::AddAssign<ChainDetails> for ChainDetails {
 pub struct Details {
     pub chain: ChainDetails,
 
-    pub inconsistent_chains: usize,
-
     /// No. of times rescue by local alignment was attempted
     pub mate_rescue: usize,
 
@@ -68,7 +66,6 @@ pub struct Details {
 impl ops::AddAssign<Details> for Details {
     fn add_assign(&mut self, rhs: Details) {
         self.chain += rhs.chain;
-        self.inconsistent_chains += rhs.inconsistent_chains;
         self.mate_rescue += rhs.mate_rescue;
         self.tried_alignment += rhs.tried_alignment;
         self.gapped += rhs.gapped;

--- a/src/main.rs
+++ b/src/main.rs
@@ -847,7 +847,6 @@ fn run() -> Result<(), CliError> {
     debug!("## Other");
     debug!("");
     debug!("Total mapping sites tried: {}", details.tried_alignment);
-    debug!("Inconsistent NAM ends: {}", details.inconsistent_chains);
     debug!("Mates rescued by alignment: {}", details.mate_rescue);
 
     info!("Total time mapping: {:.2} s", timer.elapsed().as_secs_f64());

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -406,9 +406,14 @@ pub fn align_single_end_read(
         {
             break;
         }
-        let Some(alignment) =
-            extend_seed(aligner, chain, refseq, &read, mapping_parameters.use_ssw)
-        else {
+        let Some(alignment) = extend_seed(
+            aligner,
+            chain,
+            refseq,
+            &read,
+            mapping_parameters.use_ssw,
+            index.k(),
+        ) else {
             continue;
         };
 
@@ -532,6 +537,7 @@ fn extend_seed(
     refseq: &RefSequence,
     read: &Read,
     use_ssw: bool,
+    k: usize,
 ) -> Option<Alignment> {
     let query = if chain.is_revcomp {
         read.rc()
@@ -595,11 +601,21 @@ fn extend_seed(
             let adjusted_anchors: Vec<Anchor> = chain
                 .anchors
                 .iter()
-                .map(|a| Anchor {
-                    ref_start: a.ref_start - decode_start - refseq.starts.0[contig_id],
-                    query_start: a.query_start,
+                .filter_map(|a| {
+                    let ref_start = a.ref_start - decode_start - refseq.starts.0[contig_id];
+                    // Skip anchors resulting from hash collisions
+                    if query[a.query_start..a.query_start + k] == segment[ref_start..ref_start + k]
+                    {
+                        Some(Anchor {
+                            ref_start,
+                            query_start: a.query_start,
+                        })
+                    } else {
+                        None
+                    }
                 })
                 .collect();
+
             info = aligner.align_piecewise(query, &segment, &adjusted_anchors, padding)?;
             result_start = info.ref_start + decode_start;
         }
@@ -851,6 +867,7 @@ fn extend_paired_seeds(
             refseq,
             read1,
             true, // SSW
+            k,
         );
         let alignment2 = extend_seed(
             aligner,
@@ -858,6 +875,7 @@ fn extend_paired_seeds(
             refseq,
             read2,
             true, // SSW
+            k,
         );
         if let (Some(alignment1), Some(alignment2)) = (alignment1, alignment2) {
             details[0].tried_alignment += 1;
@@ -890,6 +908,7 @@ fn extend_paired_seeds(
             refseq,
             reads[i],
             true, // SSW
+            k,
         );
         details[i].tried_alignment += 1;
         details[i].gapped += a_indv_max[i].as_ref().map_or(0, |a| a.gapped as usize);
@@ -924,6 +943,7 @@ fn extend_paired_seeds(
                         refseq,
                         reads[i],
                         true, // SSW
+                        k,
                     );
                     details[i].tried_alignment += 1;
                     details[i].gapped += alignment.as_ref().map_or(0, |a| a.gapped as usize);
@@ -1021,7 +1041,7 @@ fn rescue_read(
         if score_dropoff1 < dropoff {
             break;
         }
-        if let Some(alignment) = extend_seed(aligner, chain, refseq, read1, true) {
+        if let Some(alignment) = extend_seed(aligner, chain, refseq, read1, true, k) {
             details[0].gapped += alignment.gapped as usize;
             alignments1.push(alignment);
             details[0].tried_alignment += 1;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -9,7 +9,7 @@ use memchr::memmem;
 
 use crate::aligner::Aligner;
 use crate::aligner::{AlignmentInfo, hamming_align, hamming_distance};
-use crate::chain::{Chain, get_chains, reverse_chain_if_needed, sort_chains};
+use crate::chain::{Chain, get_chains, sort_chains};
 use crate::chainer::{Anchor, Chainer};
 use crate::cigar::{Cigar, CigarOperation};
 use crate::details::Details;
@@ -392,7 +392,6 @@ pub fn align_single_end_read(
     let mut alignments_with_best_score = 0;
     let mut best_alignment = None;
 
-    let k = index.k();
     let read = Read::new(&record.sequence);
     for (tries, chain) in chains
         .iter_mut()
@@ -407,19 +406,9 @@ pub fn align_single_end_read(
         {
             break;
         }
-        let consistent_chain = chain.is_consistent(&read, refseq, k);
-        if !consistent_chain {
-            details.inconsistent_chains += 1;
-            continue;
-        }
-        let Some(alignment) = extend_seed(
-            aligner,
-            chain,
-            refseq,
-            &read,
-            consistent_chain,
-            mapping_parameters.use_ssw,
-        ) else {
+        let Some(alignment) =
+            extend_seed(aligner, chain, refseq, &read, mapping_parameters.use_ssw)
+        else {
             continue;
         };
 
@@ -427,13 +416,13 @@ pub fn align_single_end_read(
         // if log::log_enabled!(log::Level::Trace) {
         //     let (mut ssw, mut pw) = if !mapping_parameters.use_ssw {
         //         (
-        //             extend_seed(aligner, chain, references, &read, consistent_chain, true).unwrap(),
+        //             extend_seed(aligner, chain, references, &read, true).unwrap(),
         //             alignment.clone(),
         //         )
         //     } else {
         //         (
         //             alignment.clone(),
-        //             extend_seed(aligner, chain, references, &read, consistent_chain, false).unwrap(),
+        //             extend_seed(aligner, chain, references, &read, false).unwrap(),
         //         )
         //     };
         //     // manually adds the soft clips
@@ -542,7 +531,6 @@ fn extend_seed(
     chain: &mut Chain,
     refseq: &RefSequence,
     read: &Read,
-    consistent_chain: bool,
     use_ssw: bool,
 ) -> Option<Alignment> {
     let query = if chain.is_revcomp {
@@ -571,7 +559,7 @@ fn extend_seed(
     };
     let mut result_start = 0;
     let mut gapped = true;
-    if projected_start + query.len() == projected_end && consistent_chain {
+    if projected_start + query.len() == projected_end {
         let segment = contig.decode(projected_start, projected_end);
         if let Some(hamming_dist) = hamming_distance(query, &segment)
             && (hamming_dist as f32 / query.len() as f32) < 0.05
@@ -857,17 +845,11 @@ fn extend_paired_seeds(
         let mut ch_max1 = chains[0][0].clone();
         let mut ch_max2 = chains[1][0].clone();
 
-        let consistent_chain1 = ch_max1.is_consistent(read1, refseq, k);
-        details[0].inconsistent_chains += !consistent_chain1 as usize;
-        let consistent_chain2 = ch_max2.is_consistent(read2, refseq, k);
-        details[1].inconsistent_chains += !consistent_chain2 as usize;
-
         let alignment1 = extend_seed(
             aligner,
             &mut ch_max1,
             refseq,
             read1,
-            consistent_chain1,
             true, // SSW
         );
         let alignment2 = extend_seed(
@@ -875,7 +857,6 @@ fn extend_paired_seeds(
             &mut ch_max2,
             refseq,
             read2,
-            consistent_chain2,
             true, // SSW
         );
         if let (Some(alignment1), Some(alignment2)) = (alignment1, alignment2) {
@@ -903,14 +884,11 @@ fn extend_paired_seeds(
     // the paired-end read as two single-end reads.
     let mut a_indv_max = [None, None];
     for i in 0..2 {
-        let consistent_chain = reverse_chain_if_needed(&mut chains[i][0], reads[i], refseq, k);
-        details[i].inconsistent_chains += !consistent_chain as usize;
         a_indv_max[i] = extend_seed(
             aligner,
             &mut chains[i][0],
             refseq,
             reads[i],
-            consistent_chain,
             true, // SSW
         );
         details[i].tried_alignment += 1;
@@ -940,15 +918,11 @@ fn extend_paired_seeds(
             let alignment;
             if let Some(mut this_chain) = chainsp[i].clone() {
                 if let Entry::Vacant(e) = alignment_cache[i].entry(this_chain.id) {
-                    let consistent_chain =
-                        reverse_chain_if_needed(&mut this_chain, reads[i], refseq, k);
-                    details[i].inconsistent_chains += !consistent_chain as usize;
                     alignment = extend_seed(
                         aligner,
                         &mut this_chain,
                         refseq,
                         reads[i],
-                        consistent_chain,
                         true, // SSW
                     );
                     details[i].tried_alignment += 1;
@@ -958,9 +932,7 @@ fn extend_paired_seeds(
                     alignment = alignment_cache[i].get(&this_chain.id).unwrap().clone();
                 }
             } else {
-                let mut other_chain = chainsp[1 - i].clone().unwrap();
-                details[1 - i].inconsistent_chains +=
-                    !reverse_chain_if_needed(&mut other_chain, reads[1 - i], refseq, k) as usize;
+                let other_chain = chainsp[1 - i].clone().unwrap();
                 alignment = rescue_align(aligner, &other_chain, refseq, reads[i], mu, sigma, k);
                 if alignment.is_some() {
                     details[i].mate_rescue += 1;
@@ -1049,10 +1021,7 @@ fn rescue_read(
         if score_dropoff1 < dropoff {
             break;
         }
-        let consistent_chain = reverse_chain_if_needed(chain, read1, refseq, k);
-        details[0].inconsistent_chains += !consistent_chain as usize;
-        if let Some(alignment) = extend_seed(aligner, chain, refseq, read1, consistent_chain, true)
-        {
+        if let Some(alignment) = extend_seed(aligner, chain, refseq, read1, true) {
             details[0].gapped += alignment.gapped as usize;
             alignments1.push(alignment);
             details[0].tried_alignment += 1;

--- a/src/packed_seq.rs
+++ b/src/packed_seq.rs
@@ -74,6 +74,7 @@ impl PackedSeq {
     /// Build a `PackedSeq` by packing every byte of a slice.
     pub fn from_slice(s: &[u8]) -> Self {
         let mut seq = PackedSeq::new();
+        seq.data.reserve(s.len().div_ceil(32));
         for &c in s {
             seq.push(c);
         }


### PR DESCRIPTION
This is a modified version of PR #619 and an alternative to it.

This removes anchors for which the reference sequence and the query sequence don’t match from each chain before alignment. These invalid anchors come from hash collisions.

This has no measurable performance impact.

The alternative (PR #619) is to discard invalid anchors *before* chaining, which can be slightly more accurate (because the optimal chain may change with removed anchors), but incurs a significant slowdown.

Invalid anchors are currently not removed in mapping-only mode.

I’ll post benchmark results later.