### PR TITLE
Fix masking of auxiliary hash

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -29,12 +29,12 @@ pub struct RefRandstrobe {
     ref_start: u64,
 }
 
-/// Mask for the part of the randstrobe hash that includes individual strobe hashes and orientations
-pub const REF_RANDSTROBE_HASH_MASK: u64 = 0xFFFFFFFFFFFFFF00;
 /// Number of bits reserved for offset between first and second strobe
 pub const STROBE2_OFFSET_BITS: u32 = 8;
+/// Mask for the part of the randstrobe hash that includes individual strobe hashes and orientations
+pub const REF_RANDSTROBE_HASH_MASK: u64 = !0u64 << STROBE2_OFFSET_BITS;
 /// Mask for the part of the randstrobe hash that includes the offset between first and second strobe
-pub const STROBE2_OFFSET_MASK: u64 = (1u64 << STROBE2_OFFSET_BITS) - 1;
+pub const STROBE2_OFFSET_MASK: u64 = !REF_RANDSTROBE_HASH_MASK;
 
 impl RefRandstrobe {
     pub fn new(hash: RandstrobeHash, ref_start: usize, offset: u8) -> Self {

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -70,8 +70,8 @@ impl RandstrobeParameters {
                 "aux length must be less than 64",
             ));
         }
-        self.main_hash_mask = !0u64 << (9 + aux_len);
-        self.partial_orientation_pos = 8 + aux_len;
+        self.main_hash_mask = !0u64 << (STROBE2_OFFSET_BITS + 1 + aux_len);
+        self.partial_orientation_pos = STROBE2_OFFSET_BITS + aux_len;
         self.forward_main_hash_mask = self.main_hash_mask | (1u64 << self.partial_orientation_pos);
 
         Ok(self)

--- a/src/seeding/strobes.rs
+++ b/src/seeding/strobes.rs
@@ -122,7 +122,6 @@ impl Randstrobe {
     /// the main hash and the bottom bits to the bits of the auxiliary
     /// hash. Since entries in the index are sorted by randstrobe hash, this allows
     /// us to search for the main syncmer by masking out the lower bits.
-    /// The orientation bit position (between main and aux) is left as zero.
     pub fn hash(
         hash1: u64,
         hash2: u64,
@@ -130,11 +129,10 @@ impl Randstrobe {
         is_forward2: u64,
         parameters: &RandstrobeParameters,
     ) -> u64 {
-        ((hash1 & parameters.main_hash_mask)
-            | (hash2 & !parameters.forward_main_hash_mask)
+        (hash1 & parameters.main_hash_mask)
+            | (hash2 & !parameters.forward_main_hash_mask & (REF_RANDSTROBE_HASH_MASK << 1))
             | (is_forward1 << parameters.partial_orientation_pos)
-            | (is_forward2 << STROBE2_OFFSET_BITS))
-            & (REF_RANDSTROBE_HASH_MASK << 1)
+            | (is_forward2 << STROBE2_OFFSET_BITS)
     }
 }
 


### PR DESCRIPTION
When computing the randstrobe hash, the mask `!parameters.forward_main_hash_mask` is set to 1 also at the position where the the orientation bit of the auxiliary hash is supposed to go, which means that the `| (is_forward2 << STROBE2_OFFSET_BITS)` expression doesn’t work as intended. (The orientation bit is 1 not only if the orientation is 1, but also if the aux hash happens to have a 1 at that position.)

See my comment at https://github.com/ksahlin/strobealign/pull/574/changes#r3934991716.

@Itolstoganov I’m slightly unsure, also because the comment "The orientation bit position (between main and aux) is left as zero." appears to be incorrect, so maybe something else is going on.